### PR TITLE
fix(given): 🐛 add data type validation during giving phase

### DIFF
--- a/src/lua/zencode_given.lua
+++ b/src/lua/zencode_given.lua
@@ -152,6 +152,12 @@ function operate_conversion(guessed)
    if luatype(fun) == 'table' then fun = fun.import end
    local lt = luatype(guessed.raw)
    if lt == 'table' then
+        -- check correctness of the data type
+        if guessed.zentype == "a" then assert(isarray(guessed.raw),
+            "Incorrect data type, expected array for "..guessed.name)
+        elseif guessed.zentype == "d" then assert(isdictionary(guessed.raw),
+            "Incorrect data type, expected dictionary for "..guessed.name)
+        end
 	  if guessed.schema then
 		 -- error('Invalid schema conversion for encoding: '..guessed.encoding, 2)
 		 local res = {}

--- a/src/lua/zencode_reflow.lua
+++ b/src/lua/zencode_reflow.lua
@@ -132,7 +132,7 @@ end)
 When("aggregate reflow public key from array ''",function(arr)
       empty 'reflow public key'
       local s = have(arr)
-      zencode_assert(#s ~= 0, "Empty array: "..arr)
+      zencode_assert(luatype(s) == 'table' and next(s) ~= nil, "Empty table: "..arr)
       local val
       for k, v in pairs(s) do
 	 if k == 'reflow_public_key' then val = v

--- a/test/zencode/array.bats
+++ b/test/zencode/array.bats
@@ -806,7 +806,7 @@ EOF
 
     cat <<EOF | zexe remove-table-from-table.zen table-arrays.json
 Given I have a 'string array' named 'identities'
-Given I have a 'string array' named 'identity'
+Given I have a 'string dictionary' named 'identity'
 When I create the size of 'identities'
 and I rename 'size' to 'before'
 and I remove the 'identity' from 'identities'

--- a/test/zencode/branching.bats
+++ b/test/zencode/branching.bats
@@ -453,23 +453,24 @@ EOF
 
     cat <<EOF | zexe print_the.zen print_the.data
 # Rule caller restroom-mw
-Given I have a 'string' named 'id'
+# Given I have a 'string' named 'id'
 # Given I have a valid redis connection on 'redis://localhost:6379'
 # Given I read from redis the data under the key named 'id' and save the output into 'W3C-DID'
 
-Given I have a 'string array' named 'W3C-DID'
+Given I have a 'string dictionary' named 'W3C-DID'
 
 If I verify the 'id' is not found in 'W3C-DID'
 When I set 'title' to 'Identifier Not Found' as 'string'
 When I set 'type' to 'about:blank' as 'string'
 When I set 'status' to '404' as 'number'
-Then print 'id'
+# Then print 'id'
 Then print 'status'
 Then print 'type'
 Then print 'title'
 Endif
 
 If I verify the 'id' is  found in 'W3C-DID'
+When I pickup from path 'W3C-DID.id'
 Then print 'W3C-DID'
 Then print the 'id'
 Endif

--- a/test/zencode/given.bats
+++ b/test/zencode/given.bats
@@ -494,3 +494,40 @@ EOF
     run $ZENROOM_EXECUTABLE -a fail_wrong_time.data -z fail_wrong_time.zen
     assert_line --partial 'Could not read unix timestamp 1.2'
 }
+
+@test "Load tables with wrong data type fails" {
+    cat << EOF | save_asset fail_table_wrong_dt.data
+{
+	"dict": {
+        "hello": "world"
+    },
+    "array": [
+        "hello",
+        "world"
+    ],
+    "ecdh_pks": [
+        "BLOYXryyAI7rPuyNbI0/1CfLFd7H/NbX+osqyQHjPR9BPK1lYSPOixZQWvFK+rkkJ+aJbYp6kii2Y3+fZ5vl2MA=",
+        "BKRCtsZf8PxlIO5C/rQ8brFimDMgITrqKGiD/9YMdrdeIThLoN7Zm6oAQcVGBYso6aWQmkY70I3Dg2GRAv2gCog="
+    ]
+}
+EOF
+    cat <<EOF | save_asset fail_table_wrong_dt_1.zen
+Given I have a 'string dictionary' named 'array'
+Then print the data
+EOF
+    cat <<EOF | save_asset fail_table_wrong_dt_2.zen
+Given I have a 'string array' named 'dict'
+Then print the data
+EOF
+    cat <<EOF | save_asset fail_table_wrong_dt_3.zen
+Scenario ecdh
+Given I have a 'ecdh public key dictionary' named 'ecdh pks'
+Then print the data
+EOF
+    run $ZENROOM_EXECUTABLE -a fail_table_wrong_dt.data -z fail_table_wrong_dt_1.zen
+    assert_line --partial 'Incorrect data type, expected dictionary for array'
+    run $ZENROOM_EXECUTABLE -a fail_table_wrong_dt.data -z fail_table_wrong_dt_2.zen
+    assert_line --partial 'Incorrect data type, expected array for dict'
+    run $ZENROOM_EXECUTABLE -a fail_table_wrong_dt.data -z fail_table_wrong_dt_3.zen
+    assert_line --partial 'Incorrect data type, expected dictionary for ecdh_pks'
+}

--- a/test/zencode/reflow.bats
+++ b/test/zencode/reflow.bats
@@ -113,7 +113,7 @@ EOF
 
     cat <<EOF | zexe seal_start.zen uid.json public_key_array.json
 Scenario reflow
-Given I have a 'reflow public key array' named 'public keys'
+Given I have a 'reflow public key dictionary' named 'public keys'
 and I have a 'string dictionary' named 'Sale'
 When I aggregate the reflow public key from array 'public keys'
 and I create the reflow identity of 'Sale'


### PR DESCRIPTION
This will help to ensure that the zentype declared in the codec is the right one and that the statements which act differently based on the zentype works as intended.