### PR TITLE
fix(then): 🐛 use deepcopy to copy tables from ACK to OUT

### DIFF
--- a/src/lua/zencode_then.lua
+++ b/src/lua/zencode_then.lua
@@ -90,10 +90,10 @@ local function then_insert(dest, val, key)
 	    OUT[dest] = { ACK[dest] }
 	    table.insert(OUT[dest], val)
 	 elseif isarray(ACK[dest]) then
-	    OUT[dest] = ACK[dest]
+        OUT[dest] = deepcopy(ACK[dest])
 	    table.insert(OUT[dest], val)
 	 else -- isdictionary
-	    OUT[dest] = ACK[dest]
+         OUT[dest] = deepcopy(ACK[dest])
 	    OUT[dest][key] = val
 	 end
       else -- use only val and key

--- a/test/zencode/then.bats
+++ b/test/zencode/then.bats
@@ -115,3 +115,22 @@ EOF
     save_output 'print_my_name.out'
     assert_output '{"identity":"Alice"}'
 }
+
+@test "Print '' as '' in ''" {
+    cat <<EOF | save_asset print_as_in.data
+{
+    "string": "hello"
+}
+EOF
+    cat <<EOF | zexe print_as_in.zen print_as_in.data
+Given I have a 'string'
+
+When I create the 'hex dictionary' named 'hex_data'
+
+Then print the 'string' as 'hex' in 'hex_data'
+# one more statement for trigger heapguard check
+and print the 'string'
+EOF
+    save_output 'print_as_in.out'
+    assert_output '{"hex_data":["68656c6c6f"],"string":"hello"}'
+}


### PR DESCRIPTION
fix #758 