### PR TITLE
fix: 🐛 hex2buf fails when invalid string is passed

### DIFF
--- a/src/encoding.c
+++ b/src/encoding.c
@@ -42,11 +42,15 @@ static const int32_t hextable[] = {
 };
 
 // takes zero terminated hex string, requires pre-allocation of dst,
-// returns len in bytes
+// returns len in bytes or -1 in case of error
 int hex2buf(char *dst, const char *hex) {
 	register int i, j;
-	for(i=0, j=0; hex[j]!=0; i++, j+=2)
+	for(i=0, j=0; hex[j]!=0; i++, j+=2) {
+		if(hex[j+1] == '\0') {
+			return -1;
+		}
 		dst[i] = (hextable[(short)hex[j]]<<4) + hextable[(short)hex[j+1]];
+	}
 	return(i);
 }
 

--- a/src/zen_octet.c
+++ b/src/zen_octet.c
@@ -681,13 +681,17 @@ static int from_hex(lua_State *L) {
 		if((len&1)==1) { // odd length means elision
 			s[1]='0'; // overwrite a single byte in const
 			o->len = hex2buf(o->val, s+1);
-			END(1);
 		} else {
 			o->len = hex2buf(o->val, s+2);
-			END(1);
 		}
+	} else {
+		o->len = hex2buf(o->val,s);
 	}
-	o->len = hex2buf(o->val,s);
+	if(o->len < 0) {
+		zerror(L, "%s :: Invalid octet in hex string", __func__);
+		lerror(L, "operation aborted");
+		lua_pushnil(L);
+	}
 	END(1);
 }
 


### PR DESCRIPTION
There was an undefined behavior when an odd length hex string was converted to octet.

Add check in `hex2buf` and throw a fatal error.