### PR TITLE
Remove hardcoded "ar" path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ milagro:
 		cd ${pwd}/lib/milagro-crypto-c && \
 		CC=${gcc} LD=${ld} \
 		cmake . -DCMAKE_C_FLAGS="${cflags}" -DCMAKE_SYSTEM_NAME="${system}" \
-		-DCMAKE_AR=/usr/bin/ar -DCMAKE_C_COMPILER=${gcc} ${milagro_cmake_flags}; \
+		-DCMAKE_AR=${ar} -DCMAKE_C_COMPILER=${gcc} ${milagro_cmake_flags}; \
 	fi
 	if ! [ -r ${pwd}/lib/milagro-crypto-c/lib/libamcl_core.a ]; then \
 		CC=${gcc} CFLAGS="${cflags}" AR=${ar} RANLIB=${ranlib} LD=${ld} \


### PR DESCRIPTION
Tiny fix removing hard-coded path that may cause make process to crash on some distros.