### PR TITLE
WIP:  cli FD passing

### DIFF
--- a/pass_data_fd.go
+++ b/pass_data_fd.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func main() {
+	fmt.Println("zenroom with keys and data via FDs")
+
+	cmd := exec.Command("./src/zenroom", "-z", "-k", "-", "-a", "-")
+
+	// copy output to stdout
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
+
+	// the zencode is fed via stdin
+	cmd.Stdin = strings.NewReader(`Scenario 'ecdh': create the signature of an object
+
+	Given I am known as 'Alice'
+	Given I have my 'keypair'
+	Given I have a 'string' named 'Message' in 'MyData'
+	When I create the signature of 'Message'
+	Then print 'signature'
+`)
+
+	cmd.ExtraFiles = []*os.File{
+		// fd:3
+		prepareFile(`{"Alice":{"keypair":{"private_key":"60MNAaCSj67vNjp/90jAYzCNCok61UpwJ61OQm0ud7g=","public_key":"BDUElhJa9AuMruX5o0q/ldJ7o8IAbm6geuf7S8fD8lYZDgXTxoa3TUjQ7zN1A3EjqDuoKvgxbombOJPHba27mwY="}}}`),
+		// fd:4
+		prepareFile(`{ "MyData": { "Message": "Hello, World!", "foo": 1234 } }`),
+	}
+
+	err := cmd.Run()
+	check(err)
+	log.Println("success!")
+}
+
+// copies all the data that should be passed to the sub-process into an os pipe and returns the reading side of it.
+func prepareFile(data string) *os.File {
+	rd, wr, err := os.Pipe()
+	check(err)
+	fmt.Fprintln(wr, data)
+	err = wr.Close()
+	check(err)
+	return rd
+}
+
+// if something bad happens, crash fataly with the error
+func check(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/src/cli.c
+++ b/src/cli.c
@@ -92,18 +92,18 @@ void load_file(char *dst, FILE *fd) {
 	if(!fd) {
 		error(0, "Error opening %s", strerror(errno));
 		exit(1); }
-	if(fd!=stdin) {
-		if(fseek(fd, 0L, SEEK_END)<0) {
-			error(0, "fseek(end) error in %s: %s",__func__,
-			      strerror(errno));
-			exit(1); }
-		file_size = ftell(fd);
-		if(fseek(fd, 0L, SEEK_SET)<0) {
-			error(0, "fseek(start) error in %s: %s",__func__,
-			      strerror(errno));
-			exit(1); }
-		func(0, "size of file: %u",file_size);
-	}
+	// if(fd!=stdin) {
+	// 	if(fseek(fd, 0L, SEEK_END)<0) {
+	// 		error(0, "fseek(end) error in %s: %s",__func__,
+	// 		      strerror(errno));
+	// 		exit(1); }
+	// 	file_size = ftell(fd);
+	// 	if(fseek(fd, 0L, SEEK_SET)<0) {
+	// 		error(0, "fseek(start) error in %s: %s",__func__,
+	// 		      strerror(errno));
+	// 		exit(1); }
+	// 	func(0, "size of file: %u",file_size);
+	// }
 
 	firstline = malloc(MAX_STRING);
 	// skip shebang on firstline
@@ -133,12 +133,12 @@ void load_file(char *dst, FILE *fd) {
 
 		if(!bytes) {
 			if(feof(fd)) {
-				if((fd!=stdin) && (long)offset!=file_size) {
-					warning(0, "Incomplete file read (%u of %u bytes)",
-					      offset, file_size);
-				} else {
+				// if((fd!=stdin) && (long)offset!=file_size) {
+				// 	warning(0, "Incomplete file read (%u of %u bytes)",
+				// 	      offset, file_size);
+				// } else {
 					func(0, "EOF after %u bytes",offset);
-				}
+				// }
  				dst[offset] = '\0';
 				break;
 			}
@@ -288,13 +288,25 @@ int main(int argc, char **argv) {
 	}
 
 	if(keysfile[0]!='\0') {
+		FILE *keysfd;
 		if(verbosity) act(NULL, "reading KEYS from file: %s", keysfile);
-		load_file(keys, fopen(keysfile, "r"));
+		if (keysfile[0] == '-') {
+			keysfd = fdopen(3, "r");
+		} else {
+			keysfd = fopen(keysfile, "r");
+		}
+		load_file(keys, keysfd);
 	}
 
 	if(datafile[0]!='\0' && verbosity) {
+		FILE *datafd;
 		if(verbosity) act(NULL, "reading DATA from file: %s", datafile);
-		load_file(data, fopen(datafile, "r"));
+		if (datafile[0] == '-') {
+			datafd = fdopen(4, "r");
+		} else {
+			datafd = fopen(datafile, "r");
+		}
+		load_file(data, datafd);
 	}
 
 	if(interactive) {


### PR DESCRIPTION
I was about to open a new issue to ask for what Adam already outlined in https://github.com/dyne/Zenroom/issues/103#issuecomment-739153983.

So heer is a proof of concept for passing additional file descriptors to the cli such that key material is not leaked to the filesystem.

POC because I just commented out the seek handling to determine the size of the file. Alternatively this feature could use other flags to switch the behavior more cleanly but I don't have opinions on this at all.

I chose Go for the demo but it should work with all platforms that offer this fd passing feature and I think it would offer much lighter (as in easier to build) integration than trying to bind zencode into the same binary/process via FFI.

TODO:
* [ ] clean up the seek()/EOF handling
* [ ] rethink implicit fd numbering(?)