### PR TITLE
fixed statement at line 158 of zencode_given.lua

### DIFF
--- a/src/lua/zencode_given.lua
+++ b/src/lua/zencode_given.lua
@@ -156,8 +156,10 @@ end)
 Given("am ''", function(name) Iam(name) end)
 
 Given("my name is in ''", function(name)
-		 assert(IN[name], "No name found inside "..name)
-		 Iam(IN[name])
+       pick(name, 'string')
+       assert(TMP, "No name found inside "..name)
+       local user = TMP.name
+		 Iam(user)
 end)
 
 -- variable names:


### PR DESCRIPTION
"Given my name is in ' ' " should now work in every cases.