### PR TITLE
ci: Disable apt upgrade

### DIFF
--- a/.github/workflows/cortex-arm.yml
+++ b/.github/workflows/cortex-arm.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
       - name: update dependencies
         run: |
-          sudo apt update && sudo apt upgrade
+          sudo apt update
       - name: install dependencies
         run: |
           sudo apt install zsh qemu-system-arm


### PR DESCRIPTION
The apt upgrade will failed inside ubuntu 20.04 on github actions.
After the image is updated, the apt upgrade can re-enable.