### PR TITLE
fix(zen_ecdh): check secret key size on generation of the public one

### DIFF
--- a/src/lua/zencode_ecdh.lua
+++ b/src/lua/zencode_ecdh.lua
@@ -76,18 +76,20 @@ When("create ecdh public key",function()
 		new_codec('ecdh public key')
 	end
 )
-When("create ecdh key with secret key ''",function(sec)
-	local sk = have(sec)
+
+local function _ecdh_key_from_secret(sec)
+    local sk = have(sec)
 	initkeyring'ecdh'
 	ECDH.pubgen(sk)
 	ACK.keyring.ecdh = sk
-end)
-When("create ecdh key with secret ''",function(sec)
-	local sk = have(sec)
-	initkeyring'ecdh'
-	ECDH.pubgen(sk)
-	ACK.keyring.ecdh = sk
-end)
+end
+
+When("create ecdh key with secret key ''",
+     _ecdh_key_from_secret
+)
+When("create ecdh key with secret ''",
+    _ecdh_key_from_secret
+)
 
 -- encrypt with a header and secret
 When("encrypt secret message '' with ''",function(msg, sec)

--- a/src/zen_ecdh.c
+++ b/src/zen_ecdh.c
@@ -163,15 +163,17 @@ static int ecdh_pubgen(lua_State *L) {
 	BEGIN();
 	char *failed_msg = NULL;
 	octet *sk = o_arg(L, 1);
-	if(sk == NULL) {
+	if(sk == NULL || sk->len > ECDH.fieldsize) {
 		failed_msg = "Could not allocate secret key";
 		goto end;
 	}
-	octet *tmp = o_dup(L, sk);
-	if(sk == NULL) {
+	octet *tmp = o_new(L, ECDH.fieldsize);
+	if(tmp == NULL) {
 		failed_msg = "Could not duplicate secret key";
 		goto end;
 	}
+	OCT_copy(tmp, sk);
+	OCT_pad(tmp, ECDH.fieldsize);
 	octet *pk = o_new(L,ECDH.fieldsize*2 +1);
 	if(pk == NULL) {
 		failed_msg = "Could not create public key";


### PR DESCRIPTION
- fix(zen_ecdh): check secret key size on generation of the public one
- chore(zencode_ecdh): avoid code duplication
