### PR TITLE
ci: Add check-crypto CI for all platform

### DIFF
--- a/.github/workflows/check-crypto.yml
+++ b/.github/workflows/check-crypto.yml
@@ -1,0 +1,24 @@
+name: Check crypto
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build Zenroom on linux
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo apt install zsh jq && make linux
+          make check-crypto
+      - name: Build Zenroom on macos
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          make osx
+          make check-osx

--- a/build/linux.mk
+++ b/build/linux.mk
@@ -23,7 +23,7 @@ bsd: apply-patches milagro lua53 embed-lua
 		@cp -v src/zenroom build/zenroom
 
 
-linux: cflags := -O3 ${cflags_protection} -fPIE -fPIC
+linux: cflags := -O0 ${cflags_protection} -fPIE -fPIC
 linux: apply-patches milagro lua53 embed-lua
 	CC=${gcc} AR="${ar}"  CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 		make -C src linux


### PR DESCRIPTION
There are several platforms that Zenroom support. Some changes on other specific platform may not easily to check such as cortex m.

This commit adds a github actions CI to check Zenroom will pass on ubuntu, macos and windows platform.