### PR TITLE
fix: 🐛deprecate statements with missing verify prefix

### DIFF
--- a/src/lua/zencode_array.lua
+++ b/src/lua/zencode_array.lua
@@ -167,7 +167,7 @@ end)
 --     table.insert(ACK[arr], ACK[ele])
 -- end)
 
-IfWhen("the '' is not found in ''", function(ele_name, obj_name)
+local function _not_found_in(ele_name, obj_name)
 	local ele, ele_codec = have(ele_name)
 	local obj, obj_codec = have(obj_name)
 	if obj_codec.zentype == 'array' then
@@ -180,9 +180,15 @@ IfWhen("the '' is not found in ''", function(ele_name, obj_name)
 	else
 		ZEN.assert(false, "Invalid container type: "..obj_name.." is "..obj_codec.zentype)
 	end
-end)
+end
 
-IfWhen("the '' is found in ''", function(ele_name, obj_name)
+IfWhen(deprecated("the '' is not found in ''",
+	"verify the '' is not found in ''",
+	_not_found_in)
+)
+IfWhen("verify the '' is not found in ''", _not_found_in)
+
+local function _found_in(ele_name, obj_name)
 	local ele, ele_codec = have(ele_name)
 	local obj, obj_codec = have(obj_name)
 	if obj_codec.zentype == 'array' then
@@ -200,9 +206,15 @@ IfWhen("the '' is found in ''", function(ele_name, obj_name)
 	else
 		ZEN.assert(false, "Invalid container type: "..obj_name.." is "..obj_codec.zentype)
 	end
-end)
+end
 
-IfWhen("the '' is found in '' at least '' times", function(ele_name, obj_name, times)
+IfWhen(deprecated("the '' is found in ''",
+	"verify the '' is found in ''",
+	_found_in)
+)
+IfWhen("verify the '' is found in ''", _found_in)
+
+local function _found_in_atleast(ele_name, obj_name, times)
 	local ele, ele_codec = have(ele_name)
 	ZEN.assert( ele_codec.luatype ~= 'table', "Invalid use of table in object comparison: "..ele_name)
 	local num = have(times)
@@ -220,7 +232,13 @@ IfWhen("the '' is found in '' at least '' times", function(ele_name, obj_name, t
 	else
 		ZEN.assert(found >= num, "Object "..ele_name.." found only "..tostring(found).." times instead of "..tostring(num).." in array "..obj_name)
 	end
-end)
+end
+
+IfWhen(deprecated("the '' is found in '' at least '' times",
+	"verify the '' is found in '' at least '' times",
+	_found_in_atleast)
+)
+IfWhen("verify the '' is found in '' at least '' times", _found_in_atleast)
 
 local function _aggr_array(arr)
 	local A = have(arr)

--- a/src/lua/zencode_petition.lua
+++ b/src/lua/zencode_petition.lua
@@ -212,39 +212,46 @@ IfWhen(
 	end
 )
 
-IfWhen(
-	'the petition signature is not a duplicate',
-	function()
-		if luatype(ACK.petition.list) == 'table' then
-			ZEN.assert(
-				(not array_contains(
-					ACK.petition.list,
-					ACK.petition_signature.uid_signature
-				)),
-				'Duplicate petition signature detected'
-			)
-		else
-			ACK.petition.list = {}
-		end
-		table.insert(ACK.petition.list, ACK.petition_signature.uid_signature)
-	end
+local function _check_duplicate()
+    if luatype(ACK.petition.list) == 'table' then
+        ZEN.assert(
+            (not array_contains(
+                ACK.petition.list,
+                ACK.petition_signature.uid_signature
+            )),
+            'Duplicate petition signature detected'
+        )
+    else
+        ACK.petition.list = {}
+    end
+    table.insert(ACK.petition.list, ACK.petition_signature.uid_signature)
+end
+
+IfWhen(deprecated('the petition signature is not a duplicate',
+    'verify the petition signature is not a duplicate',
+    _check_duplicate)
+)
+IfWhen('verify the petition signature is not a duplicate', _check_duplicate)
+
+local function _check_one_more()
+    -- verify that the signature is +1 (no other value supported)
+    ACK.petition_signature.one =
+        PET.prove_sign_petition(ACK.petition.owner, BIG.new(1))
+    ZEN.assert(
+        PET.verify_sign_petition(
+            ACK.petition.owner,
+            ACK.petition_signature.one
+        ),
+        'ABC petition signature adds more than one signature'
+    )
+end
+
+IfWhen(deprecated('the petition signature is just one more',
+    'verify the petition signature is just one more',
+    _check_one_more)
 )
 
-IfWhen(
-	'the petition signature is just one more',
-	function()
-		-- verify that the signature is +1 (no other value supported)
-		ACK.petition_signature.one =
-			PET.prove_sign_petition(ACK.petition.owner, BIG.new(1))
-		ZEN.assert(
-			PET.verify_sign_petition(
-				ACK.petition.owner,
-				ACK.petition_signature.one
-			),
-			'ABC petition signature adds more than one signature'
-		)
-	end
-)
+IfWhen('verify the petition signature is just one more', _check_one_more)
 
 When(
 	'add the signature to the petition',

--- a/src/lua/zencode_when.lua
+++ b/src/lua/zencode_when.lua
@@ -45,18 +45,48 @@ local function _is_found(el, t)
 	return false
 end
 
-IfWhen("'' is found", function(el)
-	ZEN.assert(_is_found(el), "Cannot find object: "..el)
-end)
-IfWhen("'' is not found", function(el)
-	ZEN.assert(not _is_found(el), "Object should not be found: "..el)
+IfWhen(deprecated("'' is found",
+    "verify '' is found",
+    function(el)
+        ZEN.assert(_is_found(el), "Cannot find object: "..el)
+    end)
+)
+
+IfWhen(deprecated("'' is not found",
+    "verify '' is not found",
+    function(el)
+        ZEN.assert(not _is_found(el), "Object should not be found: "..el)
+    end)
+)
+
+IfWhen(deprecated("'' is found in ''",
+    "verify '' is found in ''",
+    function(el, t)
+        ZEN.assert(_is_found(el, t), "Cannot find object: "..el.." in "..t)
+    end)
+)
+
+IfWhen(deprecated("'' is not found in ''",
+    "verify '' is not found in ''",
+    function(el, t)
+        ZEN.assert(not _is_found(el,t), "Object: "..el.." should not be found in "..t)
+    end)
+)
+
+IfWhen("verify '' is found", function(el)
+    ZEN.assert(_is_found(el), "Cannot find object: "..el)
 end)
 
-IfWhen("'' is found in ''", function(el, t)
-	ZEN.assert(_is_found(el, t), "Cannot find object: "..el.." in "..t)
+IfWhen("verify '' is not found", function(el)
+    ZEN.assert(not _is_found(el), "Object should not be found: "..el)
 end)
-IfWhen("'' is not found in ''", function(el, t)
-	ZEN.assert(not _is_found(el,t), "Object: "..el.." should not be found in "..t)
+
+IfWhen("verify '' is found in ''", function(el, t)
+    ZEN.assert(_is_found(el, t), "Cannot find object: "..el.." in "..t)
+end)
+
+IfWhen("verify '' is not found in ''", function(el, t)
+    ZEN.assert(not _is_found(el,t), "Object: "..el.." should not be found in "..t)
 end)
 
 When("append '' to ''", function(src, dest)

--- a/test/zencode/array.bats
+++ b/test/zencode/array.bats
@@ -33,7 +33,7 @@ When I pick the random object in 'bonnetjes'
 and I rename the 'random object' to 'lucky one'
 and I remove the 'lucky one' from 'bonnetjes'
 # redundant check
-and the 'lucky one' is not found in 'bonnetjes'
+and I verify the 'lucky one' is not found in 'bonnetjes'
 Then print the 'lucky one'
 EOF
     save_output "array_rename_remove.json"
@@ -69,92 +69,92 @@ and I have a 'base64' named 'not_found_key_base64'
 and I have a 'hex' named 'not_found_key_hex'
 and I have a 'base58' named 'not_found_key_base58'
 
-When the 'found_key_string' is found in 'my_array'
-and the 'found_key_base64' is found in 'my_array'
-and the 'found_key_hex' is found in 'my_array'
-and the 'found_key_base58' is found in 'my_array'
+When I verify the 'found_key_string' is found in 'my_array'
+and I verify the 'found_key_base64' is found in 'my_array'
+and I verify the 'found_key_hex' is found in 'my_array'
+and I verify the 'found_key_base58' is found in 'my_array'
 
-When the 'found_key_string' is found in 'my_dict'
-and the 'found_key_base64' is found in 'my_dict'
-and the 'found_key_hex' is found in 'my_dict'
-and the 'found_key_base58' is found in 'my_dict'
+When I verify the 'found_key_string' is found in 'my_dict'
+and I verify the 'found_key_base64' is found in 'my_dict'
+and I verify the 'found_key_hex' is found in 'my_dict'
+and I verify the 'found_key_base58' is found in 'my_dict'
 
-When the 'not_found_key_string' is not found in 'my_array'
-and the 'not_found_key_base64' is not found in 'my_array'
-and the 'not_found_key_hex' is not found in 'my_array'
-and the 'not_found_key_base58' is not found in 'my_array'
+When I verify the 'not_found_key_string' is not found in 'my_array'
+and I verify the 'not_found_key_base64' is not found in 'my_array'
+and I verify the 'not_found_key_hex' is not found in 'my_array'
+and I verify the 'not_found_key_base58' is not found in 'my_array'
 
-When the 'not_found_key_string' is not found in 'my_dict'
-and the 'not_found_key_base64' is not found in 'my_dict'
-and the 'not_found_key_hex' is not found in 'my_dict'
-and the 'not_found_key_base58' is not found in 'my_dict'
+When I verify the 'not_found_key_string' is not found in 'my_dict'
+and I verify the 'not_found_key_base64' is not found in 'my_dict'
+and I verify the 'not_found_key_hex' is not found in 'my_dict'
+and I verify the 'not_found_key_base58' is not found in 'my_dict'
 
 When I set 'result' to 'success' as 'string'
 
-If the 'not_found_key_string' is found in 'my_array'
+If I verify the 'not_found_key_string' is found in 'my_array'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
-If the 'not_found_key_base64' is found in 'my_array'
+If I verify the 'not_found_key_base64' is found in 'my_array'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
-If the 'not_found_key_hex' is found in 'my_array'
+If I verify the 'not_found_key_hex' is found in 'my_array'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
-IF the 'not_found_key_base58' is found in 'my_array'
-When I remove 'result'
-and I set 'result' to 'failure' as 'string'
-EndIf
-
-If the 'not_found_key_string' is found in 'my_dict'
-When I remove 'result'
-and I set 'result' to 'failure' as 'string'
-EndIf
-If the 'not_found_key_base64' is found in 'my_dict'
-When I remove 'result'
-and I set 'result' to 'failure' as 'string'
-EndIf
-If the 'not_found_key_hex' is found in 'my_dict'
-When I remove 'result'
-and I set 'result' to 'failure' as 'string'
-EndIf
-IF the 'not_found_key_base58' is found in 'my_dict'
+If I verify the 'not_found_key_base58' is found in 'my_array'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
 
-If the 'found_key_string' is not found in 'my_array'
+If I verify the 'not_found_key_string' is found in 'my_dict'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
-If the 'found_key_base64' is not found in 'my_array'
+If I verify the 'not_found_key_base64' is found in 'my_dict'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
-If the 'found_key_hex' is not found in 'my_array'
+If I verify the 'not_found_key_hex' is found in 'my_dict'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
-IF the 'found_key_base58' is not found in 'my_array'
+IF I verify the 'not_found_key_base58' is found in 'my_dict'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
 
-If the 'found_key_string' is not found in 'my_dict'
+If I verify the 'found_key_string' is not found in 'my_array'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
-If the 'found_key_base64' is not found in 'my_dict'
+If I verify the 'found_key_base64' is not found in 'my_array'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
-If the 'found_key_hex' is not found in 'my_dict'
+If I verify the 'found_key_hex' is not found in 'my_array'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
-IF the 'found_key_base58' is not found in 'my_dict'
+IF I verify the 'found_key_base58' is not found in 'my_array'
+When I remove 'result'
+and I set 'result' to 'failure' as 'string'
+EndIf
+
+If I verify the 'found_key_string' is not found in 'my_dict'
+When I remove 'result'
+and I set 'result' to 'failure' as 'string'
+EndIf
+If I verify the 'found_key_base64' is not found in 'my_dict'
+When I remove 'result'
+and I set 'result' to 'failure' as 'string'
+EndIf
+If I verify the 'found_key_hex' is not found in 'my_dict'
+When I remove 'result'
+and I set 'result' to 'failure' as 'string'
+EndIf
+IF I verify the 'found_key_base58' is not found in 'my_dict'
 When I remove 'result'
 and I set 'result' to 'failure' as 'string'
 EndIf
@@ -330,7 +330,7 @@ EOF
 Given I have a 'string array' named 'haystack'
 and I have a 'number' named 'quorum'
 and I have a 'string' named 'needle'
-When the 'needle' is found in 'haystack' at least 'quorum' times
+When I verify the 'needle' is found in 'haystack' at least 'quorum' times
 Then Print the string 'Success' 
 EOF
     save_output "needle_in_haystack.json"

--- a/test/zencode/branching.bats
+++ b/test/zencode/branching.bats
@@ -179,56 +179,56 @@ If 'hello' is not found
 When I insert string '3.success' in 'found output'
 EndIf
 
-If 'hello' is found in 'arr'
+If I verify 'hello' is found in 'arr'
 When I insert string '4.success' in 'found output'
 EndIf
 
-If 'hello' is found in 'dict'
+If I verify 'hello' is found in 'dict'
 When I insert string '5.success' in 'found output'
 EndIf
 
-If 'good' is not found in 'arr'
+If I verify 'good' is not found in 'arr'
 When I insert string '6.success' in 'found output'
 EndIf
 
-If 'good' is not found in 'dict'
+If I verify 'good' is not found in 'dict'
 When I insert string '7.success' in 'found output'
 EndIf
 
-If 'empty octet' is not found in 'not_empty_dict'
+If I verify 'empty octet' is not found in 'not_empty_dict'
 When I insert string '8.success' in 'found output'
 EndIf
 
 
-If 'hello' is found
+If I verify 'hello' is found
 When I insert string '1.fail' in 'found output'
 EndIf
 
-If 'str' is not found
+If I verify 'str' is not found
 When I insert string '2.fail' in 'found output'
 EndIf
 
-If 'good' is found in 'arr'
+If I verify 'good' is found in 'arr'
 When I insert string '3.fail' in 'found output'
 EndIf
 
-If 'good' is found in 'dict'
+If I verify 'good' is found in 'dict'
 When I insert string '4.fail' in 'found output'
 EndIf
 
-If 'hello' is not found in 'arr'
+If I verify 'hello' is not found in 'arr'
 When I insert string '5.fail' in 'found output'
 EndIf
 
-If 'hello' is not found in 'dict'
+If I verify 'hello' is not found in 'dict'
 When I insert string '6.fail' in 'found output'
 EndIf
 
-If 'hello' is found in 'empty arr'
+If I verify 'hello' is found in 'empty arr'
 When I insert string '7.fail' in 'found output'
 EndIf
 
-If 'empty_arr' is not found
+If I verify 'empty_arr' is not found
 When I insert string '8.fail' in 'found output'
 EndIf
 

--- a/test/zencode/branching.bats
+++ b/test/zencode/branching.bats
@@ -47,8 +47,8 @@ Then print string 'the conditions can never be satisfied'
 Endif
 
 # You can also check if an object exists at a certain point of the execution, with the statement:
-# If 'objectName' is found
-If 'just a random' is found
+# If I verify 'objectName' is found
+If I verify 'just a random' is found
 Then print string 'I found the newly created random number, so I certify that the condition is satisfied'
 Endif
 
@@ -167,15 +167,15 @@ Given I have a 'string' named 'str'
 
 When I create the 'string array' named 'found output'
 
-If 'str' is found
+If I verify 'str' is found
 When I insert string '1.success' in 'found output'
 EndIf
 
-If 'empty_arr' is found
+If I verify 'empty_arr' is found
 When I insert string '2.success' in 'found output'
 EndIf
 
-If 'hello' is not found
+If I verify 'hello' is not found
 When I insert string '3.success' in 'found output'
 EndIf
 

--- a/test/zencode/branching.bats
+++ b/test/zencode/branching.bats
@@ -17,30 +17,30 @@ and I have a 'number' named 'number_higher'
 # Here we try a simple comparison between the numbers
 # if the condition is satisfied, the 'When' and 'Then' statements
 # in the rest of the branch will be executed, which is not the case here.
-If number 'number_lower' is more than 'number_higher'
+If I verify number 'number_lower' is more than 'number_higher'
 When I create the random 'random_left_is_higher'
 Then print string 'number_lower is higher'
 Endif
 
 # A simple comparison where the condition is satisfied, the 'When' and 'Then' statements are executed.
-If number 'number_lower' is less than 'number_higher'
+If I verify number 'number_lower' is less than 'number_higher'
 When I create the random 'just a random'
 Then print string 'I promise that number_higher is higher than number_lower'
 Endif
 
 # We can also check if a certain number is less than or equal to another one
-If number 'number_lower' is less or equal than 'number_higher'
+If I verify number 'number_lower' is less or equal than 'number_higher'
 Then print string 'the number_lower is less than or equal to number_higher'
 Endif
 # or if it is more than or equal to
-If number 'number_lower' is more or equal than 'number_higher'
+If I verify number 'number_lower' is more or equal than 'number_higher'
 Then print string 'the number_lower is more than or equal to number_higher, imposssible!'
 Endif
 
 # Here we try a nested comparison: if the first condition is
 # satisfied, the second one is evaluated too. Given the conditions,
 # they can't both be true at the same time, so the rest of the branch won't be executed.
-If number 'number_lower' is less than 'number_higher'
+If I verify number 'number_lower' is less than 'number_higher'
 If I verify 'number_lower' is equal to 'number_higher'
 When I create the random 'random_this_is_impossible'
 Then print string 'the conditions can never be satisfied'
@@ -124,13 +124,13 @@ EOF
 Given I have a 'number' named 'left'
 and I have a 'number' named 'right'
 
-If number 'left' is less than 'right'
+If I verify number 'left' is less than 'right'
 and I verify 'right' is equal to 'right'
 Then print string 'right is higher'
 and print string 'and I am right'
 endif
 
-If number 'left' is more than 'right'
+If I verify number 'left' is more than 'right'
 Then print string 'left is higher'
 endif
 EOF

--- a/test/zencode/branching.bats
+++ b/test/zencode/branching.bats
@@ -459,7 +459,7 @@ Given I have a 'string' named 'id'
 
 Given I have a 'string array' named 'W3C-DID'
 
-If the 'id' is not found in 'W3C-DID'
+If I verify the 'id' is not found in 'W3C-DID'
 When I set 'title' to 'Identifier Not Found' as 'string'
 When I set 'type' to 'about:blank' as 'string'
 When I set 'status' to '404' as 'number'
@@ -469,7 +469,7 @@ Then print 'type'
 Then print 'title'
 Endif
 
-If the 'id' is  found in 'W3C-DID'
+If I verify the 'id' is  found in 'W3C-DID'
 Then print 'W3C-DID'
 Then print the 'id'
 Endif

--- a/test/zencode/cookbook_dictionaries.bats
+++ b/test/zencode/cookbook_dictionaries.bats
@@ -315,13 +315,13 @@ and I rename the 'result' to 'SumTransactionProductAmountAfterTheta'
 # Here we search for a dictionary what a certain name in a list. 
 # This could be useful when searching for a certain transaction in different data sets
 # We are loading the string to match from the dataset.
-#When the 'dictionaryToBeFound' is found in 'TransactionsBatchA'
-#When the 'dictionaryToBeFound' is found in 'TransactionsBatchA'
+#When I verify the 'dictionaryToBeFound' is found in 'TransactionsBatchA'
+#When I verify the 'dictionaryToBeFound' is found in 'TransactionsBatchA'
 
 # Here we are doing the opposite, so check the a dictionary is not in the list
 # and we ar ecreating the string not to be match inline in the script, just for the fun of it
 When I write string 'someRandomName' in 'not.there'
-and the 'not.there' is not found in 'TransactionsBatchA'
+and I verify the 'not.there' is not found in 'TransactionsBatchA'
 
 # CREATE Dictionary
 # You can create a new dictionary using a similar syntax to the one to create an array 

--- a/test/zencode/cookbook_when.bats
+++ b/test/zencode/cookbook_when.bats
@@ -491,9 +491,9 @@ When number 'myThirdNumber' is more than 'mySecondNumber'
 # and matches it against each element of the array.
 # It works with any kind of array, as long as the element of the array are of the same schema
 # as the variable.
-When the 'myTenthString' is found in 'myFourthArray'
-When the 'myFirstString' is not found in 'myFourthArray'
-When the 'mySeventeenthString' is found in 'myFourthArray' at least 'myFourthNumber' times
+When I verify the 'myTenthString' is found in 'myFourthArray'
+When I verify the 'myFirstString' is not found in 'myFourthArray'
+When I verify the 'mySeventeenthString' is found in 'myFourthArray' at least 'myFourthNumber' times
 Then print all data
 EOF
     cat $R/docs/examples/zencode_cookbook/$SUBDOC/whenCompleteScriptGiven.zen \

--- a/test/zencode/cookbook_when.bats
+++ b/test/zencode/cookbook_when.bats
@@ -480,10 +480,10 @@ When I verify 'myThirdNumber' is equal to 'myFourthNumber'
 
 # LESS, MORE, EQUAL
 # Number comparisons: those are pretty self explaining.
-When number 'myFourthNumber' is less or equal than 'myThirdNumber'
-When number 'myFirstNumber' is less than  'myThirdNumber'
-When number 'myThirdNumber' is more or equal than 'mySecondNumber'
-When number 'myThirdNumber' is more than 'mySecondNumber'
+When I verify number 'myFourthNumber' is less or equal than 'myThirdNumber'
+When I verify number 'myFirstNumber' is less than  'myThirdNumber'
+When I verify number 'myThirdNumber' is more or equal than 'mySecondNumber'
+When I verify number 'myThirdNumber' is more than 'mySecondNumber'
 
 # FOUND, NOT FOUND, FOUND AT LEAST n TIMES
 # The "is found" statement, takes two objects as input: 

--- a/test/zencode/dictionary.bats
+++ b/test/zencode/dictionary.bats
@@ -370,7 +370,7 @@ Given that I have a 'string dictionary' named 'TransactionsBatchA'
 Given that I have a 'number' named 'salesStartTimestamp'
 
 # Here we search if a certain dictionary exists in the list
-When the 'dictionaryToBeFound' is found in 'TransactionsBatchA'
+When I verify the 'dictionaryToBeFound' is found in 'TransactionsBatchA'
 
 # Here we find the highest value of an element, in all dictionaries
 When I find the max value 'PricePerKG' for dictionaries in 'TransactionsBatchA'

--- a/test/zencode/foreach.bats
+++ b/test/zencode/foreach.bats
@@ -35,7 +35,7 @@ Given I have a 'float array' named 'xs'
 Given I have a 'float' named 'one'
 Given I have a 'float' named 'limit'
 When I create the new array
-If number 'one' is less than 'limit'
+If I verify number 'one' is less than 'limit'
 Foreach 'x' in 'xs'
 When I move 'x' in 'new array'
 EndForeach
@@ -67,7 +67,7 @@ Given I have a 'float array' named 'xs'
 Given I have a 'float' named 'limit'
 When I create the new array
 Foreach 'x' in 'xs'
-If number 'x' is less than 'limit'
+If I verify number 'x' is less than 'limit'
 When I move 'x' in 'new array'
 Endif
 EndForeach
@@ -177,15 +177,15 @@ When I copy 'result' to 'result in array'
 # some comments
 # some comments
 # some comments
-If number 'limit' is less than 'x'
+If I verify number 'limit' is less than 'x'
 When I set 'keyname' to 'key' as 'string'
 When I append 'x' to 'keyname'
 Endif
 When I move 'result in array' in 'new nums'
-If number 'limit' is less than 'x'
+If I verify number 'limit' is less than 'x'
 When I rename the object named by 'resultname' to named by 'keyname'
 Endif
-If number 'limit' is less than 'x'
+If I verify number 'limit' is less than 'x'
 When I move named by 'keyname' in 'ifdict'
 Endif
 When I remove 'keyname'
@@ -255,13 +255,13 @@ When I create the 'float array'
 When I rename 'float array' to 'floats'
 Foreach 'x' in 'numbers'
 Foreach 'y' in 'numbers2'
-If number 'x' is more than 'limit'
-If number 'y' is more than 'limit'
+If I verify number 'x' is more than 'limit'
+If I verify number 'y' is more than 'limit'
 When I move 'x' in 'floats'
 endif
 EndForeach
-If number 'zero' is less than 'limit'
-If number 'zero' is less than 'limit'
+If I verify number 'zero' is less than 'limit'
+If I verify number 'zero' is less than 'limit'
 Foreach 'a' in 'numbers'
 Foreach 'b' in 'numbers2'
 When I move 'b' in 'floats'

--- a/test/zencode/numbers.bats
+++ b/test/zencode/numbers.bats
@@ -81,7 +81,7 @@ rule check version 1.0.0
 Given nothing
 When I write number '10' in 'left'
 and I write number '20' in 'right'
-and number 'left' is less or equal than 'right'
+and I verify number 'left' is less or equal than 'right'
 Then print the string 'OK'
 Then print data
 EOF
@@ -108,7 +108,7 @@ EOF
 # Given nothing
 # When I write number '10' in 'left'
 # and I write number '20' in 'right'
-# and number 'right' is less than 'left'
+# and I verify number 'right' is less than 'left'
 # Then print the string 'OK'
 # EOF
 
@@ -119,7 +119,7 @@ EOF
 # Given nothing
 # When I set 'left' to '0a' base '16'
 # and I set 'right' to '14' base '16'
-# and number 'left' is less or equal than 'right'
+# and I verify number 'left' is less or equal than 'right'
 # Then print the string 'OK'
 # Then print data
 # EOF
@@ -129,7 +129,7 @@ EOF
 # Given nothing
 # When I set 'left' to '0a' base '16'
 # and I set 'right' to '14' base '16'
-# and number 'left' is less than 'right'
+# and I verify number 'left' is less than 'right'
 # Then print the string 'OK'
 # Then print data
 # EOF
@@ -198,7 +198,7 @@ rule check version 1.0.0
 Given nothing
 When I write number '161917811' in 'left'
 and I write number '161917812' in 'right'
-and number 'left' is less or equal than 'right'
+and I verify number 'left' is less or equal than 'right'
 Then print the string 'OK'
 Then print data
 EOF

--- a/test/zencode/random.bats
+++ b/test/zencode/random.bats
@@ -44,7 +44,7 @@ Given nothing
 When I create the array of '32' random objects of '256' bits
 and I pick the random object in 'array'
 and I remove the 'random object' from 'array'
-and the 'random object' is not found in 'array'
+and I verify the 'random object' is not found in 'array'
 Then print the 'random object'
 EOF
     save_output "random_from_array.out"
@@ -74,7 +74,7 @@ When I pick the random object in 'bonnetjes'
 and I rename the 'random object' to 'lucky one'
 and I remove the 'lucky one' from 'bonnetjes'
 # redundant check
-and the 'lucky one' is not found in 'bonnetjes'
+and I verify the 'lucky one' is not found in 'bonnetjes'
 Then print the 'lucky one'
 EOF
     save_output 'array_rename_remove.out'

--- a/test/zencode/zkp.bats
+++ b/test/zencode/zkp.bats
@@ -189,8 +189,8 @@ Scenario petition: aggregate signature
     Given that I have a 'petition signature'
     Given I have a 'petition'
     Given I have a 'issuer public key'
-    When the petition signature is not a duplicate
-    When the petition signature is just one more
+    When I verify the petition signature is not a duplicate
+    When I verify the petition signature is just one more
     When I add the signature to the petition
     and I aggregate all the issuer public keys
     Then print the 'petition'

--- a/test/zencode/zkp_multi_petitions.bats
+++ b/test/zencode/zkp_multi_petitions.bats
@@ -161,8 +161,8 @@ Scenario petition: aggregate signature
     Given that I have a 'petition signature'
     Given I have a 'petition'
     Given I have a 'issuer public key'
-    When the petition signature is not a duplicate
-    When the petition signature is just one more
+    When I verify the petition signature is not a duplicate
+    When I verify the petition signature is just one more
     When I add the signature to the petition
     and I aggregate all the issuer public keys
     Then print the 'petition'


### PR DESCRIPTION
Fix #593