### PR TITLE
fix(w3c-did): 🐛 double the maximum size of DID documents

### DIFF
--- a/src/lua/zencode_w3c.lua
+++ b/src/lua/zencode_w3c.lua
@@ -26,7 +26,7 @@ local function import_did_document(doc)
     -- id and @context must be always present in DID-documents
     ZEN.assert(doc.id and #doc.id < 256, 'Invalid DID document: id not found')
     ZEN.assert(doc['@context'], 'Invalid DID document: @context not found')
-    ZEN.assert(#JSON.encode(doc, 'string') < 4096, 'DID document too large')
+    ZEN.assert(#JSON.encode(doc, 'string') < 8192, 'DID document too large')
     local did_components = strtok(doc.id, ':')
     -- schme: did
     ZEN.assert(did_components[1] == 'did',


### PR DESCRIPTION
Now the maximum size for DID documents is set to 8192