### PR TITLE
ci: Improve CI for cortex-m targets

### DIFF
--- a/.github/workflows/cortex-arm.yml
+++ b/.github/workflows/cortex-arm.yml
@@ -4,13 +4,17 @@ on: [push, pull_request]
 
 jobs:
   coverity-scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
+      - uses: numworks/setup-arm-toolchain@2020-q4
       - name: checkout code
         uses: actions/checkout@v2
+      - name: update dependencies
+        run: |
+          sudo apt update && sudo apt upgrade
       - name: install dependencies
         run: |
-          sudo apt install gcc-arm-none-eabi zsh qemu-system-arm 
+          sudo apt install zsh qemu-system-arm
       - name: Checkout submodules
         uses: textbook/git-checkout-submodule-action@master
       - name: build cortex-arm target 

--- a/build/tests.mk
+++ b/build/tests.mk
@@ -64,6 +64,21 @@ cortex-m-crypto-tests = \
 	${1}test/coconut_test.lua && \
 	${1}test/coconut_abc_zeta.lua
 
+cortex-m-crypto-tests = \
+	test/cortex_m_crypto_tests.sh
+
+cortex-m-zencode-integration = \
+	cd test/zencode_numbers && ./run.sh ${1}; cd -; \
+	cd test/zencode_array && ./run.sh ${1}; cd -; \
+	cd test/zencode_hash && ./run.sh ${1}; cd -; \
+	cd test/zencode_ecdh && ./run.sh ${1}; cd -; \
+	cd test/zencode_credential && ./run.sh ${1}; cd -; \
+	cd test/zencode_petition && ./run.sh ${1}; cd -;
+
+cortex-m-crypto-integration = \
+	test/octet-json.sh ${1} && \
+	test/integration_asymmetric_crypto.sh ${1}
+	
 crypto-integration = \
 	test/octet-json.sh ${1} && \
 	cd test/nist && ./run.sh ../../${1}; cd -; \
@@ -238,10 +253,13 @@ check-crypto-debug:
 	$(call zencode-tests,${test-exec})
 	cat /tmp/zenroom-test-summary.txt
 
-check-cortex-m: test-exec := qemu-system-arm -M mps2-an385 -kernel src/zenroom.bin -semihosting -nographic
 check-cortex-m:
 	rm -f /tmp/zenroom-test-summary.txt
-	$(call cortex-m-crypto-tests,${test-exec} -semihosting-config arg=)
+	--rm -f ./outlog
+	$(call cortex-m-crypto-tests)
+	$(call cortex-m-crypto-integration,cortexm)
+	$(call cortex-m-zencode-integration,cortexm)
+	cat /tmp/zenroom-test-summary.txt
 	@echo "-----------------------"
 	@echo "All CRYPTO tests passed"
 	@echo "-----------------------"

