### PR TITLE
fix: Add semihosting support for Zenroom to run on qemu

### DIFF
--- a/.github/workflows/cortex-arm.yml
+++ b/.github/workflows/cortex-arm.yml
@@ -11,6 +11,8 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt install gcc-arm-none-eabi zsh
+      - name: Checkout submodules
+        uses: textbook/git-checkout-submodule-action@master
       - name: build cortex-arm target 
         run: |
           make cortex-arm

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/cmsis"]
+	path = lib/cmsis
+	url = https://github.com/ARM-software/CMSIS_5.git

--- a/src/Makefile
+++ b/src/Makefile
@@ -23,6 +23,17 @@ BRANCH := $(shell git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 HASH := $(shell git rev-parse --short HEAD)
 VERSION := ${ZENROOM_VERSION}+${HASH}
 CFLAGS  += -I. -I../lib/lua53/src -I../lib/milagro-crypto-c/build/include -I../lib/milagro-crypto-c/include -Wall -Wextra
+
+CMSIS := ../lib/cmsis
+CORTEX_M_SRC_ASM = $(CMSIS)/Device/ARM/ARMCM3/Source/GCC/startup_ARMCM3.S
+CORTEX_M_SRC_C = $(CMSIS)/Device/ARM/ARMCM3/Source/system_ARMCM3.c
+CMSIS_INCLUDE_FLAGS = -I$(CMSIS)/Device/ARM/ARMCM3/Include \
+	-I$(CMSIS)/CMSIS/Core/Include
+CORTEX_M_CFLAGS = \
+	       $(CMSIS_INCLUDE_FLAGS) \
+	       -mthumb \
+	       -nostartfiles
+		   
 SOURCES := \
 	cli.o jutils.o zenroom.o zen_error.o \
 	lua_functions.o lua_modules.o lualibs_detected.o lua_shims.o \
@@ -35,6 +46,9 @@ SOURCES := \
 	zen_aes.o \
 	randombytes.o \
 	cortex_m.o
+
+cortex_m_boot.o: $(CORTEX_M_SRC_ASM)
+	${CC} ${CFLAGS} ${CORTEX_M_CFLAGS} -c $^ -o $@
 
 # js: CFLAGS += -I ${EMSCRIPTEN}/system/include/libc -DLIBRARY
 js: JSOUT ?= zenroom.js
@@ -113,8 +127,8 @@ ios-lib: ${SOURCES}
 android-arm android-x86 android-aarch64 java-x86_64 java-x86 java-arm java-aarch64: ${SOURCES} zenroom_jni.o
 	${CC} ${CFLAGS} ${SOURCES} zenroom_jni.o -o zenroom.so ${LDFLAGS} ${LDADD}
 
-arm: ${SOURCES}
-	${CC} ${CFLAGS} ${SOURCES} -o zenroom.elf ${LDFLAGS} ${LDADD}
+arm: ${SOURCES} cortex_m_boot.o
+	${CC} ${CFLAGS} ${CORTEX_M_CFLAGS} ${CORTEX_M_SRC_C} ${SOURCES} cortex_m_boot.o -o zenroom.elf ${LDFLAGS} ${LDADD}
 	${OBJCOPY} -O binary zenroom.elf zenroom.bin
 
 debug: CFLAGS+= -ggdb -DDEBUG=1 -Wall

--- a/src/cortex_m.c
+++ b/src/cortex_m.c
@@ -1,250 +1,124 @@
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "zenroom.h"
+
 #ifdef ARCH_CORTEX
-extern unsigned int _start_heap;
-// #define NULL (((void *)0))
-//
-//
 
+#include <errno.h>
+#undef errno
+extern int errno;
 
-/**  XXX Temporary proxy until these dependencies are resolved **/
+enum semihost_ops
+{
+  SEMIHOSTING_SYS_OPEN = 0x01,
+  SEMIHOSTING_SYS_CLOSE = 0x02,
+  SEMIHOSTING_SYS_WRITEC = 0x03,
+  SEMIHOSTING_SYS_WRITE0 = 0x04,
+  SEMIHOSTING_SYS_WRITE = 0x05,
+  SEMIHOSTING_SYS_READ = 0x06,
+  SEMIHOSTING_SYS_READC = 0x07,
+  SEMIHOSTING_SYS_ISTTY = 0x09,
+  SEMIHOSTING_SYS_SEEK = 0x0A,
+  SEMIHOSTING_SYS_EXIT = 0x18,
+};
+
+static inline int semihost_call(int R0, int R1)
+{
+  int rc;
+  __asm__ volatile(
+      "mov r0, %1\n" /* move int R0 to register r0 */
+      "mov r1, %2\n" /* move int R1 to register r1 */
+      "bkpt #0xAB\n" /* thumb mode semihosting call */
+      "mov %0, r0"   /* move register r0 to int rc */
+      : "=r"(rc)
+      : "r"(R0), "r"(R1)
+      : "r0", "r1", "ip", "lr", "memory", "cc");
+  return rc;
+}
+
 int _isatty(int fd)
 {
-    (void)fd;
-    return 0;
+  return semihost_call(SEMIHOSTING_SYS_ISTTY, (int)&fd);
 }
 
 int _read(int fd, void *buf, size_t len)
 {
-    return -1;
+  unsigned int args[] = {
+      (unsigned int)fd,
+      (unsigned int)buf,
+      (unsigned int)len,
+  };
+  return semihost_call(SEMIHOSTING_SYS_READ, (int)args);
 }
 
 int _write(int fd, const void *buf, size_t len)
 {
-    return -1;
+  unsigned int args[] = {
+      (unsigned int)fd,
+      (unsigned int)buf,
+      (unsigned int)len,
+  };
+  return semihost_call(SEMIHOSTING_SYS_WRITE0, (int)buf);
 }
 
 int _lseek(int fd, int off, int whence)
 {
-    return 0;
+  return -1;
 }
 
 int _fstat(int fd, void *st)
 {
-    return -1;
+  return -1;
 }
 
 int _close(int fd)
 {
-    return 0;
+  return semihost_call(SEMIHOSTING_SYS_CLOSE, (int)&fd);
 }
 
+int _open(const char *name,
+          int flags,
+          int mode)
+{
+  unsigned int args[] = {
+      (unsigned int)name,
+      (unsigned int)flags,
+      (unsigned int)mode,
+  };
+  return semihost_call(SEMIHOSTING_SYS_OPEN, (int)&args);
+}
 
 void abort(void)
 {
-    while(1) {
-        /* Panic! */
-    }
+  while (1)
+  {
+    /* Panic! */
+  }
 }
 
 void exit(int val)
 {
-	(void)val;
+  semihost_call(SEMIHOSTING_SYS_EXIT, val);
+  for (;;)
+    ;
 }
 
-void * _sbrk(unsigned int incr)
+static const char zenroom_test_code[] = "print('Hello, world!')";
+
+int main(void)
 {
-    static unsigned char *heap = (unsigned char *)&_start_heap;
-    void *old_heap = heap;
-    if (((incr >> 2) << 2) != incr)
-        incr = ((incr >> 2) + 1) << 2;
+  zenroom_exec(zenroom_test_code, NULL, NULL, NULL);
 
-    if (heap == NULL)
-		heap = (unsigned char *)&_start_heap;
-	else
-        heap += incr;
-    return old_heap;
+  return 0;
 }
 
-void * _sbrk_r(unsigned int incr)
+void _start(void)
 {
-    static unsigned char *heap = NULL;
-    void *old_heap = heap;
-    if (((incr >> 2) << 2) != incr)
-        incr = ((incr >> 2) + 1) << 2;
-
-    if (old_heap == NULL)
-		old_heap = heap = (unsigned char *)&_start_heap;
-    heap += incr;
-    return old_heap;
+  main();
+  exit(0);
 }
-
-extern unsigned int _stored_data;
-extern unsigned int _start_data;
-extern unsigned int _end_data;
-extern unsigned int _start_bss;
-extern unsigned int _end_bss;
-extern unsigned int _end_stack;
-extern unsigned int _start_heap;
-
-#define STACK_PAINTING
-
-static volatile unsigned int avail_mem = 0;
-static unsigned int sp;
-
-extern void main(void);
-void isr_reset(void) {
-    register unsigned int *src, *dst;
-    src = (unsigned int *) &_stored_data;
-    dst = (unsigned int *) &_start_data;
-    /* Copy the .data section from flash to RAM. */
-    while (dst < (unsigned int *)&_end_data) {
-        *dst = *src;
-        dst++;
-        src++;
-    }
-
-    /* Initialize the BSS section to 0 */
-    dst = &_start_bss;
-    while (dst < (unsigned int *)&_end_bss) {
-        *dst = 0U;
-        dst++;
-    }
-
-    /* Paint the stack. */
-    avail_mem = &_end_stack - &_start_heap;
-    {
-        asm volatile("mrs %0, msp" : "=r"(sp));
-        dst = ((unsigned int *)(&_end_stack)) - (8192 / 4 ); // 32bit
-        while ((unsigned int)dst < sp) {
-            *dst = 0xDEADC0DE;
-            dst++;
-        }
-    }
-    /* Run the program! */
-    main();
-}
-
-void isr_fault(void)
-{
-    /* Panic. */
-    while(1) ;;
-}
-
-
-void isr_memfault(void)
-{
-    /* Panic. */
-    while(1) ;;
-}
-
-void isr_busfault(void)
-{
-    /* Panic. */
-    while(1) ;;
-}
-
-void isr_usagefault(void)
-{
-    /* Panic. */
-    while(1) ;;
-}
-        
-
-void isr_empty(void)
-{
-    /* Ignore the event and continue */
-}
-
-
-
-__attribute__ ((section(".isr_vector")))
-void (* const IV[])(void) =
-{
-	(void (*)(void))(&_end_stack),
-	isr_reset,                   // Reset
-	isr_fault,                   // NMI
-	isr_fault,                   // HardFault
-	isr_memfault,                // MemFault
-	isr_busfault,                // BusFault
-	isr_usagefault,              // UsageFault
-	0, 0, 0, 0,                  // 4x reserved
-	isr_empty,                   // SVC
-	isr_empty,                   // DebugMonitor
-	0,                           // reserved
-	isr_empty,                   // PendSV
-	isr_empty,                   // SysTick
-
-    isr_empty,                     // GPIO Port A
-    isr_empty,                     // GPIO Port B
-    isr_empty,                     // GPIO Port C
-    isr_empty,                     // GPIO Port D
-    isr_empty,                     // GPIO Port E
-    isr_empty,                     // UART0 Rx and Tx
-    isr_empty,                     // UART1 Rx and Tx
-    isr_empty,                     // SSI0 Rx and Tx
-    isr_empty,                     // I2C0 Master and Slave
-    isr_empty,                     // PWM Fault
-    isr_empty,                     // PWM Generator 0
-    isr_empty,                     // PWM Generator 1
-    isr_empty,                     // PWM Generator 2
-    isr_empty,                     // Quadrature Encoder 0
-    isr_empty,                     // ADC Sequence 0
-    isr_empty,                     // ADC Sequence 1
-    isr_empty,                     // ADC Sequence 2
-    isr_empty,                     // ADC Sequence 3
-    isr_empty,                     // Watchdog timer
-    isr_empty,                     // Timer 0 subtimer A
-    isr_empty,                     // Timer 0 subtimer B
-    isr_empty,                     // Timer 1 subtimer A
-    isr_empty,                     // Timer 1 subtimer B
-    isr_empty,                     // Timer 2 subtimer A
-    isr_empty,                     // Timer 3 subtimer B
-    isr_empty,                     // Analog Comparator 0
-    isr_empty,                     // Analog Comparator 1
-    isr_empty,                     // Analog Comparator 2
-    isr_empty,                     // System Control (PLL, OSC, BO)
-    isr_empty,                     // FLASH Control
-    isr_empty,                     // GPIO Port F
-    isr_empty,                     // GPIO Port G
-    isr_empty,                     // GPIO Port H
-    isr_empty,                     // UART2 Rx and Tx
-    isr_empty,                     // SSI1 Rx and Tx
-    isr_empty,                     // Timer 3 subtimer A
-    isr_empty,                     // Timer 3 subtimer B
-    isr_empty,                     // I2C1 Master and Slave
-    isr_empty,                     // Quadrature Encoder 1
-    isr_empty,                     // CAN0
-    isr_empty,                     // CAN1
-    isr_empty,                     // CAN2
-    isr_empty,                     // Ethernet
-    isr_empty,                     // Hibernate
-
-
-};
-
-// 20k i/o buffer
-#define ZEN_BUF_LEN 20480
-static const char zenroom_test_code[] = "print('Hello, world!\r\n')";
-// char __attribute__((section(".zenmem")))
-char zen_stderr[ZEN_BUF_LEN];
-// char __attribute__((section(".zenmem")))
-char zen_stdout[ZEN_BUF_LEN];
-
-/* TODO: Initialize target-specific rng to generate initial randomness */
-
-static const char PUF_RNG[] = "uvVu3thQapaKX1Nso6ElSkzZafq3kHCG";
-
-void main(void)
-{
-    zenroom_exec_tobuf(zenroom_test_code, NULL, NULL, NULL,
-                       zen_stdout, ZEN_BUF_LEN,
-                       zen_stderr, ZEN_BUF_LEN
-                      );
-}
-
 
 #endif
-
-

--- a/src/cortex_m.ld
+++ b/src/cortex_m.ld
@@ -1,52 +1,113 @@
 MEMORY
 {
-    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 1M
-    RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
+    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 2M
+    RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 1M 
 }
+ENTRY(Reset_Handler)
 
 SECTIONS
 {
     .text :
     {
-        _start_text = .;
-        KEEP(*(.isr_vector))
+        KEEP(*(.vectors))
         *(.text*)
         *(.rodata*)
         *(.init*)
         *(.fini*)
         . = ALIGN(4);
-        _end_text = .;
     } > FLASH
     
+    __exidx_start = .;
     .edidx :
     {
         . = ALIGN(4);
         *(.ARM.exidx*)
     } > FLASH
+    __exidx_end = .;
 
-    _stored_data = .;
-
-    .data : AT (_stored_data)
+    .copy.table :
     {
-        _start_data = .;
-        *(.data*)
-        . = ALIGN(4);
-        _end_data = .;
+      . = ALIGN(4);
+      __copy_table_start__ = .;
+
+      LONG (__etext)
+      LONG (__data_start__)
+      LONG ((__data_end__ - __data_start__) / 4)
+
+      __copy_table_end__ = .;
+    } > FLASH
+
+    .zero.table :
+    {
+      . = ALIGN(4);
+      __zero_table_start__ = .;
+      __zero_table_end__ = .;
+    } > FLASH
+
+    __etext = ALIGN (4);
+
+    .data : AT (__etext)
+    {
+      __data_start__ = .;
+      *(vtable)
+      *(.data)
+      *(.data.*)
+
+      . = ALIGN(4);
+      /* preinit data */
+      PROVIDE_HIDDEN (__preinit_array_start = .);
+      KEEP(*(.preinit_array))
+      PROVIDE_HIDDEN (__preinit_array_end = .);
+
+      . = ALIGN(4);
+      /* init data */
+      PROVIDE_HIDDEN (__init_array_start = .);
+      KEEP(*(SORT(.init_array.*)))
+      KEEP(*(.init_array))
+      PROVIDE_HIDDEN (__init_array_end = .);
+
+      . = ALIGN(4);
+      /* finit data */
+      PROVIDE_HIDDEN (__fini_array_start = .);
+      KEEP(*(SORT(.fini_array.*)))
+      KEEP(*(.fini_array))
+      PROVIDE_HIDDEN (__fini_array_end = .);
+
+      KEEP(*(.jcr*))
+      . = ALIGN(4);
+      /* All data end */
+      __data_end__ = .;
     } > RAM
 
     .bss :
     {
-        _start_bss = .;
-        *(.bss*)
-        *(COMMON)
-		. = ALIGN(4);
-		*(.zenmem*)
-		. = ALIGN(4);
-        _end_bss = .;
-        _end = .;
+      __bss_start__ = .;
+      *(.bss*)
+      *(COMMON)
+      . = ALIGN(4);
+      *(.zenmem*)
+      . = ALIGN(4);
+      __bss_end__ = .;
     } > RAM
 
-}
+    .heap (COPY):
+    {
+      __HeapBase = .;
+      __end__ = .;
+      end = __end__;
+      KEEP(*(.heap*))
+      __HeapLimit = .;
+    } > RAM
 
-_start_heap = _end;
-_end_stack  = ORIGIN(RAM) + LENGTH(RAM);
+    .stack_dummy (COPY):
+    {
+      KEEP(*(.stack*))
+    } > RAM
+
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/src/zen_io.c
+++ b/src/zen_io.c
@@ -308,37 +308,6 @@ static int zen_act (lua_State *L) {
 	return 0;
 }
 
-#elif defined(ARCH_CORTEX)
-static int zen_print (lua_State *L)
-{
-    return 1;
-}
-
-static int zen_printerr(lua_State *L)
-{
-	return 1;
-}
-
-// static int zen_error (lua_State *L)
-// {
-//     return 1;
-// }
-
-static int zen_warn (lua_State *L)
-{
-    return 1;
-}
-
-static int zen_write (lua_State *L)
-{
-    return 1;
-}
-
-static int zen_act (lua_State *L)
-{
-	return 1;
-}
-
 #else
 
 


### PR DESCRIPTION
To use the semihosting will let us to test the Zenroom on
qemu-system-arm or such as cortex-m devices more easily.

But for running the semihosting correctly, we need to update the startup
file and the linker scripts.

This commit add a CMSIS repository into submodule for update the startup
file and the linker scripts to CMSIS and update the functions inside
cortex-m.c for semihosting support.

The Zenroom could be test on the following qemu scripts:
```
qemu-system-arm -M mps2-an385 -kernel src/zenroom.bin -semihosting -nographic
```