### PR TITLE
fix: Add aarch64 support

### DIFF
--- a/build/config.mk
+++ b/build/config.mk
@@ -82,6 +82,18 @@ milagro_cmake_flags += -DCMAKE_SYSTEM_PROCESSOR="arm" -DCMAKE_CROSSCOMPILING=1 -
 ldflags+=-mcpu=cortex-m3 -mthumb -mlittle-endian -mthumb-interwork -Wstack-usage=1024 -Wno-main -ffreestanding -T cortex_m.ld -nostartfiles -Wl,-gc-sections -ggdb
 endif
 
+ifneq (,$(findstring aarch64,$(MAKECMDGOALS)))
+gcc := aarch64-linux-gnu-gcc 
+objcopy := aarch64-linux-gnu-objcopy
+ranlib := aarch64-linux-gnu-ranlib
+ld := aarch64-linux-gnu 
+system := Linux 
+ldadd += -lm
+cflags := -O3 -fPIC -D'ARCH=\"LINUX\"' -DARCH_LINUX
+ldflags := -lm -lpthread
+milagro_cmake_flags += -DCMAKE_SYSTEM_PROCESSOR="aarch64" -DCMAKE_CROSSCOMPILING=1 -DCMAKE_C_COMPILER_WORKS=1
+endif
+
 ifneq (,$(findstring riscv64,$(MAKECMDGOALS)))
 gcc := riscv64-linux-gnu-gcc
 ar  := riscv64-linux-gnu-ar

--- a/build/linux.mk
+++ b/build/linux.mk
@@ -47,7 +47,7 @@ cortex-arm:	apply-patches milagro cortex-lua53 embed-lua
 aarch64: ldflags += -Wl,-Map=./zenroom.map
 aarch64: apply-patches milagro cortex-lua53 embed-lua
 	CC=${gcc} AR="${ar}" OBJCOPY="${objcopy}" CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
-	make -C src arm
+	make -C src aarch64 
 
 linux-riscv64: apply-patches milagro lua53 embed-lua
 	CC=${gcc} AR="${ar}"  CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \

--- a/src/Makefile
+++ b/src/Makefile
@@ -132,6 +132,9 @@ arm: ${SOURCES} cortex_m_boot.o
 	${CC} ${CFLAGS} ${CORTEX_M_CFLAGS} ${CORTEX_M_SRC_C} ${SOURCES} cortex_m_boot.o -o zenroom.elf ${LDFLAGS} ${LDADD}
 	${OBJCOPY} -O binary zenroom.elf zenroom.bin
 
+aarch64: ${SOURCES}
+	${CC} ${CFLAGS} ${SOURCES} -o zenroom ${LDFLAGS} ${LDADD}
+
 debug: CFLAGS+= -ggdb -DDEBUG=1 -Wall
 debug: LDADD+= -lm
 debug: clean ${SOURCES}


### PR DESCRIPTION
The cortex is the build command for building cortex-m target. This
will generate errors when building aarch64 target. This commit
fix the aarch64 build command from arm to aarch64.