### PR TITLE
fix: Fix errors when building the cortex-m target

### DIFF
--- a/build/config.mk
+++ b/build/config.mk
@@ -71,14 +71,13 @@ endif
 
 ifneq (,$(findstring cortex,$(MAKECMDGOALS)))
 gcc := arm-none-eabi-gcc
-ar  := arm-none-eabi-ar
 objcopy := arm-none-eabi-objcopy
 ranlib := arm-none-eabi-ranlib
 ld := arm-none-eabi-ld
 system := Generic
 ldadd += -lm
 cflags_protection := ""
-cflags := ${cflags_protection} -DARCH_CORTEX -mcpu=cortex-m4 -mthumb -mlittle-endian -mthumb-interwork -Wstack-usage=1024 -DLIBRARY -Wno-main -ffreestanding -nostartfiles
+cflags := ${cflags_protection} -DARCH_CORTEX -mcpu=cortex-m4 -mthumb -mlittle-endian -mthumb-interwork -Wstack-usage=1024 -DLIBRARY -Wno-main -ffreestanding -nostartfiles -specs=nano.specs -specs=nosys.specs
 milagro_cmake_flags += -DCMAKE_SYSTEM_PROCESSOR="arm" -DCMAKE_CROSSCOMPILING=1 -DCMAKE_C_COMPILER_WORKS=1
 ldflags+=-mcpu=cortex-m4 -mthumb -mlittle-endian -mthumb-interwork -Wstack-usage=1024 -Wno-main -ffreestanding -T cortex_m.ld -nostartfiles -Wl,-gc-sections -ggdb
 endif

--- a/src/cortex_m.c
+++ b/src/cortex_m.c
@@ -238,10 +238,10 @@ static const char PUF_RNG[] = "uvVu3thQapaKX1Nso6ElSkzZafq3kHCG";
 
 void main(void)
 {
-    zenroom_exec_rng_tobuf(zenroom_test_code, NULL, NULL, NULL, 1,
-                           zen_stdout, ZEN_BUF_LEN,
-                           zen_stderr, ZEN_BUF_LEN,
-                           PUF_RNG, 32);
+    zenroom_exec_tobuf(zenroom_test_code, NULL, NULL, NULL,
+                       zen_stdout, ZEN_BUF_LEN,
+                       zen_stderr, ZEN_BUF_LEN
+                      );
 }
 
 

--- a/src/zen_random.c
+++ b/src/zen_random.c
@@ -80,8 +80,8 @@ void* rng_alloc() {
 		Z->random_seed[61] = (ttmp >> 16) & 0xff;
 		Z->random_seed[62] = (ttmp >>  8) & 0xff;
 		Z->random_seed[63] =  ttmp & 0xff;
-	}
 #endif
+	}
 	// RAND_seed is destructive, preserve seed here
 	char tseed[RANDOM_SEED_LEN];
 	memcpy(tseed,Z->random_seed,RANDOM_SEED_LEN);


### PR DESCRIPTION
There are some compiling errors when building the cortex-m target.
Such as undefined reference to _sbrk(), _write(), _read()...etc,
use the deprecated API `zenroom_exec_rng_tobuf`, and the wrong brace
position.

This commit link the undefined reference to newlib nano specs, change
the deprecated API to zenroom_exec_tobuf and correct the brace position.