### PR TITLE
fix uninitialized ACK data, required by CODEC (fixes #447)

### DIFF
--- a/src/lua/zencode_w3c.lua
+++ b/src/lua/zencode_w3c.lua
@@ -147,12 +147,12 @@ ZEN.add_schema(
         -- only internal 'jws' member has peculiar encoding
         verifiable_credential = function(obj)
             ACK.verifiable_credential = {}
-            ZEN.CODEC.verifiable_credential = {
+            new_codec('verifiable_credential', {
                 name = 'verifiable_credential',
                 encoding = 'string',
                 zentype = 'schema',
                 luatype = 'table'
-            }
+            })
             return (deepmap(OCTET.from_string, obj))
         end
     }

--- a/src/lua/zencode_w3c.lua
+++ b/src/lua/zencode_w3c.lua
@@ -146,6 +146,7 @@ ZEN.add_schema(
         -- flexible verifiable credential
         -- only internal 'jws' member has peculiar encoding
         verifiable_credential = function(obj)
+            ACK.verifiable_credential = {}
             ZEN.CODEC.verifiable_credential = {
                 name = 'verifiable_credential',
                 encoding = 'string',


### PR DESCRIPTION
Looks a bit like sweeping under the carpet, but at least
it is initialized....