--- a/test/cortex_m_crypto_tests.sh
+++ b/test/cortex_m_crypto_tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+[[ -r test ]] || {
+    print "Run from base directory: ./test/$0"
+    return 1
+}
+
+if ! test -r ./test/utils.sh; then
+    echo "run executable from its own directory: $0"; exit 1; fi
+. ./test/utils.sh
+
+run_zenroom_on_cortexm_qemu() {
+	qemu_zenroom_run "$*"
+	cat ./outlog
+}
+
+if [[ "$1" == "cortexm" ]]; then
+	zen=run_zenroom_on_cortexm_qemu
+fi
+
+crypto_tests=(
+	test/octet.lua
+	test/octet_conversion.lua
+	test/hash.lua
+	test/ecdh.lua
+	test/dh_session.lua
+	test/nist/aes_gcm.lua
+	test/nist/aes_cbc.lua
+	test/nist/aes_ctr.lua
+	test/ecp_generic.lua
+	test/elgamal.lua
+	test/bls_pairing.lua
+	test/coconut_test.lua
+	test/crypto_abc_zeta.lua
+)
+
+len=${#crypto_tests[@]}
+for ((i=0; i < len; i++)); do
+    run_zenroom_on_cortexm_qemu ${crypto_tests[$i]}
+done

--- a/test/octet-json.sh
+++ b/test/octet-json.sh
@@ -4,11 +4,29 @@ tstr="Zenroom test"
 zenroom=$1
 valgrind=$2
 
+[[ -r test ]] || {
+    print "Run from base directory: ./test/$0"
+    return 1
+}
+
+if ! test -r ./test/utils.sh; then
+	echo "run executable from its own directory: $0"; exit 1; fi
+. ./test/utils.sh
+
+run_zenroom_on_cortexm_qemu(){
+	qemu_zenroom_run "$*"
+	cat ./outlog
+}
+
 function grind() {
-	if [[ "$2" != "valgrind" ]]; then
-		$zenroom $*
-	else
+	if [[ "$valgrind" == "valgrind" ]]; then
 		valgrind --max-stackframe=2064480 $zenroom $*
+	else
+		if [[ "$zenroom" == "cortexm" ]]; then
+			run_zenroom_on_cortexm_qemu $*
+		else
+			$zenroom $*
+		fi
 	fi
 	return $?
 }

--- a/test/zencode_array/run.sh
+++ b/test/zencode_array/run.sh
@@ -6,6 +6,12 @@
 if ! test -r ../utils.sh; then
 	echo "run executable from its own directory: $0"; exit 1; fi
 . ../utils.sh
+
+is_cortexm=false
+if [[ "$1" == "cortexm" ]]; then
+	is_cortexm=true
+fi
+
 Z="`detect_zenroom_path` `detect_zenroom_conf`"
 ####################
 

--- a/test/zencode_credential/run.sh
+++ b/test/zencode_credential/run.sh
@@ -9,6 +9,12 @@ RNGSEED="hex:0000000000000000000000000000000000000000000000000000000000000000000
 if ! test -r ../utils.sh; then
 	echo "run executable from its own directory: $0"; exit 1; fi
 . ../utils.sh
+
+is_cortexm=false
+if [[ "$1" == "cortexm" ]]; then
+	is_cortexm=true
+fi
+
 Z="`detect_zenroom_path` `detect_zenroom_conf`"
 ####################
 # use zexe if you have zenroom in a system-wide path

--- a/test/zencode_ecdh/run.sh
+++ b/test/zencode_ecdh/run.sh
@@ -5,6 +5,12 @@
 if ! test -r ../utils.sh; then
 	echo "run executable from its own directory: $0"; exit 1; fi
 . ../utils.sh
+
+is_cortexm=false
+if [[ "$1" == "cortexm" ]]; then
+	is_cortexm=true
+fi
+
 Z="`detect_zenroom_path` `detect_zenroom_conf`"
 ####################
 

--- a/test/zencode_hash/run.sh
+++ b/test/zencode_hash/run.sh
@@ -8,6 +8,12 @@
 if ! test -r ../utils.sh; then
 	echo "run executable from its own directory: $0"; exit 1; fi
 . ../utils.sh
+
+is_cortexm=false
+if [[ "$1" == "cortexm" ]]; then
+	is_cortexm=true
+fi
+
 Z="`detect_zenroom_path` `detect_zenroom_conf`"
 ####################
 

--- a/test/zencode_numbers/run.sh
+++ b/test/zencode_numbers/run.sh
@@ -6,9 +6,14 @@
 if ! test -r ../utils.sh; then
 	echo "run executable from its own directory: $0"; exit 1; fi
 . ../utils.sh
+
+is_cortexm=false
+if [[ "$1" == "cortexm" ]]; then
+	is_cortexm=true
+fi
+
 Z="`detect_zenroom_path` `detect_zenroom_conf`"
 ####################
-
 
 cat <<EOF | zexe hash_string.zen | tee hex.json
 rule output encoding hex

--- a/test/zencode_parser.sh
+++ b/test/zencode_parser.sh
@@ -6,9 +6,30 @@ echo "============================="
 echo "ERRORS ARE OK IN THIS SECTION"
 
 alias zenroom="${1:-./src/zenroom}"
+
+[[ -r test ]] || {
+    print "Run from base directory: ./test/$0"
+    return 1
+}
+
+if ! test -r ./test/utils.sh; then
+	echo "run executable from its own directory: $0"; exit 1; fi
+. ./test/utils.sh
+
+run_zenroom_on_cortexm_qemu(){
+	qemu_zenroom_run "$*"
+	cat ./outlog
+}
+
+if [[ "$1" == "cortexm" ]]; then
+	zenroom=run_zenroom_on_cortexm_qemu
+fi
+
+tmpfile=`mktemp`
+
 set -e
 
-cat << EOF | zenroom -z
+cat << EOF > $tmpfile && $zenroom $tmpfile -z
 rule check version 1.0.0
 Scenario credential: credential keygen
 Given that I am known as 'Alice'
@@ -16,7 +37,7 @@ When I create the credential keypair
 Then print my 'credential keypair'
 EOF
 
-cat << EOF | zenroom -z
+cat << EOF > $tmpfile && $zenroom $tmpfile -z
 rule check version 1.0.0
 Scenario credential: issuer keygen
 Given that I am known as 'MadHatter'
@@ -25,7 +46,7 @@ Then print my 'issuer keypair'
 EOF
 
 
-cat << EOF | zenroom -z
+cat << EOF > $tmpfile && $zenroom $tmpfile -z
 rule check version 1.0.0
 rule unknown ignore
 Scenario credential: issuer keygen
@@ -38,7 +59,7 @@ EOF
 set +e
 # force error: check processing stop
 
-cat << EOF | zenroom -z
+cat << EOF > $tmpfile && $zenroom $tmpfile -z
 rule check version 1.0.0
 Scenario credential: issuer keygen
 Given that I am known as 'MadHatter'
@@ -47,7 +68,7 @@ Then print 'Success' 'OK'
 EOF
 [[ $? == 0 ]] && return 1
 
-cat << EOF | zenroom -z
+cat << EOF > $tmpfile && $zenroom $tmpfile -z
 rule check version 1.0.0
 Scenario credential: issuer keygen
 Given that I am known as 'MadHatter'
@@ -56,7 +77,7 @@ Then print 'Success' 'OK'
 EOF
 [[ $? == 0 ]] && return 1
 
-cat << EOF | zenroom -z
+cat << EOF > $tmpfile && $zenroom $tmpfile -z
 rule check version 1.0.0
 Scenario credential: issuer keygen
 Given that I am known as 'MadHatter'
@@ -65,7 +86,7 @@ Then print 'Success' 'OK'
 EOF
 [[ $? == 0 ]] && return 1
 
-cat << EOF | zenroom -z
+cat << EOF > $tmpfile && $zenroom $tmpfile -z
 rule check version 1.0.0
 Scenario credential: issuer keygen
 Given that I am known as 'MadHatter'
@@ -80,3 +101,5 @@ echo "============================="
 echo " NO MORE ERRORS SHOULD APPEAR"
 echo
 echo
+
+rm -rf $tmpfile

--- a/test/zencode_petition/run.sh
+++ b/test/zencode_petition/run.sh
@@ -9,6 +9,12 @@
 if ! test -r ../utils.sh; then
 	echo "run executable from its own directory: $0"; exit 1; fi
 . ../utils.sh
+
+is_cortexm=false
+if [[ "$1" == "cortexm" ]]; then
+	is_cortexm=true
+fi
+
 Z="`detect_zenroom_path` `detect_zenroom_conf`"
 
 ####################


### PR DESCRIPTION
This commit adds the zencode integration test and the crypto
integration test for Arm cortex-m targets.

For testing the Zenroom on the cortex-m3 device, the stderr and stdout
stream should be changed. The stderr messages in Zenroom will be
redirect to semihosting console. The stdout message will be written
into the "stdout" file since the QEMU doesn't have the stderr and stdout
stream.

Since the QEMU also can not receive the stdin stream, the test script
will be written into a temp file. The QEMU will open the temp file
via semihosting to get the test scripts.