### PR TITLE
fix: Add build directory for cmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,13 +115,15 @@ milagro:
 	@echo "-- Building milagro (${system})"
 	if ! [ -r ${pwd}/lib/milagro-crypto-c/CMakeCache.txt ]; then \
 		cd ${pwd}/lib/milagro-crypto-c && \
+		mkdir -p build && \
+		cd build && \
 		CC=${gcc} LD=${ld} \
-		cmake . -DCMAKE_C_FLAGS="${cflags}" -DCMAKE_SYSTEM_NAME="${system}" \
+		cmake ../ -DCMAKE_C_FLAGS="${cflags}" -DCMAKE_SYSTEM_NAME="${system}" \
 		-DCMAKE_AR=${ar} -DCMAKE_C_COMPILER=${gcc} ${milagro_cmake_flags}; \
 	fi
 	if ! [ -r ${pwd}/lib/milagro-crypto-c/lib/libamcl_core.a ]; then \
 		CC=${gcc} CFLAGS="${cflags}" AR=${ar} RANLIB=${ranlib} LD=${ld} \
-		make -C ${pwd}/lib/milagro-crypto-c; \
+		make -C ${pwd}/lib/milagro-crypto-c/build; \
 	fi
 
 check-milagro: milagro
@@ -157,11 +159,12 @@ install-lua:
 
 clean:
 	make clean -C ${pwd}/lib/lua53/src
-	if [ -f ${pwd}/lib/milagro-crypto-c/Makefile ]; then \
-		make clean -C ${pwd}/lib/milagro-crypto-c; \
+	if [ -f ${pwd}/lib/milagro-crypto-c/build/Makefile ]; then \
+		make clean -C ${pwd}/lib/milagro-crypto-c/build; \
 	fi
 	rm -f ${pwd}/lib/milagro-crypto-c/CMakeCache.txt
 	rm -rf ${pwd}/lib/milagro-crypto-c/CMakeFiles
+	rm -rf ${pwd}/lib/milagro-crypto-c/build
 	git checkout ${pwd}/lib/milagro-crypto-c/CPackConfig.cmake
 	make clean -C ${pwd}/src
 	make clean -C ${pwd}/bindings

--- a/build/config.mk
+++ b/build/config.mk
@@ -9,7 +9,7 @@ website := ${pwd}/docs
 luasrc := ${pwd}/lib/lua53/src
 ldadd := ${pwd}/lib/lua53/src/liblua.a
 lua_embed_opts := ""
-lua_cflags := -DLUA_COMPAT_5_3 -DLUA_COMPAT_MODULE -DLUA_COMPAT_BITLIB -I${pwd}/lib/milagro-crypto-c/include -I${pwd}/src
+lua_cflags := -DLUA_COMPAT_5_3 -DLUA_COMPAT_MODULE -DLUA_COMPAT_BITLIB -I${pwd}/lib/milagro-crypto-c/build/include -I${pwd}/src -I${pwd}/lib/milagro-crypto-c/include 
 
 # ----------------
 # zenroom defaults
@@ -33,7 +33,7 @@ rsa_bits := ""
 ecdh_curve := SECP256K1
 ecp_curve  := BLS383
 milagro_cmake_flags := -DBUILD_SHARED_LIBS=OFF -DBUILD_PYTHON=OFF -DBUILD_DOXYGEN=OFF -DBUILD_DOCS=OFF -DBUILD_BENCHMARKS=OFF -DBUILD_EXAMPLES=OFF -DWORD_SIZE=32 -DBUILD_PAILLIER=OFF -DBUILD_X509=OFF -DBUILD_WCC=OFF -DBUILD_MPIN=OFF -DAMCL_CURVE=${ecdh_curve},${ecp_curve} -DAMCL_RSA=${rsa_bits} -DCMAKE_SHARED_LIBRARY_LINK_FLAGS="" -DC99=1 -DPAIRING_FRIENDLY_BLS383='BLS' -DCOMBA=1
-milib := ${pwd}/lib/milagro-crypto-c/lib
+milib := ${pwd}/lib/milagro-crypto-c/build/lib
 ldadd += ${milib}/libamcl_curve_${ecp_curve}.a
 ldadd += ${milib}/libamcl_pairing_${ecp_curve}.a
 ldadd += ${milib}/libamcl_curve_${ecdh_curve}.a

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,7 @@ ARCH := $(shell uname -m)
 BRANCH := $(shell git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 HASH := $(shell git rev-parse --short HEAD)
 VERSION := ${ZENROOM_VERSION}+${HASH}
-CFLAGS  += -I. -I../lib/lua53/src -I../lib/milagro-crypto-c/include -Wall -Wextra
+CFLAGS  += -I. -I../lib/lua53/src -I../lib/milagro-crypto-c/build/include -I../lib/milagro-crypto-c/include -Wall -Wextra
 SOURCES := \
 	cli.o jutils.o zenroom.o zen_error.o \
 	lua_functions.o lua_modules.o lualibs_detected.o lua_shims.o \


### PR DESCRIPTION
The source code and the build code are mixed together. This
will produce some errors during compiling.

This commit adds a build directory for cmake.
To avoid mixing the source code and the build code together.