### PR TITLE
feat: ✨ add zencode contract parse api

### DIFF
--- a/bindings/javascript/src/index.spec.ts
+++ b/bindings/javascript/src/index.spec.ts
@@ -9,6 +9,7 @@ import {
   zenroom_hash,
   introspect,
   zencode_parse_contract,
+  safe_zencode_parse_contract,
 } from "./index";
 import { TextEncoder } from "util";
 var enc = new TextEncoder();
@@ -334,14 +335,14 @@ test("Check the introspection with data", async (t) => {
 });
 
 test("parse simple contract", async (t) => {
-  const { result } = await zencode_parse_contract(`Scenario ecdh
+  const { result } = await safe_zencode_parse_contract(`Scenario ecdh
   Given nothing
   Then print all data`);
   t.deepEqual(JSON.parse(result), {invalid: [], ignored: []});
 })
 
 test("parse contract with an invalid statement", async (t) => {
-  const { result } = await zencode_parse_contract(`Scenario ecdh
+  const { result } = await safe_zencode_parse_contract(`Scenario ecdh
   Given gibberish
   Given nothing
   Then print all data`);
@@ -359,7 +360,7 @@ test("parse contract with an invalid statement", async (t) => {
 })
 
 test("parse contract with more than one invalid statement", async (t) => {
-  const { result } = await zencode_parse_contract(`Scenario ecdh
+  const { result } = await safe_zencode_parse_contract(`Scenario ecdh
   Given gibberish
   Given nothing
   When gibberish
@@ -393,7 +394,7 @@ test("parse contract with more than one invalid statement", async (t) => {
 
 
 test("parse contract with ingnore statements", async (t) => {
-  const { result } = await zencode_parse_contract(`Rule unknown ignore
+  const { result } = await safe_zencode_parse_contract(`Rule unknown ignore
   Scenario ecdh
   Given gibberish
   and more gibberish
@@ -420,7 +421,7 @@ test("parse contract with ingnore statements", async (t) => {
 })
 
 test("parse contract with muliple ingnore and invalid statements", async (t) => {
-  const { result } = await zencode_parse_contract(`Rule unknown ignore
+  const { result } = await safe_zencode_parse_contract(`Rule unknown ignore
   Scenario ecdh
   Given gibberish
   and more gibberish
@@ -465,4 +466,23 @@ test("parse contract with muliple ingnore and invalid statements", async (t) => 
     ]
   }
   t.deepEqual(JSON.parse(result), expected);  
+})
+
+test("strict parse of contract", async (t) => {
+  try {
+    await zencode_parse_contract(`Rule unknown ignore
+    Scenario ecdh
+    Given gibberish
+    and more gibberish
+    Given nothing
+    When gibberish
+    Not a real statement
+    When done
+    Something more
+    Then print all data
+    Is it clear?
+    Then gibberish`);
+  } catch(error) {
+    t.true(error.logs.includes('Zencode line 6 found invalid statement out of given or then phase: When gibberish'));
+  }
 })

--- a/bindings/javascript/src/index.spec.ts
+++ b/bindings/javascript/src/index.spec.ts
@@ -8,8 +8,8 @@ import {
   zenroom_hash_final,
   zenroom_hash,
   introspect,
-  zencode_parse_contract,
-  safe_zencode_parse_contract,
+  zencode_valid_code,
+  safe_zencode_valid_code,
 } from "./index";
 import { TextEncoder } from "util";
 var enc = new TextEncoder();
@@ -335,14 +335,14 @@ test("Check the introspection with data", async (t) => {
 });
 
 test("parse simple contract", async (t) => {
-  const { result } = await safe_zencode_parse_contract(`Scenario ecdh
+  const { result } = await safe_zencode_valid_code(`Scenario ecdh
   Given nothing
   Then print all data`);
   t.deepEqual(JSON.parse(result), {invalid: [], ignored: []});
 })
 
 test("parse contract with an invalid statement", async (t) => {
-  const { result } = await safe_zencode_parse_contract(`Scenario ecdh
+  const { result } = await safe_zencode_valid_code(`Scenario ecdh
   Given gibberish
   Given nothing
   Then print all data`);
@@ -360,7 +360,7 @@ test("parse contract with an invalid statement", async (t) => {
 })
 
 test("parse contract with more than one invalid statement", async (t) => {
-  const { result } = await safe_zencode_parse_contract(`Scenario ecdh
+  const { result } = await safe_zencode_valid_code(`Scenario ecdh
   Given gibberish
   Given nothing
   When gibberish
@@ -394,7 +394,7 @@ test("parse contract with more than one invalid statement", async (t) => {
 
 
 test("parse contract with ingnore statements", async (t) => {
-  const { result } = await safe_zencode_parse_contract(`Rule unknown ignore
+  const { result } = await safe_zencode_valid_code(`Rule unknown ignore
   Scenario ecdh
   Given gibberish
   and more gibberish
@@ -421,7 +421,7 @@ test("parse contract with ingnore statements", async (t) => {
 })
 
 test("parse contract with muliple ingnore and invalid statements", async (t) => {
-  const { result } = await safe_zencode_parse_contract(`Rule unknown ignore
+  const { result } = await safe_zencode_valid_code(`Rule unknown ignore
   Scenario ecdh
   Given gibberish
   and more gibberish
@@ -470,7 +470,7 @@ test("parse contract with muliple ingnore and invalid statements", async (t) => 
 
 test("strict parse of contract", async (t) => {
   try {
-    await zencode_parse_contract(`Rule unknown ignore
+    await zencode_valid_code(`Rule unknown ignore
     Scenario ecdh
     Given gibberish
     and more gibberish

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -217,6 +217,7 @@ export const introspect = async (zencode, props?: ZenroomProps) => {
 
 export const zencode_valid_code = async (
   zencode: string,
+  conf: string | null = null,
   strict: number = 1
 ): Promise<ZenroomResult> => {
   const Module = await getModule();
@@ -224,6 +225,7 @@ export const zencode_valid_code = async (
     let result = "";
     let logs = "";
     const _exec = Module.cwrap("zencode_valid_code", "number", [
+      "string",
       "string",
       "number",
     ]);
@@ -238,12 +240,13 @@ export const zencode_valid_code = async (
     Module.onAbort = () => {
       reject({ result, logs });
     };
-    _exec(zencode, strict);
+    _exec(zencode, conf, strict);
   });
 }
 
 export const safe_zencode_valid_code = async (
-  zencode: string
+  zencode: string,
+  conf: string | null = null
 ): Promise<ZenroomResult> => {
-  return zencode_valid_code(zencode, 0);
+  return zencode_valid_code(zencode, conf, 0);
 }

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -215,7 +215,7 @@ export const introspect = async (zencode, props?: ZenroomProps) => {
   }
 };
 
-export const zencode_parse_contract = async (
+export const zencode_valid_code = async (
   zencode: string,
   strict: number = 1
 ): Promise<ZenroomResult> => {
@@ -223,7 +223,7 @@ export const zencode_parse_contract = async (
   return new Promise((resolve, reject) => {
     let result = "";
     let logs = "";
-    const _exec = Module.cwrap("zencode_parse_contract", "number", [
+    const _exec = Module.cwrap("zencode_valid_code", "number", [
       "string",
       "number",
     ]);
@@ -242,8 +242,8 @@ export const zencode_parse_contract = async (
   });
 }
 
-export const safe_zencode_parse_contract = async (
+export const safe_zencode_valid_code = async (
   zencode: string
 ): Promise<ZenroomResult> => {
-  return zencode_parse_contract(zencode, 0);
+  return zencode_valid_code(zencode, 0);
 }

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -216,7 +216,8 @@ export const introspect = async (zencode, props?: ZenroomProps) => {
 };
 
 export const zencode_parse_contract = async (
-  zencode: string
+  zencode: string,
+  strict: number = 1
 ): Promise<ZenroomResult> => {
   const Module = await getModule();
   return new Promise((resolve, reject) => {
@@ -224,6 +225,7 @@ export const zencode_parse_contract = async (
     let logs = "";
     const _exec = Module.cwrap("zencode_parse_contract", "number", [
       "string",
+      "number",
     ]);
     Module.print = (t: string) => (result += t);
     Module.printErr = (t: string) => (logs += t);
@@ -236,6 +238,12 @@ export const zencode_parse_contract = async (
     Module.onAbort = () => {
       reject({ result, logs });
     };
-    _exec(zencode);
+    _exec(zencode, strict);
   });
+}
+
+export const safe_zencode_parse_contract = async (
+  zencode: string
+): Promise<ZenroomResult> => {
+  return zencode_parse_contract(zencode, 0);
 }

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -214,3 +214,28 @@ export const introspect = async (zencode, props?: ZenroomProps) => {
     return JSON.parse(Buffer.from(heap, "base64").toString("utf-8"));
   }
 };
+
+export const zencode_parse_contract = async (
+  zencode: string
+): Promise<ZenroomResult> => {
+  const Module = await getModule();
+  return new Promise((resolve, reject) => {
+    let result = "";
+    let logs = "";
+    const _exec = Module.cwrap("zencode_parse_contract", "number", [
+      "string",
+    ]);
+    Module.print = (t: string) => (result += t);
+    Module.printErr = (t: string) => (logs += t);
+    Module.exec_ok = () => {
+      resolve({ result, logs });
+    };
+    Module.exec_error = () => {
+      reject({ result, logs });
+    };
+    Module.onAbort = () => {
+      reject({ result, logs });
+    };
+    _exec(zencode);
+  });
+}

--- a/build/config.mk
+++ b/build/config.mk
@@ -223,7 +223,7 @@ ld_emsdk_settings := -I ${EMSCRIPTEN}/system/include/libc -DLIBRARY
 ld_emsdk_settings += -sMODULARIZE=1	-sSINGLE_FILE=1 --embed-file lua@/
 ld_emsdk_settings += -sMALLOC=dlmalloc --no-heap-copy -sALLOW_MEMORY_GROWTH=1
 ld_emsdk_settings += -sINITIAL_MEMORY=${JS_INIT_MEM} -sMAXIMUM_MEMORY=${JS_MAX_MEM}
-ld_emsdk_settings += -sINCOMING_MODULE_JS_API=print,printErr -s "EXPORTED_FUNCTIONS='[\"_zenroom_exec\",\"_zencode_exec\",\"_zenroom_hash_init\",\"_zenroom_hash_update\",\"_zenroom_hash_final\",\"_zencode_valid_input\",\"_zencode_parse_contract\"]'" -s "EXPORTED_RUNTIME_METHODS='[\"ccall\",\"cwrap\"]'"
+ld_emsdk_settings += -sINCOMING_MODULE_JS_API=print,printErr -s "EXPORTED_FUNCTIONS='[\"_zenroom_exec\",\"_zencode_exec\",\"_zenroom_hash_init\",\"_zenroom_hash_update\",\"_zenroom_hash_final\",\"_zencode_valid_input\",\"_zencode_valid_code\"]'" -s "EXPORTED_RUNTIME_METHODS='[\"ccall\",\"cwrap\"]'"
 ld_emsdk_optimizations := -O3 -sSTRICT -flto -sUSE_SDL=0 -sEVAL_CTORS=1
 cc_emsdk_settings := -DARCH_WASM -D'ARCH=\"WASM\"'
 cc_emsdk_optimizations := -O3 -sSTRICT -flto -fno-rtti -fno-exceptions

--- a/build/config.mk
+++ b/build/config.mk
@@ -223,7 +223,7 @@ ld_emsdk_settings := -I ${EMSCRIPTEN}/system/include/libc -DLIBRARY
 ld_emsdk_settings += -sMODULARIZE=1	-sSINGLE_FILE=1 --embed-file lua@/
 ld_emsdk_settings += -sMALLOC=dlmalloc --no-heap-copy -sALLOW_MEMORY_GROWTH=1
 ld_emsdk_settings += -sINITIAL_MEMORY=${JS_INIT_MEM} -sMAXIMUM_MEMORY=${JS_MAX_MEM}
-ld_emsdk_settings += -sINCOMING_MODULE_JS_API=print,printErr -s "EXPORTED_FUNCTIONS='[\"_zenroom_exec\",\"_zencode_exec\",\"_zenroom_hash_init\",\"_zenroom_hash_update\",\"_zenroom_hash_final\",\"_zencode_valid_input\"]'" -s "EXPORTED_RUNTIME_METHODS='[\"ccall\",\"cwrap\"]'"
+ld_emsdk_settings += -sINCOMING_MODULE_JS_API=print,printErr -s "EXPORTED_FUNCTIONS='[\"_zenroom_exec\",\"_zencode_exec\",\"_zenroom_hash_init\",\"_zenroom_hash_update\",\"_zenroom_hash_final\",\"_zencode_valid_input\",\"_zencode_parse_contract\"]'" -s "EXPORTED_RUNTIME_METHODS='[\"ccall\",\"cwrap\"]'"
 ld_emsdk_optimizations := -O3 -sSTRICT -flto -sUSE_SDL=0 -sEVAL_CTORS=1
 cc_emsdk_settings := -DARCH_WASM -D'ARCH=\"WASM\"'
 cc_emsdk_optimizations := -O3 -sSTRICT -flto -fno-rtti -fno-exceptions

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -157,7 +157,8 @@ _G['CONF'] = {
 						  name = 'hex' },
 			 format = 'log' -- or 'compact' for base64 encoded json
 		   },
-   parser = {strict_match = true},
+   parser = {strict_match = true,
+             strict_parse = true},
    exec = { scope = 'full' }, -- from conf scope=given, triggers:
                               -- parser.strict_match=false
                               -- missing.fatal=false

--- a/src/lua/zencode.lua
+++ b/src/lua/zencode.lua
@@ -530,7 +530,11 @@ function ZEN:parse(text)
 	  -- continue
    end
    collectgarbage'collect'
-   return res
+   if res == true then
+	  return true
+   else
+	  return JSON.encode(res)
+   end
 end
 
 

--- a/src/lua/zencode.lua
+++ b/src/lua/zencode.lua
@@ -519,7 +519,7 @@ function ZEN:parse(text)
 		 elseif not fm then
 			if ZEN.phase == 'g' and not ZEN.last_valid_statement then
 				if CONF.parser.strict_parse then
-					table.insert(traceback, '-'..self.linenum..'	'..line)
+					table.insert(traceback, '-'..self.linenum..'  '..line)
 					warn('Zencode line '..self.linenum..' pattern ignored: ' .. line, 1)
 				else
 					table.insert(res.ignored, {line, self.linenum})
@@ -527,7 +527,7 @@ function ZEN:parse(text)
 			elseif ZEN.phase == 't' then
 				ZEN.last_valid_statement = false
 				if CONF.parser.strict_parse then
-					table.insert(traceback, '-'..self.linenum..'	'..line)
+					table.insert(traceback, '-'..self.linenum..'  '..line)
 					warn('Zencode line '..self.linenum..' pattern ignored: ' .. line, 1)
 				 else
 					table.insert(res.ignored, {line, self.linenum})

--- a/src/zenroom.c
+++ b/src/zenroom.c
@@ -584,12 +584,14 @@ int zencode_valid_input(const char *script, const char *conf, const char *keys, 
 	return( _check_zenroom_result(Z));
 }
 
-int zencode_parse_contract(const char *script) {
+int zencode_parse_contract(const char *script, const int strict) {
 	if (_check_script_arg(script) != SUCCESS) return ERR_INIT;
 	zenroom_t *Z = zen_init(NULL, NULL, NULL);
 	if (_check_zenroom_init(Z) != SUCCESS) return ERR_INIT;
 	// disable strict parsing
-	luaL_dostring(Z->lua, "CONF.parser.strict_parse=false");
+	if (!strict) {
+		luaL_dostring(Z->lua, "CONF.parser.strict_parse=false");
+	}
 	// ZEN:begin()
 	lua_getglobal(Z->lua, "ZEN");
 	lua_getfield(Z->lua, -1, "begin");

--- a/src/zenroom.c
+++ b/src/zenroom.c
@@ -584,9 +584,11 @@ int zencode_valid_input(const char *script, const char *conf, const char *keys, 
 	return( _check_zenroom_result(Z));
 }
 
-int zencode_parse_contract(const char *script, const int strict) {
+int zencode_valid_code(const char *script, const char *conf, const int strict) {
 	if (_check_script_arg(script) != SUCCESS) return ERR_INIT;
-	zenroom_t *Z = zen_init(NULL, NULL, NULL);
+	const char *c, *k, *d;
+	c = conf ? (conf[0] == '\0') ? NULL : conf : NULL;
+	zenroom_t *Z = zen_init(c, NULL, NULL);
 	if (_check_zenroom_init(Z) != SUCCESS) return ERR_INIT;
 	// disable strict parsing
 	if (!strict) {

--- a/src/zenroom.h
+++ b/src/zenroom.h
@@ -43,6 +43,9 @@ int zencode_exec_tobuf(const char *script, const char *conf, const char *keys, c
 // validate the input data processing only Given scope and print the CODEC
 int zencode_valid_input(const char *script, const char *conf, const char *keys, const char *data, const char *extra);
 
+// parse the contract returing ignored and invalid statements
+int zencode_parse_contract(const char *script);
+
 // direct access hash calls
 // hash_type may be a string of: 'sha256' or 'sha512'
 // all functions return 0 on success, anything else signals an error

--- a/src/zenroom.h
+++ b/src/zenroom.h
@@ -45,7 +45,7 @@ int zencode_valid_input(const char *script, const char *conf, const char *keys, 
 
 // parse the contract failing on wrong syntax when strict is set to 1
 // otherwise return an array of ignored and invalid statements when strict is set to 0
-int zencode_parse_contract(const char *script, const int strict);
+int zencode_valid_code(const char *script, const char *conf, const int strict);
 
 // direct access hash calls
 // hash_type may be a string of: 'sha256' or 'sha512'

--- a/src/zenroom.h
+++ b/src/zenroom.h
@@ -43,8 +43,9 @@ int zencode_exec_tobuf(const char *script, const char *conf, const char *keys, c
 // validate the input data processing only Given scope and print the CODEC
 int zencode_valid_input(const char *script, const char *conf, const char *keys, const char *data, const char *extra);
 
-// parse the contract returing ignored and invalid statements
-int zencode_parse_contract(const char *script);
+// parse the contract failing on wrong syntax when strict is set to 1
+// otherwise return an array of ignored and invalid statements when strict is set to 0
+int zencode_parse_contract(const char *script, const int strict);
 
 // direct access hash calls
 // hash_type may be a string of: 'sha256' or 'sha512'


### PR DESCRIPTION
- feat: add strict_parse configuration flag
- fix: return of parse is json encoded
- fix: parser does not ignore invalid statement that are not at the contract borders
- feat(zenroom): ✨ add new C api to parse zencode contracts
- feat(javascript): ✨ expose zencode_parse_contract api to js
- refactor: ♻️  add parse api input to decide whether it has to be strict or not
- feat(javscirpt): ✨ parse api is by default strict, add also safe_zencode_parse_contract as an alias for non strict parsing
