### PR TITLE
fix: use the correct flag when using asm inline

### DIFF
--- a/src/p256-m.c
+++ b/src/p256-m.c
@@ -175,7 +175,7 @@ static uint64_t u32_muladd64(uint32_t x, uint32_t y, uint32_t z, uint32_t t);
  * Arm's Cortex-A and Cortex-M lines of CPUs, which start with the v6-M and
  * v7-M architectures. __ARM_ARCH_PROFILE is not defined for v6 and earlier.
  */
-#if defined(__GNUC__) &&                                                     \
+#if defined(__GCC_ASM_FLAG_OUTPUTS__) &&                                     \
     defined(__ARM_ARCH) && __ARM_ARCH >= 6 && defined(__ARM_ARCH_PROFILE) && \
     (__ARM_ARCH_PROFILE == 77 || __ARM_ARCH_PROFILE == 65) /* 'M' or 'A' */
 


### PR DESCRIPTION
Following [GCC documentation](https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html), in particular section [FlagOutputOperands](https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html#FlagOutputOperands).