### PR TITLE
feat(hash): ✨ zencode statement to create an hash to point

### DIFF
--- a/src/lua/zencode_hash.lua
+++ b/src/lua/zencode_hash.lua
@@ -51,20 +51,36 @@ When(
     end
 )
 
-When(
-    "create the hash to point '' of each object in ''",
-    function(what, arr)
-        local F = _G[what]
-        ZEN.assert(
+When("create the hash to point '' of ''", function(curve, object)
+    local F = _G[curve]
+    ZEN.assert(
             luatype(F.hashtopoint) == 'function',
-            'Hash type ' .. what .. ' is invalid (no hashtopoint)'
+            'Hash type ' .. curve .. ' is invalid (no hashtopoint)'
+    )
+    empty'hash_to_point'
+    local obj = have(object)
+    ACK.hash_to_point = F.hashtopoint(ZEN.serialize(obj))
+    new_codec('hash_to_point', { zentype='element' })
+end)
+
+When(deprecated("create the hash to point '' of each object in ''",
+    [[Foreach 'element' in 'array'
+When I create the hash to point of 'array'
+and I move 'hash to point' in 'array of hashes'
+EndForeach]],
+    function(curve, object)
+        local F = _G[curve]
+        ZEN.assert(
+                luatype(F.hashtopoint) == 'function',
+                'Hash type ' .. curve .. ' is invalid (no hashtopoint)'
         )
-        local A = have(arr)
-        local count = isarray(A)
-        ZEN.assert(count > 0, 'Object is not an array: ' .. arr)
-        ACK.hash_to_point = deepmap(F.hashtopoint, A)
-	new_codec('hash_to_point', { luatype='table', zentype='array' })
-    end
+        empty'hash_to_point'
+        local obj = have(object)
+        local count = isarray(obj)
+        ZEN.assert(count > 0, 'Object is not an array: ' .. object)
+        ACK.hash_to_point = deepmap(F.hashtopoint, obj)
+        new_codec('hash_to_point', { luatype='table', zentype='array' })
+    end)
 )
 
 When(

--- a/test/zencode/hash.bats
+++ b/test/zencode/hash.bats
@@ -189,3 +189,18 @@ EOF
 
 
 }
+
+@test "Hash to point ECP" {
+    cat << EOF | zexe hash_to_point.zen
+Given nothing
+When I set 'string' to 'hello world!' as 'string'
+and I create the hash to point 'ECP' of 'string'
+and I rename 'hash to point' to 'hash to point ecp'
+and I create the hash to point 'ECP2' of 'string'
+and I rename 'hash to point' to 'hash to point ecp2'
+Then print 'hash to point ecp'
+Then print 'hash to point ecp2'
+EOF
+    save_output 'hash_to_point.json'
+    assert_output '{"hash_to_point_ecp":"Awd+icZ7dJ55g2iQFzcwtdM/gLTU7HQ663RoAxj8d82YTtLuHIQAbPMDxMfP7/RFAg==","hash_to_point_ecp2":"AhTWpLtcBe+YX4hIBogbdhkQwj36Y+uhaqF0+BR3NeLs1bez+LIRclu9kxgAfeiVCLK3u/eYavyFEtQ2zyf8Mc+tbwRy18oGghnano/eGpkEbPqapfH3otxVeUcLdCb9AduV4iMLeGKydqkBilCrTWghg5JRDJxScA6uE1010azDNY9YnBJWi+Saxlxo7aIXDNv4skA1+VgT9GBzMb1EsfPhOsksJh+alnIF7ERyhF/blHf67toTzfjZlkhTJkeK"}'
+}


### PR DESCRIPTION
Also deprecated the hash to point of each object in an array with the following message:
```
[W]  DEPRECATED:
create the hash to point '' of each object in ''
use instead
Foreach 'element' in 'array'
When I create the hash to point of 'array'
and I move 'hash to point' in 'array of hashes'
EndForeach
```