### PR TITLE
ci: Add deterministic random test for cortex m device

### DIFF
--- a/build/tests.mk
+++ b/build/tests.mk
@@ -259,6 +259,7 @@ check-crypto-debug:
 check-cortex-m:
 	rm -f /tmp/zenroom-test-summary.txt
 	--rm -f ./outlog
+	$(call determinism-tests,cortexm)
 	$(call cortex-m-crypto-tests)
 	$(call cortex-m-crypto-integration,cortexm)
 	$(call cortex-m-zencode-integration,cortexm)

--- a/src/cortex_m.c
+++ b/src/cortex_m.c
@@ -151,6 +151,7 @@ void load_file(char *dst, char *file)
 
 extern zenroom_t *Z;
 int SEMIHOSTING_STDOUT_FILENO;
+char external_random_seed[RANDOM_SEED_LEN];
 
 // implement the fault handler
 void HardFault_Handler(void)
@@ -197,6 +198,8 @@ int main(void)
   int verbosity = 1;
   int retcode = EXIT_SUCCESS;
 
+  memset(external_random_seed, 0, RANDOM_SEED_LEN);
+
   while (ptr != NULL)
   {
     if (strncmp(ptr, "-k", 2) == 0)
@@ -217,6 +220,14 @@ int main(void)
     {
       ptr = strtok(NULL, delim);
       snprintf(conffile, MAX_STRING - 1, "%s", ptr);
+    }
+    else if(strncmp(ptr, "-seed", 5) == 0){
+      ptr = strtok(NULL, delim);
+      if(strlen(ptr) != RANDOM_SEED_LEN){
+        error(NULL, "The seed length must be %d",RANDOM_SEED_LEN);
+        exit(EXIT_FAILURE);
+      }
+      memcpy(external_random_seed, ptr, RANDOM_SEED_LEN);
     }
     else
     {

--- a/src/zenroom.c
+++ b/src/zenroom.c
@@ -28,6 +28,10 @@
 #include <sys/wait.h>
 #endif
 
+#ifdef ARCH_CORTEX
+	#include "zenroom.h"
+	extern char external_random_seed[RANDOM_SEED_LEN];
+#endif
 
 #include <errno.h>
 
@@ -201,6 +205,11 @@ zenroom_t *zen_init(const char *conf, char *keys, char *data) {
 		func(NULL,"LIBC print functions in use");
 		break;
 	}
+
+#ifdef ARCH_CORTEX
+	// Copy the seed from external source
+	memcpy(Z->random_seed, external_random_seed, RANDOM_SEED_LEN);
+#endif
 
 	// use RNGseed from configuration if present (deterministic mode)
 	if(zconf_rngseed[0] != 0x0) {


### PR DESCRIPTION
This commit improved the deterministic test to test on cortex-m device.
Since the cortex-m device didn't implement random seed generator. The
test file will fetch random seed from /dev/urandom. The random seed
should be passed by `-seed` flag for cortex-m device on qemu.