### PR TITLE
fix(given): 🐛 prefix and suffix can be passed as input varibale

### DIFF
--- a/src/lua/zencode_given.lua
+++ b/src/lua/zencode_given.lua
@@ -403,15 +403,16 @@ Given("rename '' to ''",function(old, new)
        CODEC[old] = nil
 end)
 
-Given("'' part of '' after string prefix ''", function(enc, src, pfx)
+Given("'' part of '' after string prefix ''", function(enc, src, pfx_name)
 		 local whole = IN[src]
 		 zencode_assert(whole, "Cannot find '" .. src .. "' anywhere (null value?)")
+		 local pfx = IN[pfx_name] or pfx_name
 		 local plen = #pfx
 		 local wlen = #whole
 		 zencode_assert(wlen > plen, "String too short: "
 					.. src.. "("..wlen..") prefix("..plen..")")
 		 zencode_assert(string.sub(whole, 1, plen) == pfx,
-					"Prefix not found in "..src..": "..pfx)
+					"Prefix not found in "..src..": "..pfx_name)
 		 -- if not conv and ZEN.schemas[what] then conv = what end
 		 ZEN.TMP = guess_conversion(string.sub(whole,plen+1,wlen), enc)
 		 ZEN.TMP.name = src
@@ -419,15 +420,16 @@ Given("'' part of '' after string prefix ''", function(enc, src, pfx)
 		 gc()
 end)
 
-Given("'' part of '' before string suffix ''", function(enc, src, sfx)
+Given("'' part of '' before string suffix ''", function(enc, src, sfx_name)
 		 local whole = IN[src]
 		 zencode_assert(whole, "Cannot find '" .. src .. "' anywhere (null value?)")
+		 local sfx = IN[sfx_name] or sfx_name
 		 local slen = #sfx
 		 local wlen = #whole
 		 zencode_assert(wlen > slen, "String too short: "
 					.. src.. "("..wlen..") suffix("..slen..")")
 		 zencode_assert(string.sub(whole, wlen-slen+1, wlen) == sfx,
-					"Suffix not found in "..src..": "..sfx)
+					"Suffix not found in "..src..": "..sfx_name)
 		 -- if not conv and ZEN.schemas[what] then conv = what end
 		 ZEN.TMP = guess_conversion(string.sub(whole,1,wlen-slen), enc)
 		 ZEN.TMP.name = src

--- a/test/zencode/given.bats
+++ b/test/zencode/given.bats
@@ -580,3 +580,25 @@ EOF
     save_output 'given_in_path.json'
     assert_output '{"my_array_1_1":"hello","my_array_2_1":"one","my_array_2_2_hi":"world","my_number_array_1":1,"my_string_array_2":"world"}'
 }
+
+
+@test "Given to decode partials with string prefix and suffix in other variable" {
+	  cat << EOF | save_asset prefix_from_varibale.json
+{
+    "token": "BEARER eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiI2ZGEyY2IyNDk3MjMzN2ZhYTU1NDA2ZDYwYmZkYmU1MDM4NDk1ODc5IiwiaWF0IjoxNzA5ODkyNDI3LCJpc3MiOiJodHRwczovL2F1dGh6LXNlcnZlcjEuemVuc3dhcm0uZm9ya2JvbWIuZXU6MzEwMCIsImF1ZCI6ImRpZDpkeW5lOnNhbmRib3guc2lnbnJvb206UFREdnZRbjFpV1FpVnhrZnNEblVpZDhGYmllS2JIcTQ2UXM4YzlDWng2NyIsImV4cCI6MTcwOTg5NjAyN30.OReIXP6ZjSL8iHyno1nDwWw32SqlG3HIoFqoBpIb1OwuvOgUbGmdCNgfJToq7dT8kG2gsgIJYr40BcnNJDVX_Q",
+    "prefix": "BEARER ",
+    "suffix": " eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiI2ZGEyY2IyNDk3MjMzN2ZhYTU1NDA2ZDYwYmZkYmU1MDM4NDk1ODc5IiwiaWF0IjoxNzA5ODkyNDI3LCJpc3MiOiJodHRwczovL2F1dGh6LXNlcnZlcjEuemVuc3dhcm0uZm9ya2JvbWIuZXU6MzEwMCIsImF1ZCI6ImRpZDpkeW5lOnNhbmRib3guc2lnbnJvb206UFREdnZRbjFpV1FpVnhrZnNEblVpZDhGYmllS2JIcTQ2UXM4YzlDWng2NyIsImV4cCI6MTcwOTg5NjAyN30.OReIXP6ZjSL8iHyno1nDwWw32SqlG3HIoFqoBpIb1OwuvOgUbGmdCNgfJToq7dT8kG2gsgIJYr40BcnNJDVX_Q"
+ }
+EOF
+    cat << EOF | zexe prefix_from_varibale.zen prefix_from_varibale.json
+Scenario 'w3c': token
+Given I have a 'string' part of 'token' before string suffix 'suffix'
+and I rename 'token' to 'bearer'
+Given I have a 'json web token' part of 'token' after string prefix 'prefix'
+When I pickup a 'string dictionary' from path 'token.payload'
+Then print the 'payload'
+Then print the 'bearer'
+EOF
+    save_output 'prefix_from_varibale.json'
+    assert_output '{"bearer":"BEARER","payload":{"aud":"did:dyne:sandbox.signroom:PTDvvQn1iWQiVxkfsDnUid8FbieKbHq46Qs8c9CZx67","exp":1.709896e+09,"iat":1.709892e+09,"iss":"https://authz-server1.zenswarm.forkbomb.eu:3100","sub":"6da2cb24972337faa55406d60bfdbe5038495879"}}'
+}


### PR DESCRIPTION
This is needed when the prefix or suffix contains a withspace, since the inline value will replace it with an underscore