### PR TITLE
Fix/rule sorting

### DIFF
--- a/lib/lua54/src/ltable.c
+++ b/lib/lua54/src/ltable.c
@@ -98,21 +98,18 @@ static const Node dummynode_ = {
 
 static const TValue absentkey = {ABSTKEYCONSTANT};
 
-
 /*
-** Hash for integers. To allow a good hash, use the remainder operator
-** ('%'). If integer fits as a non-negative int, compute an int
-** remainder, which is faster. Otherwise, use an unsigned-integer
-** remainder, which uses all bits and ensures a non-negative result.
+** Hash for integers. Modified for Zenroom
+https://luyuhuang.tech/2021/07/30/hash-collision.html
 */
-static Node *hashint (const Table *t, lua_Integer i) {
-  lua_Unsigned ui = l_castS2U(i);
-  if (ui <= cast_uint(INT_MAX))
-    return hashmod(t, cast_int(ui));
-  else
-    return hashmod(t, ui);
+inline uint64_t betterhash(uint64_t x) {
+    x = (x ^ (x >> 30)) * UINT64_C(0xbf58476d1ce4e5b9);
+    x = (x ^ (x >> 27)) * UINT64_C(0x94d049bb133111eb);
+    x = x ^ (x >> 31);
+    return x;
 }
 
+#define hashint(t,i)		hashpow2(t, betterhash(i))
 
 /*
 ** Hash for floating-point numbers.

--- a/lib/lua54/src/ltable.c
+++ b/lib/lua54/src/ltable.c
@@ -25,6 +25,7 @@
 
 #include <math.h>
 #include <limits.h>
+#include <stdint.h>
 
 #include "lua.h"
 
@@ -102,7 +103,7 @@ static const TValue absentkey = {ABSTKEYCONSTANT};
 ** Hash for integers. Modified for Zenroom
 https://luyuhuang.tech/2021/07/30/hash-collision.html
 */
-inline uint64_t betterhash(uint64_t x) {
+static uint64_t betterhash(uint64_t x) {
     x = (x ^ (x >> 30)) * UINT64_C(0xbf58476d1ce4e5b9);
     x = (x ^ (x >> 27)) * UINT64_C(0x94d049bb133111eb);
     x = x ^ (x >> 31);

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -148,6 +148,7 @@ _G['CONF'] = {
 	  encoding = { fun = get_encoding_function('base64'),
 				   name = 'base64' },
 	  format = { fun = JSON.auto, name = 'json' },
+	  sorting = true,
 	  versioning = false
    },
    debug = { encoding = { fun = get_encoding_function('hex'),

--- a/src/lua/json.lua
+++ b/src/lua/json.lua
@@ -71,6 +71,9 @@ local function encode_table(val, stack, whitespaces)
 
   stack[val] = true
 
+  local _ipairs <const> = fif(CONF.output.sorting,sort_ipairs,ipairs)
+  local _pairs <const> = fif(CONF.output.sorting,sort_pairs,pairs)
+
   if rawget(val, 1) ~= nil or next(val) == nil then
     -- Treat as array -- check keys are valid and it is not sparse
     local n = 0
@@ -85,15 +88,15 @@ local function encode_table(val, stack, whitespaces)
       error("invalid table: sparse array (n="..n..", #val="..#val..")")
     end
     -- Encode
-    for i, v in sort_ipairs(val) do
-        res[#res+1] = encode(v, stack, whitespaces)
-    end
+	for i, v in _ipairs(val) do
+	   res[#res+1] = encode(v, stack, whitespaces)
+	end
     stack[val] = nil
     return "[" .. table.concat(res, separator) .. "]"
 
   else
     -- Treat as an object
-    for k, v in sort_pairs(val) do
+    for k, v in _pairs(val) do
       if type(k) ~= "string" then
         error("invalid table: mixed or invalid key types")
       end

--- a/src/lua/zencode.lua
+++ b/src/lua/zencode.lua
@@ -284,6 +284,14 @@ function ZEN:begin(new_heap)
 			 CONF.output.format = get_format(format)
 			 return true and CONF.output.format
 		  end,
+		  ['output sorting'] = function(what)
+			 if what == 'true' then
+				CONF.output.sorting = true
+			 else
+				CONF.output.sorting = false
+			 end
+			 return true
+		  end,
 		  ['output versioning'] = function ()
 			 CONF.output.versioning = true
 			 return true

--- a/test/zencode/rules.bats
+++ b/test/zencode/rules.bats
@@ -2,6 +2,24 @@ load ../bats_setup
 load ../bats_zencode
 SUBDOC=rules
 
+@test "Rule output unsorted" {
+    cat << EOF | save_asset rule_input_unsorted.data
+{ "reverse_order": { "c": 3, "b": 2, "a": 1 } }
+EOF
+	>&3 cat rule_input_unsorted.data
+	cat <<EOF | zexe rule_input_unsorted.zen rule_input_unsorted.data
+rule output sorting false
+
+Given I have a 'string dictionary' named 'reverse order'
+and debug
+Then print all data
+EOF
+
+	save_output rule_input_unsorted.out
+	assert_output '{"reverse_order":{"c":3,"b":2,"a":1}}'
+}
+
+
 # --- version --- #
 @test "Rule check version" {
     cat <<EOF | zexe check_version.zen

--- a/test/zencode/rules.bats
+++ b/test/zencode/rules.bats
@@ -2,24 +2,6 @@ load ../bats_setup
 load ../bats_zencode
 SUBDOC=rules
 
-@test "Rule output unsorted" {
-    cat << EOF | save_asset rule_input_unsorted.data
-{ "reverse_order": { "c": 3, "b": 2, "a": 1 } }
-EOF
-	>&3 cat rule_input_unsorted.data
-	cat <<EOF | zexe rule_input_unsorted.zen rule_input_unsorted.data
-rule output sorting false
-
-Given I have a 'string dictionary' named 'reverse order'
-and debug
-Then print all data
-EOF
-
-	save_output rule_input_unsorted.out
-	assert_output '{"reverse_order":{"c":3,"b":2,"a":1}}'
-}
-
-
 # --- version --- #
 @test "Rule check version" {
     cat <<EOF | zexe check_version.zen
@@ -370,4 +352,26 @@ Then print the data
 EOF
     run $ZENROOM_EXECUTABLE -z -a rule_path_separator.data rule_path_separator_fail.zen
     assert_line --partial 'Rule invalid: Rule path separator --'
+}
+
+@test "Rule output unsorted" {
+    cat << EOF | save_asset rule_input_unsorted.data
+{ "reverse_order": { "c": 3, "b": 2, "a": 1 } }
+EOF
+	>&3 cat rule_input_unsorted.data
+	cat <<EOF | zexe rule_input_unsorted.zen rule_input_unsorted.data
+rule output sorting false
+
+Given I have a 'string dictionary' named 'reverse order'
+and debug
+Then print all data
+EOF
+
+# TODO: switching off sorting makes results non-deterministic
+# we may want to code a way to keep same order as input
+# but that may require a custom JSON parser to fill in CODEC
+# and even further complexity.
+
+#	save_output rule_input_unsorted.out
+#	assert_output '{"reverse_order":{"c":3,"b":2,"a":1}}'
 }


### PR DESCRIPTION
Add a rule to switch off deterministic sorting of JSON encoded dictionaries in output

This breaks determinism in Zenroom but may be desirable in some situations.

It does not grant equality between input and output sorting, which is non-deterministic as per Lua's hash tables.

Also improves the integer index hashing of tables in lua with a better algorithm against collisions.