### PR TITLE
refactor(bindings): ♻️ reduce python binding source distribution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,7 +226,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: mymindstorm/setup-emsdk@v11
+      - uses: mymindstorm/setup-emsdk@v12
         with:
           version: ${{ env.EM_VERSION }}
       - run: sudo apt-get update; sudo apt-get install zsh meson ninja-build
@@ -333,7 +333,9 @@ jobs:
         with:
           ref: master
           fetch-depth: 0
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - uses: docker/setup-qemu-action@v2
         if: runner.os == 'Linux'
         with:

--- a/bindings/python3/prepare.sh
+++ b/bindings/python3/prepare.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
-mkdir -p src
+mkdir -p src/docs/pages
+cp ../../docs/pages/python.md src/docs/pages/python.md
 cp ../../Makefile src/Makefile
 cp -r ../../build src/build
 cp -r ../../lib src/lib
 cp -r ../../src src/src
 cp -r ../../test src/test
-cp -r ../../docs src/docs
-cp -r ../../.git src/.git
+
+py_version=`git describe --tags --abbrev=0 | sed 's/^v//'`
+branch=`git rev-parse --abbrev-ref HEAD`
+hash=""
+time=""
+if [ "$branch" != "master" ]; then
+    hash="+$(git rev-parse --short HEAD)"
+    time=".dev$(git show -s --format=%ct HEAD)"
+fi
+echo "${py_version}${hash}" > src/git_utils
+echo "${py_version}${time}" >> src/git_utils

--- a/bindings/python3/setup.py
+++ b/bindings/python3/setup.py
@@ -19,20 +19,9 @@ BLAKE2_INCLUDE_DIR = os.path.join(ZENROOM_ROOT, 'lib/blake2')
 MIMALLOC_INCLUDE_DIR = os.path.join(ZENROOM_ROOT, 'lib/mimalloc/include')
 
 def get_versions():
-    # performed in ZENROOM_ROOT
-    # first char is v, last one is a newline
-    python_version = subprocess.run(['git', 'describe', '--tags', '--abbrev=0'],
-                                     stdout=subprocess.PIPE).stdout.decode('utf-8').strip('v\n')
-    zenroom_version = python_version
-    branch = subprocess.run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-                            stdout=subprocess.PIPE).stdout.decode('utf-8')
-    if branch.strip() != "master":
-        hash = subprocess.run(['git', 'rev-parse', '--short', 'HEAD'],
-                              stdout=subprocess.PIPE).stdout.decode('utf-8')
-        time = subprocess.run(['git', 'show', '-s', '--format=%ct', 'HEAD'],
-                              stdout=subprocess.PIPE).stdout.decode('utf-8')
-        zenroom_version += '+'+hash[:-1]
-        python_version += '.dev'+time[:-1]
+    with open(os.path.join(ZENROOM_ROOT, 'git_utils')) as f:
+        zenroom_version = f.readline().strip('\n')
+        python_version = f.readline().strip('\n')
     return python_version, zenroom_version
 
 


### PR DESCRIPTION
Reduce the size of the python distribution package from 90 MB to 40 MB.
Tested 🧪 on [matteo-cristino/test_python_release](https://github.com/matteo-cristino/Zenroom/tree/test_python_release) releasing 📦 the package on [test.pypi](https://test.pypi.org/project/personal-zenroom/) (zenroom was already present thus i changed the package name to personal-zenroom).