### PR TITLE
fix(zencode): 🐛 deprecate rule caller restroom-mw in favour of rule unknown ignore

### DIFF
--- a/src/lua/zencode.lua
+++ b/src/lua/zencode.lua
@@ -269,13 +269,9 @@ function ZEN:begin(new_heap)
 			 CONF.parser.strict_match = false
 			 return true
 		  end,
-		  ['collision ignore'] = function ()
-			 CONF.heap.check_collision = false
-			 return true
-		  end,
 		  ['caller restroom-mw'] = function()
+			 warn("DEPRECATED:\nRule caller restroom-mw\nuse instead\nRule unknown ignore")
 			 CONF.parser.strict_match = false
-			 CONF.heap.check_collision = false
 			 return true
 		  end,
 		  ['set'] = function (conf, value)

--- a/test/zencode/rules.bats
+++ b/test/zencode/rules.bats
@@ -170,21 +170,6 @@ EOF
     assert_output '{"result":"test_passed"}'
 }
 
-# --- caller restroom-mw --- #
-@test "caller restroom-mw" {
-    cat <<EOF | zexe caller_restroom-mw.zen
-Rule caller restroom-mw
-
-Given nothing
-When I test the rule with a statement that does not exist
-and I also have a collision in data and keys
-When I write string 'test passed' in 'result'
-Then print the 'result'
-EOF
-    save_output caller_restroom-mw_output.json
-    assert_output '{"result":"test_passed"}'
-}
-
 # --- set --- #
 @test "set" {
     cat << EOF | zexe set_hash.zen


### PR DESCRIPTION
Also remove rule collision ignore since it is not valid anymore