### PR TITLE
fix: print all empty octets as empty strings

### DIFF
--- a/src/lua/zencode_data.lua
+++ b/src/lua/zencode_data.lua
@@ -364,7 +364,7 @@ end
        elseif dt == 'zenroom.float' or dt == 'zenroom.time' then
 		    return to_number_f(data)
        elseif iszen(dt) then
-        if fun == O.to_string and fun(data) == nil then return "" end
+        if fun(data) == nil then return "" end
         -- leverage first class citizen method on zenroom data
         return fun(data:octet())
        end

--- a/test/zencode/then.bats
+++ b/test/zencode/then.bats
@@ -293,3 +293,14 @@ EOF
     save_output 'tables_with_empty_strings.out'
     assert_output '{"array":["hello world!","","goodbye world!"],"dictionary":{"another_str":"goodbye world!","empty_str":"","str":"hello world!"}}'
 }
+
+@test "Fail with tables with empty strings" {
+    cat <<EOF | save_asset fail_tables_with_empty_strings.zen
+Rule unknown ignore
+Given I have the 'string array' named 'array'
+Given I have the 'string array' named 'dictionary'
+Then print all data
+EOF
+    run $ZENROOM_EXECUTABLE -z -a tables_with_empty_strings.json fail_tables_with_empty_strings.zen
+    assert_line --partial "Incorrect data type, expected array for dictionary"
+}

--- a/test/zencode/zencode_exec.bats
+++ b/test/zencode/zencode_exec.bats
@@ -196,25 +196,23 @@ EOF
 	assert_output '{"myMessage":"Dear Bob, your name is too short, goodbye - Alice.","output":["Zenroom_certifies_that_signatures_are_all_correct!"]}'
 }
 
-# TODO: how to test failure and error message with zencode_exec?
 @test "failing test print encoded trace with empty string in it" {
-    skip
 
-	# empty conf
-	echo > zencode_exec_stdin
+    # empty conf
+    echo > zencode_exec_stdin
 
     # zencode
-	cat <<EOF | base64 -w0 >> zencode_exec_stdin
+    cat <<EOF | base64 -w0 >> zencode_exec_stdin
 Rule unknown ignore
 Given I have the 'string array' named 'array'
 Given I have the 'string array' named 'dictionary'
 Then print all data
 
 EOF
-	echo >> zencode_exec_stdin
+    echo >> zencode_exec_stdin
 
     # keys
-	cat <<EOF | base64 -w0 >> zencode_exec_stdin
+    cat <<EOF | base64 -w0 >> zencode_exec_stdin
 {
     "dictionary": {
         "str": "hello world!",
@@ -228,11 +226,12 @@ EOF
     ]
 }
 EOF
-	echo >> zencode_exec_stdin
+    echo >> zencode_exec_stdin
 
     echo >> zencode_exec_stdin # data
     echo >> zencode_exec_stdin # extra
     echo >> zencode_exec_stdin # context
 
-	cat zencode_exec_stdin | ${TR}/zencode-exec
+    run ${TR}/zencode-exec < zencode_exec_stdin
+    assert_line --partial "Zencode line 3: Given I have the 'string array' named 'dictionary'"
 }

--- a/test/zencode/zencode_exec.bats
+++ b/test/zencode/zencode_exec.bats
@@ -195,3 +195,44 @@ EOF
 	save_output verified.json
 	assert_output '{"myMessage":"Dear Bob, your name is too short, goodbye - Alice.","output":["Zenroom_certifies_that_signatures_are_all_correct!"]}'
 }
+
+# TODO: how to test failure and error message with zencode_exec?
+@test "failing test print encoded trace with empty string in it" {
+    skip
+
+	# empty conf
+	echo > zencode_exec_stdin
+
+    # zencode
+	cat <<EOF | base64 -w0 >> zencode_exec_stdin
+Rule unknown ignore
+Given I have the 'string array' named 'array'
+Given I have the 'string array' named 'dictionary'
+Then print all data
+
+EOF
+	echo >> zencode_exec_stdin
+
+    # keys
+	cat <<EOF | base64 -w0 >> zencode_exec_stdin
+{
+    "dictionary": {
+        "str": "hello world!",
+        "empty_str": "",
+        "another_str": "goodbye world!",
+    },
+    "array": [
+        "hello world!",
+        "",
+        "goodbye world!"
+    ]
+}
+EOF
+	echo >> zencode_exec_stdin
+
+    echo >> zencode_exec_stdin # data
+    echo >> zencode_exec_stdin # extra
+    echo >> zencode_exec_stdin # context
+
+	cat zencode_exec_stdin | ${TR}/zencode-exec
+}


### PR DESCRIPTION
- fix: print all empty octets as empty strings
- test(zencode): add failing tests with empty octets in the trace
