### PR TITLE
fix(bats): remove SUBDOC in bats_setup

### DIFF
--- a/test/bats_setup
+++ b/test/bats_setup
@@ -8,7 +8,6 @@ setup() {
     load "$TR"/test_helper/bats-support/load
     load "$TR"/test_helper/bats-assert/load
     load "$TR"/test_helper/bats-file/load
-    SUBDOC=lua
     if [ "$ZENROOM_EXECUTABLE" == "" ]; then
 	ZENROOM_EXECUTABLE="${TR}/zenroom"
     fi


### PR DESCRIPTION
SUBDOC was fixed to "lua", and the new SUBDOC defined in the bats files were not taken into account.. 