### PR TITLE
fix: increment js binding wasm stack size to 7MB and correct reported error from lerror

### DIFF
--- a/bindings/javascript/src/index.spec.ts
+++ b/bindings/javascript/src/index.spec.ts
@@ -1,5 +1,4 @@
 import test from "ava";
-import fs from "node:fs/promises";
 
 import {
   zencode_exec,
@@ -497,16 +496,17 @@ test("strict parse of contract", async (t) => {
 })
 
 test("correctly fails on huge input", async (t) => {
-  const data = await fs.readFile("huge_input.json", { encoding: 'utf8' });
+  // 6MiB base64 -> 4718592 bytes in octets
+  const data = `{"keyring":{"ecdh":"AxLMXkey00i2BD675vpMQ8WhP/CwEfmdRr+BtpuJ2rM="}, "bytes": "${"a".repeat(6*1024*1024)}"}`;
   try {
     await zencode_exec(`Scenario ecdh
       Given I have a 'keyring'
       Given I have a 'base64' named 'bytes'
       When I create the ecdh signature of 'bytes'
       Then print the 'ecdh signature'`, { data: data, keys: null });
-    t.fail("input of size 4286808 should not pass");
+    t.fail("input of size bigger than 4MiB should not pass");
   } catch(error) {
     const lines = JSON.parse(error.logs);
-    t.is(lines.includes('[!] Cannot create octet, size too big: 4286808'), true, error.logs);
+    t.is(lines.includes('[!] Cannot create octet, size too big: 4718592'), true, error.logs);
   } 
 })

--- a/bindings/javascript/src/index.spec.ts
+++ b/bindings/javascript/src/index.spec.ts
@@ -504,8 +504,9 @@ test("correctly fails on huge input", async (t) => {
       Given I have a 'base64' named 'bytes'
       When I create the ecdh signature of 'bytes'
       Then print the 'ecdh signature'`, { data: data, keys: null });
+    t.fail("input of size 4286808 should not pass");
   } catch(error) {
     const lines = JSON.parse(error.logs);
-    t.is(lines.includes('[!] from_string: invalid string size: 4443896'), true, error.logs);
+    t.is(lines.includes('[!] Cannot create octet, size too big: 4286808'), true, error.logs);
   } 
 })

--- a/build/config.mk
+++ b/build/config.mk
@@ -5,6 +5,7 @@
 
 JS_INIT_MEM := 8MB
 JS_MAX_MEM := 256MB
+JS_STACK_SIZE := 7MB
 
 pwd := $(shell pwd)
 mil := ${pwd}/build/milagro
@@ -222,7 +223,7 @@ system := Javascript
 ld_emsdk_settings := -I ${EMSCRIPTEN}/system/include/libc -DLIBRARY
 ld_emsdk_settings += -sMODULARIZE=1	-sSINGLE_FILE=1 --embed-file lua@/
 ld_emsdk_settings += -sMALLOC=dlmalloc --no-heap-copy -sALLOW_MEMORY_GROWTH=1
-ld_emsdk_settings += -sINITIAL_MEMORY=${JS_INIT_MEM} -sMAXIMUM_MEMORY=${JS_MAX_MEM}
+ld_emsdk_settings += -sINITIAL_MEMORY=${JS_INIT_MEM} -sMAXIMUM_MEMORY=${JS_MAX_MEM} -sSTACK_SIZE=${JS_STACK_SIZE}
 ld_emsdk_settings += -sINCOMING_MODULE_JS_API=print,printErr -s "EXPORTED_FUNCTIONS='[\"_zenroom_exec\",\"_zencode_exec\",\"_zenroom_hash_init\",\"_zenroom_hash_update\",\"_zenroom_hash_final\",\"_zencode_valid_input\",\"_zencode_valid_code\"]'" -s "EXPORTED_RUNTIME_METHODS='[\"ccall\",\"cwrap\"]'"
 ld_emsdk_optimizations := -O3 -sSTRICT -flto -sUSE_SDL=0 -sEVAL_CTORS=1
 cc_emsdk_settings := -DARCH_WASM -D'ARCH=\"WASM\"'

--- a/src/zen_error.c
+++ b/src/zen_error.c
@@ -86,13 +86,19 @@ void get_log_prefix(void *Z, log_priority prio, char dest[5]) {
 
 // error reported with lua context
 int lerror(void *LL, const char *fmt, ...) {
+  char msg[MAX_ERRMSG+4];
+  int len;
   lua_State *L = (lua_State*)LL;
-  va_list argp;
+  va_list argp, argp_copy;
   va_start(argp, fmt);
-  zerror(L, fmt, argp); // logs on all platforms
+  va_copy(argp_copy, argp);
+  len = mutt_vsnprintf(msg, MAX_ERRMSG, fmt, argp);
+  msg[len] = 0x0;
+  zerror(L, msg); // logs on all platforms
   luaL_where(L, 1); // 1 is the function which called the running function
-  lua_pushvfstring(L, fmt, argp);
+  lua_pushvfstring(L, fmt, argp_copy);
   va_end(argp);
+  va_end(argp_copy);
   lua_concat(L, 2);
   return lua_error(L); // fatal
 }

--- a/src/zen_octet.c
+++ b/src/zen_octet.c
@@ -646,7 +646,7 @@ static int from_base64(lua_State *L) {
 	if(!len) {
 		lerror(L, "base64 string contains invalid characters");
 		return 0; }
-	int nlen = len + len + len;
+	int nlen = B64decoded_len(len);
 	octet *o = o_new(L, nlen); // 4 byte header
 	SAFE(o);
 	OCT_frombase64(o, (char*)s);

--- a/test/lua/big_shift.lua
+++ b/test/lua/big_shift.lua
@@ -1,13 +1,13 @@
 -- some test for shift right
 
 for i=0,20 do
-   print()
-   print(i)
    divisor = O.from_number(2^i)
    before = BIG.new(O.random(5+i*2))
    after = BIG.shr(before, i)
-   print(before:octet():pad(5+i*2):bin())
-   print(after:octet():pad(5+i*2):bin())
+   -- print()
+   -- print(i)
+   -- print(before:octet():pad(5+i*2):bin())
+   -- print(after:octet():pad(5+i*2):bin())
    assert(before/INT.new(divisor) == after, "shr has not worked as intended")
    assert(before>>i == after, ">> has not worked as intented")
 end
@@ -16,13 +16,13 @@ end
 huge=INT.new(O.from_hex("FBFFDFB70126F9FE83CF124CF22FFFFFF01F3B788DA11A846B8D623D1D43584763B70B79C43909EC6EDC880461EE95A6"))
 
 for i=0,30 do
-   print()
-   print(i)
    divisor = O.from_number(2^i)
    before = huge
    after = BIG.shr(before, i)
-   print(before:octet():pad(48):bin())
-   print(after:octet():pad(48):bin())
+   -- print()
+   -- print(i)
+   --print(before:octet():pad(48):bin())
+   --print(after:octet():pad(48):bin())
    assert(before/INT.new(divisor) == after, "shr has not worked as intended")
    assert(before>>i == after, ">> has not worked as intented")
 end


### PR DESCRIPTION
- fix(js): increment wasm stack size to 7MB
- test(js): zenroom correctly fails on input larger than 4MiB
- fix: result octect length computation when decoding from base64
- chore(js): update huge_input file to really have a varibale whose size is bigger than the accepted one
- test(js): update test to new input
- fix(zen_error): lerror does not forward optional args to zerror
- chore: remove some useless printing from test file
