### PR TITLE
fix: 🐛 found statements work also with floats 

### DIFF
--- a/src/lua/zencode_table.lua
+++ b/src/lua/zencode_table.lua
@@ -157,7 +157,7 @@ local function _is_found_in(ele_name, obj_name)
         end
     elseif obj_codec.zentype == 'd' then
         local el = O.to_string(ele)
-        return obj[el] and (luatype(obj[el]) == 'table' or #obj[el] ~= 0)
+        return obj[el] and (luatype(obj[el]) == 'table' or tonumber(obj[el]) or #obj[el] ~= 0)
     else
         zencode_assert(false, "Invalid container type: "..obj.." is "..obj_codec)
     end

--- a/src/lua/zencode_when.lua
+++ b/src/lua/zencode_when.lua
@@ -27,7 +27,7 @@ When("done", function() end)
 
 
 local function _is_found(el)
-    return ACK[el] and (luatype(ACK[el]) == 'table' or #ACK[el] ~= 0)
+    return ACK[el] and (luatype(ACK[el]) == 'table' or tonumber(ACK[el]) or #ACK[el] ~= 0)
 end
 
 IfWhen("verify '' is found", function(el)

--- a/test/zencode/dictionary.bats
+++ b/test/zencode/dictionary.bats
@@ -331,6 +331,7 @@ EOF
 {
 	"TransactionsBatchA": {
 		"MetaData": "This var is Not a Table",
+		"number": 1234,
 		"Information": {
 			"Metadata": "TransactionsBatchB6789",
 			"Buyer": "John Doe"
@@ -357,6 +358,7 @@ EOF
 		}
 	},
 	"dictionaryToBeFound": "Information",
+	"numberToBeFound": "number",
 	"salesStartTimestamp": 1597573200,
 	"PricePerKG": 3
 }
@@ -366,11 +368,13 @@ EOF
 Rule check version 2.0.0
 
 Given that I have a 'string' named 'dictionaryToBeFound'
+Given that I have a 'string' named 'numberToBeFound'
 Given that I have a 'string dictionary' named 'TransactionsBatchA'
 Given that I have a 'number' named 'salesStartTimestamp'
 
-# Here we search if a certain dictionary exists in the list
+# Here we search if a certain dictionary and a number exists in the list
 When I verify the 'dictionaryToBeFound' is found in 'TransactionsBatchA'
+and I verify the 'numberToBeFound' is found in 'TransactionsBatchA'
 
 # Here we find the highest value of an element, in all dictionaries
 When I find the max value 'PricePerKG' for dictionaries in 'TransactionsBatchA'
@@ -442,7 +446,7 @@ When I copy contents of 'blockchains' in 'TransactionsBatchA'
 Then print 'TransactionsBatchA'
 EOF
     save_output 'copy_contents_in.json'
-    assert_output '{"TransactionsBatchA":{"ABC-Transactions1Data":{"PricePerKG":100,"ProductPurchasePrice":50,"TransactionValue":1500,"TransferredProductAmount":15,"UndeliveredProductAmount":7,"timestamp":1.597573e+09},"ABC-Transactions2Data":{"PricePerKG":80,"TransactionValue":1600,"TransferredProductAmount":20,"timestamp":1.597573e+09},"ABC-Transactions3Data":{"PricePerKG":70,"TransactionValue":700,"TransferredProductAmount":10,"timestamp":1.597573e+09},"Information":{"Buyer":"John Doe","Metadata":"TransactionsBatchB6789"},"MetaData":"This var is Not a Table","b1":{"endpoint":"http://pesce.com/","last-transaction":"123"},"b2":{"endpoint":"http://fresco.com/","last-transaction":"234"}}}'
+    assert_output '{"TransactionsBatchA":{"ABC-Transactions1Data":{"PricePerKG":100,"ProductPurchasePrice":50,"TransactionValue":1500,"TransferredProductAmount":15,"UndeliveredProductAmount":7,"timestamp":1.597573e+09},"ABC-Transactions2Data":{"PricePerKG":80,"TransactionValue":1600,"TransferredProductAmount":20,"timestamp":1.597573e+09},"ABC-Transactions3Data":{"PricePerKG":70,"TransactionValue":700,"TransferredProductAmount":10,"timestamp":1.597573e+09},"Information":{"Buyer":"John Doe","Metadata":"TransactionsBatchB6789"},"MetaData":"This var is Not a Table","b1":{"endpoint":"http://pesce.com/","last-transaction":"123"},"b2":{"endpoint":"http://fresco.com/","last-transaction":"234"},"number":1234}}'
 
 }
 

--- a/test/zencode/when.bats
+++ b/test/zencode/when.bats
@@ -311,3 +311,40 @@ EOF
     save_output 'cast_float.out'
     assert_output '{"b64":"ITQjFPGiNLU0LC0yQeI=","fb64":6.734502e+32,"finteger":1.234568e+26,"integer":"123456789123456789123456789"}'
 }
+
+
+@test "verify is found" {
+    cat <<EOF | save_asset found.json
+{
+    "str": "hello",
+    "integer": "123456789123456789123456789",
+    "float": 1234,
+    "dict": {
+            "str_1": "hello",
+            "str_2": "world"
+    },
+    "array": [
+             "hello",
+             "world"
+    ]
+}
+EOF
+
+    cat <<EOF | zexe found.zen found.json
+Given I  have a 'string' named 'str'
+and I have a 'integer'
+and I have a 'float'
+and I have a 'string dictionary' named 'dict'
+and I have a 'string array' named 'array'
+
+When I verify 'str' is found
+and I verify 'integer' is found
+and I verify 'float' is found
+and I verify 'dict' is found
+and I verify 'array' is found
+
+Then print the string 'found everything'
+EOF
+    save_output 'found.out'
+    assert_output '{"output":["found_everything"]}'
+}


### PR DESCRIPTION
fix #754 