### PR TITLE
Really weird memory leak

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -54,7 +54,7 @@ fn aquire_zen_gil() -> ZenGIL {
     mutex.lock().unwrap()
 }
 
-const BUF_SIZE: usize = 2 * 1024 * 1024;
+const BUF_SIZE: usize = 10 * 1024;
 
 type Fun = unsafe extern "C" fn(
     *mut ::std::os::raw::c_char,

--- a/src/zen_io.c
+++ b/src/zen_io.c
@@ -107,7 +107,7 @@ static int zen_write (lua_State *L) {
   octet *o = o_arg(L, 1); // it may be null (empty string)
   if(!o) return 0;
   if (Z->stdout_buf) {
-	char *p = Z->stderr_buf+Z->stderr_pos;
+	char *p = Z->stdout_buf+Z->stdout_pos;
 	if (Z->stdout_pos+o->len > Z->stdout_len)
 	  zerror(L, "No space left in output buffer");
 	memcpy(p, o->val, o->len);


### PR DESCRIPTION
After changing the body of the test with a loop that executed the test multiple times, something really strange happened.

For a buffer of size 10 * 1024 the for loop executed until the end

For a buffer size of 512 * 1024 or more the number of iteration executed without error is proportional to the size of the buffer.