### PR TITLE
fix(javascript): remove console.log from introspect function

### DIFF
--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -207,7 +207,6 @@ export const introspect = async (zencode, props?: ZenroomProps) => {
     const { result } = await zencode_valid_input(zencode, props);
     return JSON.parse(result).CODEC;
   } catch ({ logs }) {
-    console.error(logs);
     const heap = JSON.parse(logs)
       .filter((l) => l.startsWith("J64 HEAP:"))
       .map((l) => l.replace("J64 HEAP:", "").trim())[0];


### PR DESCRIPTION
This console.log generate a lot of messages when using ncr that makes it harder to understand if real errors happen
