### PR TITLE
build: fix meson build for python source distribution

### DIFF
--- a/bindings/python3/prepare.sh
+++ b/bindings/python3/prepare.sh
@@ -8,12 +8,14 @@ cp -r ../../src src/src
 cp -r ../../test src/test
 
 py_version=`git describe --tags --abbrev=0 | sed 's/^v//'`
+py_version_hash=${py_version}
+py_version_time=${py_version}
+hash="$(git rev-parse --short HEAD)"
 branch=`git rev-parse --abbrev-ref HEAD`
-hash=""
-time=""
 if [ "$branch" != "master" ]; then
-    hash="+$(git rev-parse --short HEAD)"
-    time=".dev$(git show -s --format=%ct HEAD)"
+    py_version_hash="${py_version_hash}+${hash}"
+    py_version_time="${py_version_time}.dev$(git show -s --format=%ct HEAD)"
 fi
-echo "${py_version}${hash}" > src/git_utils
-echo "${py_version}${time}" >> src/git_utils
+echo "${py_version_hash}" > src/git_utils
+echo "${py_version_time}" >> src/git_utils
+echo "${hash}" >> src/git_utils

--- a/build/meson.build
+++ b/build/meson.build
@@ -1,7 +1,7 @@
 project(
     'zenroom',
     'c',
-    version: run_command(['git', 'describe', '--tags'], capture : true, check : true).stdout().strip().split('-')[0],
+    version: run_command('meson_version.sh', capture:true, check: true).stdout().strip(),
     license: 'GPL3',
      meson_version: '>=0.49.2',
     default_options: [
@@ -10,13 +10,17 @@ project(
     ],
 )
 
+if run_command(['git','describe'], check:false).returncode() == 0
+    commit_hash = run_command(['git', 'rev-parse', '--short', 'HEAD'], capture: true, check : true).stdout().strip()
+else
+    commit_hash = run_command(['awk', 'NR==3', '../git_utils'], capture: true, check : true).stdout().strip()
+endif
 current_year = run_command(['date','+%Y'],capture:true, check:true).stdout().strip()
-commit_hash = run_command(['git', 'rev-parse', '--short', 'HEAD'], capture: true, check : true).stdout().strip()
 
 add_project_arguments(
     '-DVERSION="' + meson.project_version() +'"',
-	'-DCURRENT_YEAR="' + current_year +'"',
-	'-DCOMMIT="' + commit_hash +'"',
+    '-DCURRENT_YEAR="' + current_year +'"',
+    '-DCOMMIT="' + commit_hash +'"',
     '-D_POSIX_C_SOURCE=200112L',
     '-D_DARWIN_C_SOURCE',
     language: 'c'

--- a/build/meson_version.sh
+++ b/build/meson_version.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if $(git describe >/dev/null 2>/dev/null); then
+    echo $(git describe --tags) | cut -d- -f1
+    exit 0
+else
+    echo $(head -1 ../git_utils) | cut -d+ -f1
+    exit 0
+fi


### PR DESCRIPTION
In python source distribution the `.git` folder is not present to reduce the package size. A file, named `git_utils`, contains the tag, commit hash and time of the last commit. The `make meson` command now if  `.git` is not found search the needed information inside  `git_utils`.