### PR TITLE
Check that milagro makefile is generated before running clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,9 @@ install-lua:
 
 clean:
 	make clean -C ${pwd}/lib/lua53/src
-	make clean -C ${pwd}/lib/milagro-crypto-c
+	if [ -f ${pwd}/lib/milagro-crypto-c/Makefile ]; then \
+		make clean -C ${pwd}/lib/milagro-crypto-c; \
+	fi
 	rm -f ${pwd}/lib/milagro-crypto-c/CMakeCache.txt
 	rm -rf ${pwd}/lib/milagro-crypto-c/CMakeFiles
 	make clean -C src


### PR DESCRIPTION
Without this check `make clean` fails in case when milagro makefile hasn't been generated.