### PR TITLE
Improve automatic type casting of some overloaded functions

### DIFF
--- a/src/zen_octet.c
+++ b/src/zen_octet.c
@@ -1020,8 +1020,8 @@ static int concat_n(lua_State *L) {
 	OCT_copy(n, x);
 	OCT_joctet(n, y);
 end:
-	o_free(L, y);
-	o_free(L, x);
+	if(y!=&ys) o_free(L, y);
+	if(x!=&xs) o_free(L, x);
 	if(failed_msg) {
 		THROW(failed_msg);
 	}


### PR DESCRIPTION
This PR aims at making it easier to use zenroom types in various overloaded functions and while doing so it fixes some bugs occurring in situations in which the first class citizen is not found.