### PR TITLE
inline statements in credentials

### DIFF
--- a/src/lua/zencode_bbs.lua
+++ b/src/lua/zencode_bbs.lua
@@ -132,13 +132,13 @@ ZEN:add_schema(
 --]]
 
 -- generate the private key
-When('create bbs key',function()
+When("create bbs key",function()
     initkeyring'bbs'
     ACK.keyring.bbs = BBS.keygen()
 end)
 
 -- generate the public key
-When('create bbs public key',function()
+When("create bbs public key",function()
     empty'bbs public key'
     local sk = havekey'bbs'
     ACK.bbs_public_key = BBS.sk2pk(sk)

--- a/src/lua/zencode_bitcoin.lua
+++ b/src/lua/zencode_bitcoin.lua
@@ -147,8 +147,8 @@ local function _keygen(name)
 	local kp = ECDH.keygen()
 	ACK.keyring[name] = kp.private
 end
-When('create bitcoin key', function() _keygen('bitcoin') end)
-When('create testnet key', function() _keygen('testnet') end)
+When("create bitcoin key", function() _keygen('bitcoin') end)
+When("create testnet key", function() _keygen('testnet') end)
 
 local function _import_wif(sec, name)
 		local sk = have(sec)
@@ -212,8 +212,8 @@ local function _create_tx(name, recipient)
 	ACK[name..'_transaction'] = tx
 	new_codec(name..'_transaction') -- TODO: { schema = 'transaction' })
 end
-When('create bitcoin transaction', function() _create_tx('bitcoin') end)
-When('create testnet transaction', function() _create_tx('testnet') end)
+When("create bitcoin transaction", function() _create_tx('bitcoin') end)
+When("create testnet transaction", function() _create_tx('testnet') end)
 When("create bitcoin transaction to ''", function(recipient) _create_tx('bitcoin', recipient) end)
 When("create testnet transaction to ''", function(recipient) _create_tx('testnet', recipient) end)
 

--- a/src/lua/zencode_credential.lua
+++ b/src/lua/zencode_credential.lua
@@ -34,7 +34,7 @@ local function import_issuer_pk_f(obj)
 end
 
 -- credential keypair operations
-When('create credential key',function()
+When("create credential key",function()
 	initkeyring'credential'
 	ACK.keyring.credential = INT.random()
 end)
@@ -50,13 +50,13 @@ When("create credential key with secret ''",function(sec)
 	ACK.keyring.credential = INT.new(secret)
 end)
 
-When('create issuer key',function()
+When("create issuer key",function()
 		initkeyring'issuer'
 		ACK.keyring.issuer = CRED.issuer_keygen()
 	end
 )
 
-When('create issuer public key',function()
+When("create issuer public key",function()
 	havekey'issuer'
 	ACK.issuer_public_key = {
 	   alpha = G2 * ACK.keyring.issuer.x,
@@ -100,7 +100,7 @@ ZEN:add_schema(
    }
 )
 
-When('create credential request', function()
+When("create credential request", function()
 	havekey'credential'
 	ACK.credential_request = CRED.prepare_blind_sign(ACK.keyring.credential)
 	new_codec('credential request')
@@ -130,7 +130,7 @@ ZEN:add_schema(
 	  }
    }
 )
-When('create credential signature',function()
+When("create credential signature",function()
 		have 'credential request'
       havekey'issuer'
       ACK.credential_signature =
@@ -143,7 +143,7 @@ When('create credential signature',function()
       new_codec'verifier'
    end
 )
-When('create credentials',function()
+When("create credentials",function()
       have 'credential signature'
       havekey'credential'
       -- prepare output with an aggregated sigma credential
@@ -200,7 +200,7 @@ ZEN:add_schema(
    }
 )
 
-When('aggregate issuer public keys',function()
+When("aggregate issuer public keys",function()
 		have 'issuer public key'
 		if not ACK.verifiers then
 			ACK.verifiers = {}
@@ -239,7 +239,7 @@ When("create credential proof",function()
 		new_codec('credential proof')
 	end
 )
-IfWhen('verify credential proof',function()
+IfWhen("verify credential proof",function()
 		have 'credential proof'
 		have 'verifiers'
 		zencode_assert(

--- a/src/lua/zencode_credential.lua
+++ b/src/lua/zencode_credential.lua
@@ -50,9 +50,7 @@ When("create credential key with secret ''",function(sec)
 	ACK.keyring.credential = INT.new(secret)
 end)
 
-When(
-	'create issuer key',
-	function()
+When('create issuer key',function()
 		initkeyring'issuer'
 		ACK.keyring.issuer = CRED.issuer_keygen()
 	end
@@ -132,10 +130,8 @@ ZEN:add_schema(
 	  }
    }
 )
-When(
-   'create credential signature',
-   function()
-      have 'credential request'
+When('create credential signature',function()
+		have 'credential request'
       havekey'issuer'
       ACK.credential_signature =
 	 CRED.blind_sign(ACK.keyring.issuer, ACK.credential_request)
@@ -147,9 +143,7 @@ When(
       new_codec'verifier'
    end
 )
-When(
-   'create credentials',
-   function()
+When('create credentials',function()
       have 'credential signature'
       havekey'credential'
       -- prepare output with an aggregated sigma credential
@@ -160,9 +154,7 @@ When(
    end
 )
 
-When(
-   "aggregate credentials in ''",
-   function(creds)
+When("aggregate credentials in ''",function(creds)
       local cred_t = have(creds)
       havekey'credential'
       -- prepare output with an aggregated sigma credential
@@ -208,9 +200,7 @@ ZEN:add_schema(
    }
 )
 
-When(
-	'aggregate issuer public keys',
-	function()
+When('aggregate issuer public keys',function()
 		have 'issuer public key'
 		if not ACK.verifiers then
 			ACK.verifiers = {}
@@ -224,9 +214,7 @@ When(
 )
 
 
-When(
-	"aggregate verifiers in ''",
-	function(issuers)
+When("aggregate verifiers in ''",function(issuers)
 		local issuers_t = have(issuers)
 		empty''
 		local res = { alpha = nil, beta = nil}
@@ -241,9 +229,7 @@ When(
 	end
 )
 
-When(
-	'create credential proof',
-	function()
+When("create credential proof",function()
 		have 'verifiers'
 		have 'credentials'
 		empty 'credential proof'
@@ -253,9 +239,7 @@ When(
 		new_codec('credential proof')
 	end
 )
-IfWhen(
-	'verify credential proof',
-	function()
+IfWhen('verify credential proof',function()
 		have 'credential proof'
 		have 'verifiers'
 		zencode_assert(

--- a/src/lua/zencode_ecdh.lua
+++ b/src/lua/zencode_ecdh.lua
@@ -65,16 +65,11 @@ ZEN:add_schema(
 	}
 )
 
-When(
-	"create ecdh key",
-	function()
+When("create ecdh key",function()
 		initkeyring'ecdh'
 		ACK.keyring.ecdh = ECDH.keygen().private
-	end
-)
-When(
-	"create ecdh public key",
-	function()
+end)
+When("create ecdh public key",function()
 		empty'ecdh public key'
 		local sk = havekey'ecdh'
 		ACK.ecdh_public_key = ECDH.pubgen(sk)
@@ -95,9 +90,7 @@ When("create ecdh key with secret ''",function(sec)
 end)
 
 -- encrypt with a header and secret
-When(
-	"encrypt secret message '' with ''",
-	function(msg, sec)
+When("encrypt secret message '' with ''",function(msg, sec)
 		local text = have(msg)
 		local sk = have(sec)
 		empty'secret message'
@@ -115,13 +108,10 @@ When(
 			ACK.secret_message.header
 		)
 		new_codec('secret message')
-	end
-)
+end)
 
 -- decrypt with a secret
-When(
-	"decrypt text of '' with ''",
-	function(msg, sec)
+When("decrypt text of '' with ''",function(msg, sec)
 		local sk = have(sec)
 		local text = have(msg)
 		empty'text'
@@ -140,8 +130,7 @@ When(
 			   'Decryption error: authentication failure, checksum mismatch')
 		new_codec'text'
 		new_codec'checksum'
-	end
-)
+end)
 
 -- check various locations to find the public key
 local function _pubkey_compat(_key)
@@ -160,9 +149,7 @@ local function _pubkey_compat(_key)
 end
 
 -- encrypt to a single public key
-When(
-	"encrypt secret message of '' for ''",
-	function(msg, _key)
+When("encrypt secret message of '' for ''",function(msg, _key)
 		local sk = havekey'ecdh'
 		have(msg)
 		local pk = _pubkey_compat(_key)
@@ -180,12 +167,9 @@ When(
 			ACK.secret_message.header
 		)
 		new_codec('secret message')
-	end
-)
+end)
 
-When(
-	"decrypt text of '' from ''",
-	function(secret, _key)
+When("decrypt text of '' from ''",function(secret, _key)
 		local sk = havekey'ecdh'
 		have(secret)
 		local pk = _pubkey_compat(_key)
@@ -199,8 +183,7 @@ When(
 		)
 		new_codec'text'
 		new_codec'checksum'
-	end
-)
+end)
 
 -- sign a message and verify
 local function _signing(msg, var)
@@ -221,13 +204,11 @@ local function _verifying(msg, sig, by)
    )
 end
 
-When(
-   "create signature of ''", function(msg)
+When("create signature of ''",function(msg)
    _signing(msg, 'signature')
 end)
 
-When(
-   "create ecdh signature of ''", function(msg)
+When("create ecdh signature of ''",function(msg)
    _signing(msg, 'ecdh_signature')
 end)
 
@@ -248,26 +229,14 @@ end)
 -- The deterministic ecdsa/ecdh above uses the default SHA512 to sign and verify.
 -- If one wnats to use another hash, the ECDH.verify_deterministic should be
 -- called with the correct integer input.
-IfWhen(
-    "verify '' has a ecdh deterministic signature in '' by ''",
-    _verifying
-)
+IfWhen("verify '' has a ecdh deterministic signature in '' by ''",_verifying)
 
 When("create ecdsa deterministic signature of ''",function(msg)
     _signing_det(msg, "ecdsa_deterministic_signature")
 end)
 
-IfWhen(
-    "verify '' has a ecdsa deterministic signature in '' by ''",
-    _verifying
-)
+IfWhen("verify '' has a ecdsa deterministic signature in '' by ''",_verifying)
 
-IfWhen(
-   "verify '' has a signature in '' by ''",
-   _verifying
-)
+IfWhen("verify '' has a signature in '' by ''",_verifying)
 
-IfWhen(
-   "verify '' has a ecdh signature in '' by ''",
-   _verifying
-)
+IfWhen("verify '' has a ecdh signature in '' by ''",_verifying)

--- a/src/lua/zencode_eddsa.lua
+++ b/src/lua/zencode_eddsa.lua
@@ -32,13 +32,13 @@ ZEN:add_schema(
 )
 
 -- generate the private key
-When('create eddsa key',function()
+When("create eddsa key",function()
 	initkeyring'eddsa'
 	ACK.keyring.eddsa = ED.secgen()
 end)
 
 -- generate the public key
-When('create eddsa public key',function()
+When("create eddsa public key",function()
 	empty'eddsa public key'
 	local sk = havekey'eddsa'
 	ACK.eddsa_public_key = ED.pubgen(sk)

--- a/src/lua/zencode_ethereum.lua
+++ b/src/lua/zencode_ethereum.lua
@@ -201,12 +201,12 @@ ZEN:add_schema(
         },
 })
 
-When('create ethereum key', function()
+When("create ethereum key", function()
 	initkeyring'ethereum'
 	ACK.keyring.ethereum = ECDH.keygen().private
 end)
 
-When('create ethereum address', function()
+When("create ethereum address", function()
 	empty'ethereum address'
 	local pk = ACK.ethereum_public_key
 	if not pk then

--- a/src/lua/zencode_given.lua
+++ b/src/lua/zencode_given.lua
@@ -260,46 +260,34 @@ local function ack(what)
 
 end
 
-Given(
-   'nothing',
-   function()
+Given('nothing',function()
       zencode_assert(
          (next(IN) == nil),
          'Undesired data passed as input'
       )
-   end
-)
+end)
 
 -- maybe TODO: Given all valid data
 -- convert and import data only when is known by schema and passes validation
 -- ignore all other data structures that are not known by schema or don't pass validation
 
-Given(
-   "am ''",
-   function(name)
+Given("am ''",function(name)
       Iam(name)
-   end
-)
+end)
 
-Given(
-   "my name is in '' named ''",
-   function(sc, name)
+Given("my name is in '' named ''",function(sc, name)
       pick(name, sc)
       assert(ZEN.TMP.name, 'No name found in: ' .. name)
       Iam(O.to_string(operate_conversion(ZEN.TMP)))
       CODEC[name] = nil -- just used to get name
-   end
-)
+end)
 
-Given(
-   "my name is in '' named '' in ''",
-   function(sc, name, struct)
+Given("my name is in '' named '' in ''",function(sc, name, struct)
       pickin(struct, name, sc)
       assert(ZEN.TMP.name,  'No name found in: '..name)
       Iam(O.to_string(operate_conversion(ZEN.TMP)))
       CODEC[name] = nil -- just name string
-   end
-)
+end)
 
 -- variable names:
 -- s = schema of variable (or encoding)
@@ -307,139 +295,98 @@ Given(
 -- t = table containing the variable
 
 -- TODO: I have a '' as ''
-Given(
-   "''",
-   function(n)
+Given("''",function(n)
       pick(n)
       ack(n)
       gc()
-   end
-)
+end)
 
-Given(
-   "'' in ''",
-   function(s, t)
+Given("'' in ''",function(s, t)
       pickin(t, s)
       ack(s) -- save it in ACK.obj
       gc()
-   end
-)
+end)
 
 -- public keys for keyring arrays
 -- returns a special array for upcoming session:
 -- public_key_session : { name : value }
-Given(
-   "'' public key from ''",
-   function(s, t)
+Given("'' public key from ''",function(s, t)
       -- if not pickin(t, s, nil, false) then
       -- 	pickin(s, t)
       -- end
       pickin(t, s..'_public_key', s..'_public_key', false)
       ack_table('public_key_session', t)
-   end
-)
+end)
 
-Given(
-   "'' from ''",
-   function(s, t)
+Given("'' from ''",function(s, t)
       -- if not pickin(t, s, nil, false) then
       -- 	pickin(s, t)
       -- end
       pickin(t, s, s, false)
       ack_table(s, t)
       gc()
-   end
-)
+end)
 
-Given(
-   "'' named ''",
-   function(s, n)
+Given("'' named ''",function(s, n)
       -- zencode_assert(encoder, "Invalid input encoding for '"..n.."': "..s)
       pick(n, s)
       ack(n)
       gc()
-   end
-)
+end)
 
-Given(
-   "'' named by ''",
-   function(s, n)
+Given("'' named by ''",function(s, n)
       -- local name = have(n)
       local name = _index_to_string(IN[n])
       -- zencode_assert(encoder, "Invalid input encoding for '"..n.."': "..s)
       pick(name, s)
       ack(name)
       gc()
-   end
-)
+end)
 
-Given(
-   "'' named '' in ''",
-   function(s, n, t)
+Given("'' named '' in ''",function(s, n, t)
       pickin(t, n, s)
       ack(n) -- save it in ACK.name
       gc()
-   end
-)
+end)
 
-Given(
-   "'' named by '' in ''",
-   function(s, n, t)
+Given("'' named by '' in ''",function(s, n, t)
       local name = _index_to_string(IN[n])
       pickin(t, name, s)
       ack(name) -- save it in ACK.name
       gc()
-   end
-)
+end)
 
-Given(
-   "my ''",
-   function(n)
+Given("my ''",function(n)
       zencode_assert(WHO, 'No identity specified, use: Given I am ...')
       pickin(WHO, n)
       ack(n)
       gc()
-   end
-)
+end)
 
-Given(
-   "my '' named ''",
-   function(s, n)
+Given("my '' named ''",function(s, n)
       -- zencode_assert(encoder, "Invalid input encoding for '"..n.."': "..s)
       pickin(WHO, n, s)
       ack(n)
       gc()
-   end
-)
-Given(
-   "my '' named by ''",
-   function(s, n)
+end)
+Given("my '' named by ''",function(s, n)
       -- zencode_assert(encoder, "Invalid input encoding for '"..n.."': "..s)
       local name = _index_to_string(IN[n])
       pickin(WHO, name, s)
       ack(name)
       gc()
-   end
-)
+end)
 
-Given(
-   "'' is valid",
-   function(n)
+Given("'' is valid",function(n)
       pick(n)
       gc()
-   end
-)
-Given(
-   "my '' is valid",
-   function(n)
+end)
+Given("my '' is valid",function(n)
       pickin(WHO, n)
       gc()
-   end
-)
+end)
 
-Given(
-   "rename '' to ''",
-   function(old, new)
+Given("rename '' to ''",function(old, new)
        empty(new)
        have(old)
        ACK[new] = ACK[old]
@@ -448,8 +395,7 @@ Given(
 
        ACK[old] = nil
        CODEC[old] = nil
-   end
-)
+end)
 
 Given("'' part of '' after string prefix ''", function(enc, src, pfx)
 		 local whole = IN[src]

--- a/src/lua/zencode_given.lua
+++ b/src/lua/zencode_given.lua
@@ -260,7 +260,7 @@ local function ack(what)
 
 end
 
-Given('nothing',function()
+Given("nothing",function()
       zencode_assert(
          (next(IN) == nil),
          'Undesired data passed as input'

--- a/src/lua/zencode_hash.lua
+++ b/src/lua/zencode_hash.lua
@@ -22,9 +22,7 @@
 
 
 -- hashing single strings
-When(
-    "create hash of ''",
-    function(s)
+When("create hash of ''",function(s)
         local src = have(s)
         if luatype(src) == 'table' then
             src = zencode_serialize(src) -- serialize tables using zenroom's algo
@@ -34,9 +32,7 @@ When(
     end
 )
 
-When(
-    "create hash of '' using ''",
-    function(s, h)
+When("create hash of '' using ''",function(s, h)
         local src = have(s)
         if luatype(src) == 'table' then
             src = zencode_serialize(src)
@@ -53,7 +49,7 @@ When(
     end
 )
 
-When("create hash to point '' of ''", function(curve, object)
+When("create hash to point '' of ''",function(curve, object)
     local F = _G[curve]
     zencode_assert(
             luatype(F.hashtopoint) == 'function',
@@ -65,9 +61,7 @@ When("create hash to point '' of ''", function(curve, object)
     new_codec('hash_to_point', { zentype='e' })
 end)
 
-When(
-    "create hashes of each object in ''",
-    function(arr)
+When("create hashes of each object in ''",function(arr)
         local A = have(arr)
         local count = isarray(A)
         zencode_assert(count > 0, 'Object is not an array: ' .. arr)
@@ -77,9 +71,7 @@ When(
 )
 
 -- HMAC from RFC2104.
-When(
-    "create HMAC of '' with key ''",
-    function(obj, key)
+When("create HMAC of '' with key ''",function(obj, key)
         local src = have(obj)
         if luatype(src) == 'table' then
             src = zencode_serialize(src)
@@ -94,9 +86,7 @@ When(
     end
 )
 
-When(
-    "create key derivation of ''",
-    function(obj)
+When("create key derivation of ''",function(obj)
         local src = have(obj)
         if luatype(src) == 'table' then
             src = zencode_serialize(src)
@@ -106,9 +96,7 @@ When(
     end
 )
 
-When(
-    "create key derivations of each object in ''",
-    function(tab)
+When("create key derivations of each object in ''",function(tab)
         local t = have(tab)
         zencode_assert(luatype(t) == 'table', 'Object is not a table: ' .. tab)
         ACK.key_derivations =
@@ -133,24 +121,18 @@ local function _pbkdf2_f(src, pass, n)
     new_codec('key derivation', { zentype = 'e' })
 end
 
-When(
-    "create key derivation of '' with password ''",
-    function(obj, salt)
+When("create key derivation of '' with password ''",function(obj, salt)
 	_pbkdf2_f(have(obj), have(salt), 5000)
     end
 )
 
-When(
-    "create key derivation of '' with '' rounds",
-    function(obj, iter)
+When("create key derivation of '' with '' rounds",function(obj, iter)
 	local n = tonumber(iter) or tonumber(tostring(have(iter)))
 	_pbkdf2_f(have(obj), nil, n)
     end
 )
 
-When(
-    "create key derivation of '' with '' rounds with password ''",
-    function(obj, iter, salt)
+When("create key derivation of '' with '' rounds with password ''",function(obj, iter, salt)
 	local n = tonumber(iter) or tonumber(tostring(have(iter)))
 	_pbkdf2_f(have(obj), have(salt), n)
     end

--- a/src/lua/zencode_petition.lua
+++ b/src/lua/zencode_petition.lua
@@ -140,7 +140,7 @@ When("create petition ''",function(uid)
 		-- OUT.petition_ecdh_sign = map(ACK.petition_ecdh_sign, hex)
 end)
 
-When('verify new petition to be empty',function()
+When("verify new petition to be empty",function()
 		zencode_assert(
 			ECP.isinf(ACK.petition.scores.pos.left),
 			'Invalid new petition: positive left score is not zero'
@@ -181,7 +181,7 @@ When("create petition signature ''",function(uid)
         new_codec('petition_signature')
 end)
 
-IfWhen('verify signature proof is correct',function()
+IfWhen("verify signature proof is correct",function()
 		zencode_assert(
 			CRED.verify_cred_uid(
 				ACK.issuer_public_key,
@@ -193,7 +193,7 @@ IfWhen('verify signature proof is correct',function()
 		)
 end)
 
-IfWhen('verify petition signature is not a duplicate', function()
+IfWhen("verify petition signature is not a duplicate", function()
     if luatype(ACK.petition.list) == 'table' then
         zencode_assert(
             (not array_contains(
@@ -208,7 +208,7 @@ IfWhen('verify petition signature is not a duplicate', function()
     table.insert(ACK.petition.list, ACK.petition_signature.uid_signature)
 end)
 
-IfWhen('verify petition signature is just one more', function()
+IfWhen("verify petition signature is just one more", function()
     -- verify that the signature is +1 (no other value supported)
     ACK.petition_signature.one =
         PET.prove_sign_petition(ACK.petition.owner, BIG.new(1))
@@ -222,7 +222,7 @@ IfWhen('verify petition signature is just one more', function()
 
 end)
 
-When('add signature to petition',function()
+When("add signature to petition",function()
 		-- add the signature to the petition count
 		local scores = ACK.petition.scores
 		local psign = ACK.petition_signature.one
@@ -234,7 +234,7 @@ When('add signature to petition',function()
 		ACK.petition.scores = scores
 end)
 
-When('create a petition tally',function()
+When("create a petition tally",function()
 		havekey'credential'
 		zencode_assert(ACK.petition, 'Petition not found')
 		ACK.petition_tally =
@@ -246,7 +246,7 @@ When('create a petition tally',function()
         new_codec('petition_tally')
 end)
 
-When('count petition results',function()
+When("count petition results",function()
 		zencode_assert(ACK.petition, 'Petition not found')
 		zencode_assert(ACK.petition_tally, 'Tally not found')
 		zencode_assert(

--- a/src/lua/zencode_petition.lua
+++ b/src/lua/zencode_petition.lua
@@ -114,9 +114,7 @@ ZEN:add_schema(
 	}
 )
 
-When(
-	"create petition ''",
-	function(uid)
+When("create petition ''",function(uid)
 		havekey'credential'
 		-- zencode_assert(ACK.keyring.credential,"Credential key not found")
 		ACK.petition = {
@@ -140,12 +138,9 @@ When(
 		-- ecdh:private(ACK.cred_kp.private)
 		-- ACK.petition_ecdh_sign = { ecdh:sign(MSG.pack(OUT.petition)) }
 		-- OUT.petition_ecdh_sign = map(ACK.petition_ecdh_sign, hex)
-	end
-)
+end)
 
-When(
-	'verify new petition to be empty',
-	function()
+When('verify new petition to be empty',function()
 		zencode_assert(
 			ECP.isinf(ACK.petition.scores.pos.left),
 			'Invalid new petition: positive left score is not zero'
@@ -162,12 +157,9 @@ When(
 			ECP.isinf(ACK.petition.scores.neg.right),
 			'Invalid new petition: negative right score is not zero'
 		)
-	end
-)
+end)
 
-When(
-	"create petition signature ''",
-	function(uid)
+When("create petition signature ''",function(uid)
 		have'credentials'
 		have'issuer public key'
 		havekey'credential'
@@ -187,12 +179,9 @@ When(
 			uid_petition = ack_uid
 		}
         new_codec('petition_signature')
-	end
-)
+end)
 
-IfWhen(
-	'verify signature proof is correct',
-	function()
+IfWhen('verify signature proof is correct',function()
 		zencode_assert(
 			CRED.verify_cred_uid(
 				ACK.issuer_public_key,
@@ -202,8 +191,7 @@ IfWhen(
 			),
 			'Petition signature is invalid'
 		)
-	end
-)
+end)
 
 IfWhen('verify petition signature is not a duplicate', function()
     if luatype(ACK.petition.list) == 'table' then
@@ -234,9 +222,7 @@ IfWhen('verify petition signature is just one more', function()
 
 end)
 
-When(
-	'add signature to petition',
-	function()
+When('add signature to petition',function()
 		-- add the signature to the petition count
 		local scores = ACK.petition.scores
 		local psign = ACK.petition_signature.one
@@ -246,12 +232,9 @@ When(
 		scores.neg.right = scores.neg.right + psign.scores.neg.right
 		-- TODO: ZEN:push({'petition' ,'scores'}
 		ACK.petition.scores = scores
-	end
-)
+end)
 
-When(
-	'create a petition tally',
-	function()
+When('create a petition tally',function()
 		havekey'credential'
 		zencode_assert(ACK.petition, 'Petition not found')
 		ACK.petition_tally =
@@ -261,12 +244,9 @@ When(
 		)
 		ACK.petition_tally.uid = ACK.petition.uid
         new_codec('petition_tally')
-	end
-)
+end)
 
-When(
-	'count petition results',
-	function()
+When('count petition results',function()
 		zencode_assert(ACK.petition, 'Petition not found')
 		zencode_assert(ACK.petition_tally, 'Tally not found')
 		zencode_assert(
@@ -279,5 +259,4 @@ When(
 			ACK.petition_tally
 		).pos)
         new_codec('petition_results')
-	end
-)
+end)

--- a/src/lua/zencode_pvss.lua
+++ b/src/lua/zencode_pvss.lua
@@ -125,13 +125,13 @@ ZEN:add_schema(
 ---------------------------------------- PVSS initialization -------------------------------------
 
 -- Participant generates the private key
-When('create pvss key',function()
+When("create pvss key",function()
     initkeyring'pvss'
     ACK.keyring.pvss = PVSS.keygen()
 end)
 
 -- Participant generates the public key
-When('create pvss public key',function()
+When("create pvss public key",function()
     empty'pvss public key'
     local sk = havekey'pvss'
     ACK.pvss_public_key = PVSS.sk2pk(GENERATORS, sk)

--- a/src/lua/zencode_qp.lua
+++ b/src/lua/zencode_qp.lua
@@ -146,13 +146,13 @@ ZEN:add_schema(
 --# DILITHIUM #--
 
 -- generate the private key
-When('create dilithium key',function()
+When("create dilithium key",function()
 	initkeyring'dilithium'
 	ACK.keyring.dilithium = QP.sigkeygen().private
 end)
 
 -- generate the public key
-When('create dilithium public key',function()
+When("create dilithium public key",function()
 	empty'dilithium public key'
 	local sk = havekey'dilithium'
 	ACK.dilithium_public_key = QP.sigpubgen(sk)
@@ -188,13 +188,13 @@ end)
 --# KYBER #--
 
 -- generate the private key
-When('create kyber key',function()
+When("create kyber key",function()
 	initkeyring'kyber'
 	ACK.keyring.kyber = QP.kemkeygen().private
 end)
 
 -- generate public key
-When('create kyber public key',function()
+When("create kyber public key",function()
 	empty'kyber public key'
 	local sk = havekey'kyber'
 	ACK.kyber_public_key = QP.kempubgen(sk)
@@ -230,13 +230,13 @@ end)
 --# NTRUP #--
 
 -- generate the private key
-When('create ntrup key',function()
+When("create ntrup key",function()
 	initkeyring'ntrup'
 	ACK.keyring.ntrup = QP.ntrup_keygen().private
 end)
 
 -- generate the public key
-When('create ntrup public key',function()
+When("create ntrup public key",function()
 	empty'ntrup public key'
 	local sk = havekey'ntrup'
 	ACK.ntrup_public_key = QP.ntrup_pubgen(sk)

--- a/src/lua/zencode_reflow.lua
+++ b/src/lua/zencode_reflow.lua
@@ -103,7 +103,7 @@ local function _makeuid(src)
    return(uid)
 end
 
-When('create reflow key',function()
+When("create reflow key",function()
         -- keygen: δ = r.O ; γ = δ.G2
         initkeyring 'reflow'
         ACK.keyring.reflow = INT.random()
@@ -122,7 +122,7 @@ function(sec)
     ACK.keyring.reflow = INT.new(sk)
 end)
 
-When('create reflow public key',function()
+When("create reflow public key",function()
         empty 'reflow public key'
         havekey 'reflow'
         ACK.reflow_public_key = G2 * ACK.keyring.reflow
@@ -204,7 +204,7 @@ end
 When("create reflow seal with identity ''",_create_reflow_seal_f)
 When("create reflow seal",function() _create_reflow_seal_f('reflow identity') end)
 
-When('create reflow signature',function()
+When("create reflow signature",function()
 	empty 'reflow signature'
 	have 'reflow seal'
 	have 'issuer public key'
@@ -238,7 +238,7 @@ When('create reflow signature',function()
 	new_codec('reflow signature')
 end)
 
-When('prepare credentials for verification',function()
+When("prepare credentials for verification",function()
         have 'credential'
         local res = false
         for _, v in pairs(ACK.issuer_public_key) do
@@ -252,7 +252,7 @@ When('prepare credentials for verification',function()
         ACK.verifiers = res
 end)
 
-IfWhen('verify reflow signature credential',function()
+IfWhen("verify reflow signature credential",function()
         have 'reflow_signature'
         have 'verifiers'
         have 'reflow_seal'
@@ -279,7 +279,7 @@ IfWhen("verify reflow signature fingerprint is new", function()
     )
 end)
 
-When('add reflow fingerprint to reflow seal',function()
+When("add reflow fingerprint to reflow seal",function()
         have 'reflow_signature'
         have 'reflow_seal'
         if not ACK.reflow_seal.fingerprints then
@@ -294,14 +294,14 @@ When('add reflow fingerprint to reflow seal',function()
         end
 end)
 
-When('add reflow signature to reflow seal',function()
+When("add reflow signature to reflow seal",function()
         have 'reflow_seal'
         have 'reflow_signature'
         ACK.reflow_seal.SM =
             ACK.reflow_seal.SM + ACK.reflow_signature.signature
 end)
 
-IfWhen('verify reflow seal is valid',function()
+IfWhen("verify reflow seal is valid",function()
         have 'reflow_seal'
         zencode_assert(
             ECP2.miller(ACK.reflow_seal.verifier, ACK.reflow_seal.identity)

--- a/src/lua/zencode_reflow.lua
+++ b/src/lua/zencode_reflow.lua
@@ -103,18 +103,14 @@ local function _makeuid(src)
    return(uid)
 end
 
-When(
-    'create reflow key',
-    function()
+When('create reflow key',function()
         -- keygen: δ = r.O ; γ = δ.G2
         initkeyring 'reflow'
         ACK.keyring.reflow = INT.random()
         -- BLS secret signing key
-    end
-)
+end)
 
-When("create reflow key with secret key ''",
-function(sec)
+When("create reflow key with secret key ''",function(sec)
     local sk = have(sec)
     initkeyring'reflow'
     ACK.keyring.reflow = INT.new(sk)
@@ -126,19 +122,14 @@ function(sec)
     ACK.keyring.reflow = INT.new(sk)
 end)
 
-When(
-    'create reflow public key',
-    function()
+When('create reflow public key',function()
         empty 'reflow public key'
         havekey 'reflow'
         ACK.reflow_public_key = G2 * ACK.keyring.reflow
 	new_codec'reflow public key'
-    end
-)
+end)
 
-When(
-   "aggregate reflow public key from array ''",
-   function(arr)
+When("aggregate reflow public key from array ''",function(arr)
       empty 'reflow public key'
       local s = have(arr)
       zencode_assert(#s ~= 0, "Empty array: "..arr)
@@ -157,16 +148,15 @@ When(
 	 end
       end
       new_codec'reflow public key'
-   end
-)
+end)
 
-When("create reflow identity of ''", function(doc)
+When("create reflow identity of ''",function(doc)
 	empty 'reflow identity'
 	ACK.reflow_identity = _makeuid(have(doc))
 	new_codec'reflow identity'
 end)
 
-When("create reflow identity of objects in ''", function(doc)
+When("create reflow identity of objects in ''",function(doc)
 	empty 'reflow identity'
 	local arr = have(doc)
 	zencode_assert(luatype(arr)=='table', "Object is not an array or dictionary: "..doc)
@@ -192,8 +182,7 @@ When("create reflow identity of objects in ''", function(doc)
 	end
 	ACK.reflow_identity = res
 	new_codec'reflow identity'
-end
-)
+end)
 
 local function _create_reflow_seal_f(uid)
     empty 'reflow seal'
@@ -212,13 +201,10 @@ local function _create_reflow_seal_f(uid)
     new_codec'reflow seal'
 end
 
-When(
-    "create reflow seal with identity ''",
-    _create_reflow_seal_f)
-When("create reflow seal",
-    function() _create_reflow_seal_f('reflow identity') end)
+When("create reflow seal with identity ''",_create_reflow_seal_f)
+When("create reflow seal",function() _create_reflow_seal_f('reflow identity') end)
 
-When('create reflow signature', function()
+When('create reflow signature',function()
 	empty 'reflow signature'
 	have 'reflow seal'
 	have 'issuer public key'
@@ -252,9 +238,7 @@ When('create reflow signature', function()
 	new_codec('reflow signature')
 end)
 
-When(
-    'prepare credentials for verification',
-    function()
+When('prepare credentials for verification',function()
         have 'credential'
         local res = false
         for _, v in pairs(ACK.issuer_public_key) do
@@ -266,12 +250,9 @@ When(
             end
         end
         ACK.verifiers = res
-    end
-)
+end)
 
-IfWhen(
-    'verify reflow signature credential',
-    function()
+IfWhen('verify reflow signature credential',function()
         have 'reflow_signature'
         have 'verifiers'
         have 'reflow_seal'
@@ -284,8 +265,7 @@ IfWhen(
             ),
             'Signature has an invalid credential to sign'
         )
-    end
-)
+end)
 
 IfWhen("verify reflow signature fingerprint is new", function()
     have 'reflow_signature'
@@ -297,12 +277,9 @@ IfWhen("verify reflow signature fingerprint is new", function()
         not ACK.reflow_seal.fingerprints[ACK.reflow_signature.zeta],
         'Signature fingerprint is not new'
     )
-end
-)
+end)
 
-When(
-    'add reflow fingerprint to reflow seal',
-    function()
+When('add reflow fingerprint to reflow seal',function()
         have 'reflow_signature'
         have 'reflow_seal'
         if not ACK.reflow_seal.fingerprints then
@@ -315,22 +292,16 @@ When(
                 ACK.reflow_signature.zeta
             )
         end
-    end
-)
+end)
 
-When(
-    'add reflow signature to reflow seal',
-    function()
+When('add reflow signature to reflow seal',function()
         have 'reflow_seal'
         have 'reflow_signature'
         ACK.reflow_seal.SM =
             ACK.reflow_seal.SM + ACK.reflow_signature.signature
-    end
-)
+end)
 
-IfWhen(
-    'verify reflow seal is valid',
-    function()
+IfWhen('verify reflow seal is valid',function()
         have 'reflow_seal'
         zencode_assert(
             ECP2.miller(ACK.reflow_seal.verifier, ACK.reflow_seal.identity)
@@ -338,12 +309,9 @@ IfWhen(
             ECP2.miller(G2, ACK.reflow_seal.SM),
             "reflow seal doesn't validates"
         )
-    end
-)
+end)
 
-When(
-    "aggregate reflow seal array in ''",
-    function(arr)
+When("aggregate reflow seal array in ''",function(arr)
         have(arr)
         empty 'reflow seal'
         local dst = {}
@@ -366,8 +334,7 @@ When(
         end
         ACK.reflow_seal = dst
 	new_codec'reflow seal'
-    end
-)
+end)
 
 --------------------
 -- MATERIAL PASSPORT
@@ -391,9 +358,7 @@ local function _aggregate_array(arr)
    return(res)
 end
 
-When(
-   "create material passport of ''",
-   function(obj)
+When("create material passport of ''",function(obj)
 	  local key = havekey'reflow'
 	  local cred = have'credentials'
 	  local id = have'reflow identity'
@@ -424,9 +389,7 @@ When(
 	  new_codec'material passport'
 end)
 
-IfWhen(
-   "verify material passport of ''",
-   function(obj)
+IfWhen("verify material passport of ''",function(obj)
 	  local src = have(obj)
 	  local mp = have'material passport'
 	  local pub = have'issuer public key'
@@ -449,9 +412,7 @@ end)
 -- Complex check calculates UID of object and compares to seal, if
 -- correct then validates, else searches for .track array of seals and
 -- calculates aggregated UID, if correct then validates
-IfWhen(
-   "verify material passport of '' is valid",
-   function(obj)
+IfWhen("verify material passport of '' is valid",function(obj)
 	  have(obj)
 	  have(obj..'.seal')
       -- TODO

--- a/src/lua/zencode_schnorr.lua
+++ b/src/lua/zencode_schnorr.lua
@@ -67,13 +67,13 @@ ZEN:add_schema(
 
 
 -- generate the private key
-When('create schnorr key',function()
+When("create schnorr key",function()
 	initkeyring'schnorr'
 	ACK.keyring.schnorr = SCH.keygen()
 end)
 
 -- generate the public key
-When('create schnorr public key',function()
+When("create schnorr public key",function()
 	empty'schnorr public key'
 	local sk = havekey'schnorr'
 	ACK.schnorr_public_key = SCH.pubgen(sk)

--- a/src/lua/zencode_then.lua
+++ b/src/lua/zencode_then.lua
@@ -229,11 +229,11 @@ Then("print my '' from ''",function(k, f)
 	OUT[WHO][k] = then_outcast( val, k, codec.encoding )[k]
 end)
 
-Then('print keyring',function()
+Then("print keyring",function()
 	local val = have'keyring'
 	OUT.keyring = ZEN.schemas['keyring'].export(val)
 end)
-Then('print my keyring',function()
+Then("print my keyring",function()
 	Iam()
 	local val = have'keyring'
 	OUT[WHO] = { keyring = ZEN.schemas['keyring'].export(val) }
@@ -248,7 +248,7 @@ end)
 -- my data from
 -- my data from as
 
-Then('print data',function()
+Then("print data",function()
 	for k, v in pairs(ACK) do
 	   if k ~= 'keyring' then
 	      OUT[k] = then_outcast(v, k)
@@ -286,7 +286,7 @@ Then("print data from '' as ''", function(src, e)
 	end
 end)
 
-Then('print my data',function()
+Then("print my data",function()
 	Iam() -- sanity checks
 	OUT[WHO] = { }
 	for k, v in pairs(ACK) do

--- a/src/lua/zencode_verify.lua
+++ b/src/lua/zencode_verify.lua
@@ -52,34 +52,26 @@ local function _neq(left, right)
   end
 end
 
-IfWhen(
-  "verify '' is equal to ''",
-  function(l, r)
+IfWhen("verify '' is equal to ''",function(l, r)
     local left = have(l)
     local right = have(r)
     zencode_assert(
       _eq(left, right),
       'Verification fail: elements are not equal: ' .. l .. ' == ' .. r
     )
-  end
-)
+end)
 
-IfWhen(
-  "verify '' is not equal to ''",
-  function(l, r)
+IfWhen("verify '' is not equal to ''",function(l, r)
     local left = have(l)
     local right = have(r)
     zencode_assert(
       _neq(left, right),
       'Verification fail: elements are equal: ' .. l .. ' == ' .. r
     )
-  end
-)
+end)
 
 -- comparison inside dictionary
-IfWhen(
-  "verify '' is equal to '' in ''",
-  function(l, tr, tt)
+IfWhen("verify '' is equal to '' in ''",function(l, tr, tt)
     local left = have(l)
     local tab = have(tt)
     local right = tab[tr]
@@ -88,12 +80,9 @@ IfWhen(
       'Verification fail: elements are not equal: ' ..
         l .. ' == ' .. tt .. '.' .. tr
     )
-  end
-)
+end)
 
-IfWhen(
-  "verify '' is not equal to '' in ''",
-  function(l, tr, tt)
+IfWhen("verify '' is not equal to '' in ''",function(l, tr, tt)
     local left = have(l)
     local tab = have(tt)
     local right = tab[tr]
@@ -102,8 +91,7 @@ IfWhen(
       'Verification fail: elements are equal: ' ..
         l .. ' == ' .. tt .. '.' .. tr
     )
-  end
-)
+end)
 
 -- check a tuple of numbers before comparison, convert to BIG or number, and then compare
 local function numcheck(l, r, op)
@@ -284,19 +272,14 @@ local function validemail(str)
   return true
 end
 
-IfWhen(
-  "verify '' is a email",
-  function(name)
+IfWhen("verify '' is a email",function(name)
     local A = ACK[name]
     zencode_assert(A, 'Object not found: ' .. name)
     local res, err = validemail(O.to_string(A))
     zencode_assert(res, err)
-  end
-)
+end)
 
-IfWhen(
-  "verify '' contains a list of emails",
-  function(name)
+IfWhen("verify '' contains a list of emails",function(name)
     local A = ACK[name]
     zencode_assert(A, 'Object not found: ' .. name)
     zencode_assert(
@@ -308,8 +291,7 @@ IfWhen(
       res, err = validemail(O.to_string(v))
       zencode_assert(res, (err or 'OK') .. ' on email: ' .. O.to_string(v))
     end
-  end
-)
+end)
 
 IfWhen("verify elements in '' are equal", function(obj_name)
     local obj = have(obj_name)


### PR DESCRIPTION
This PR changes the Zencode definition lua code to insure that all statements (`Given(...) When(...) Then(...) IfWhen(...)`) are made on the same line, so that any editor or `grep` or `awk` or emacs `occur` function can easily list all statements declared in a Lua source file.