### PR TITLE
Feat/random seed

### DIFF
--- a/src/lua/zencode_random.lua
+++ b/src/lua/zencode_random.lua
@@ -22,6 +22,16 @@
 
 -- random operations, mostly on arrays and schemas supported
 
+When("seed random with ''",
+     function(seed)
+         local s = have(seed)
+         zencode_assert(iszen(type(s)), "New random seed is not a valid zenroom type: "..seed)
+         local fingerprint = random_seed(s:octet()) -- pass the seed for srand init
+         act("New random seed of "..#s.." bytes")
+         xxx("New random fingerprint: "..fingerprint:hex())
+     end
+)
+
 When("create random ''", function(dest)
 		zencode_assert(not ACK[dest], "Cannot overwrite existing value: "..dest)
 		ACK[dest] = OCTET.random(32) -- TODO: right now hardcoded 256 bit random secrets

--- a/src/lua/zencode_when.lua
+++ b/src/lua/zencode_when.lua
@@ -575,16 +575,6 @@ When("create float '' cast of integer in ''", function(dest, source)
 	new_codec(dest, {encoding = 'float'})
 end)
 
-When("seed random with ''",
-     function(seed)
-	local s = have(seed)
-	zencode_assert(iszen(type(s)), "New random seed is not a valid zenroom type: "..seed)
-	local fingerprint = random_seed(s) -- pass the seed for srand init
-	act("New random seed of "..#s.." bytes")
-	xxx("New random fingerprint: "..fingerprint:hex())
-     end
-)
-
 local ops2 = {
     ['zenroom.big'] = {['+'] = BIG.zenadd, ['-'] = BIG.zensub, ['*'] = BIG.zenmul, ['/'] = BIG.zendiv},
     ['zenroom.float'] = {['+'] = F.add, ['-'] = F.sub, ['*'] = F.mul, ['/'] = F.div},

--- a/src/zen_config.c
+++ b/src/zen_config.c
@@ -115,19 +115,19 @@ int zen_conf_parse(zenroom_t *ZZ, const char *configuration) {
 			if(strcasecmp(lex.string,"logfmt") ==0) { curconf = LOGFMT;  break; } // str
 			if(strcasecmp(lex.string,"maxiter")==0) { curconf = MAXITER; break; } // str
 			if(curconf==RNGSEED) {
-				int len = strlen(lex.string);
-				if( len-4 != RANDOM_SEED_LEN *2) { // hex doubles size
-					_err( "Invalid length of random seed: %u (must be %u)\n",
-					      len/2, RANDOM_SEED_LEN);
-					// free(lexbuf);
-					return 0;
-				}
 				if(strncasecmp(lex.string, "hex:", 4) != 0) { // hex: prefix needed
 					_err( "Invalid rngseed data prefix (must be hex:)\n");
 					// free(lexbuf);
 					return 0;
 				}
-				for(p=4; p<RANDOM_SEED_LEN*2; p++) {
+				int len = strlen(lex.string)-4;
+				if( len/2 != RANDOM_SEED_LEN) { // hex doubles size
+					_err( "Invalid length of random seed: %u (must be %u)\n",
+					      len/2, RANDOM_SEED_LEN);
+					// free(lexbuf);
+					return 0;
+				}
+				for(p=4; p<len; p++) {
 				  if(! isxdigit(lex.string[p]) ) {
 					_err( "Invalid hex digit in random seed: %c\n",
 						  lex.string[p]);
@@ -136,8 +136,8 @@ int zen_conf_parse(zenroom_t *ZZ, const char *configuration) {
 				}
 
 				// copy string and null terminate
-				memcpy(ZZ->zconf_rngseed, lex.string+4, RANDOM_SEED_LEN*2);
-				ZZ->zconf_rngseed[(RANDOM_SEED_LEN*2)] = 0x0;
+				memcpy(ZZ->zconf_rngseed, lex.string+4, len);
+				ZZ->zconf_rngseed[len] = 0x0;
 				break;
 			}
 			if(curconf==LOGFMT) {

--- a/src/zen_parse.c
+++ b/src/zen_parse.c
@@ -130,11 +130,12 @@ static int lua_trim_quotes(lua_State* L) {
 
 static int lua_unserialize_json(lua_State* L) {
 	const char *in;
-	size_t size;
 	register int level = 0;
 	register char *p;
 	register char in_literal_str = 0;
+	size_t size;
 	in = luaL_checklstring(L, 1, &size);
+	size_t orig_size = size;
 	char brakets[MAX_DEPTH];
 	p = (char*)in;
 	while (size && isspace(*p) ) { size--; p++; } // first char
@@ -187,6 +188,11 @@ static int lua_unserialize_json(lua_State* L) {
 		}
 	}
 	// should never be here
+	zerror(L, "JSON unknown parser error");
+	zerror(L, "JSON input string size: %u",orig_size);
+	zerror(L, "JSON parser level: %u", level);
+	for(int i=level; i>0; i--)
+		zerror(L,"JSON parser bracket[%u] = '%c'",i,brakets[i]);
 	lerror(L, "JSON has malformed beginning or end");
 	return 0;
 }

--- a/src/zen_random.c
+++ b/src/zen_random.c
@@ -84,22 +84,25 @@ void* rng_alloc(zenroom_t *ZZ) {
 
 
 static int rng_uint8(lua_State *L) {
+	BEGIN();
 	Z(L);
 	uint8_t res = RAND_byte(Z->random_generator);
 	lua_pushinteger(L, (lua_Integer)res);
-	return(1);
+	END(1);
 }
 
 static int rng_uint16(lua_State *L) {
+	BEGIN();
 	Z(L);
 	uint16_t res =
 		RAND_byte(Z->random_generator)
 		| (uint32_t) RAND_byte(Z->random_generator) << 8;
 	lua_pushinteger(L, (lua_Integer)res);
-	return(1);
+	END(1);
 }
 
 static int rng_int32(lua_State *L) {
+	BEGIN();
 	Z(L);
 	uint32_t res =
 		RAND_byte(Z->random_generator)
@@ -107,9 +110,11 @@ static int rng_int32(lua_State *L) {
 		| (uint32_t) RAND_byte(Z->random_generator) << 16
 		| (uint32_t) RAND_byte(Z->random_generator) << 24;
 	lua_pushinteger(L, (lua_Integer)res);
-	return(1);
+	END(1);
 }
 
+// this is not really useful, however prints current seed as a table
+// of integer values. Current seed is the octet global RNGSEED.
 static int rng_rr256(lua_State *L) {
   Z(L);
 	lua_newtable(L);

--- a/test/benchmark/bbs/hamming.lua
+++ b/test/benchmark/bbs/hamming.lua
@@ -1,0 +1,65 @@
+warn 'BBS+ hamming benchmarks'
+
+SAMPLES = os.getenv('BBS_HAMMING_SAMPLES')
+if not SAMPLES then SAMPLES = 10 end
+warn ('SAMPLES: '..SAMPLES)
+B3 = BBS.ciphersuite'shake256'
+
+local kp = keygen(B3)
+
+local msg = { OCTET.random(512) }
+local idx = { 1 }
+
+local signed = sign(B3, kp, msg)
+
+local prev = create_proof(B3, kp.pk, signed, msg, idx)
+local bbs_hammings = { }
+for i=1,SAMPLES do
+    local proof = create_proof(B3, kp.pk, signed, msg, idx)
+    table.insert(bbs_hammings, O.hamming(proof, prev))
+end
+
+-- save length of BBS proofs
+local rlen = #prev
+warn('BBS proof length: '..rlen)
+
+
+-- use zenroom runtime seed
+local prng_hammings = { }
+for i=1,SAMPLES do
+    table.insert(prng_hammings, O.hamming(O.random(rlen), O.random(rlen)))
+end
+
+-- static seed retrieved from third-party to measure the PRNG
+-- hamming. To get a new one copy here by hand the output of:
+-- `make random_org_seed`
+warn 'static benchmark seed from random.org'
+random_org = JSON.decode(KEYS)
+random_seed(OCTET.from_hex(random_org.seed))
+
+local extrng_hammings = { }
+for i=1,SAMPLES do
+    table.insert(extrng_hammings, O.hamming(O.random(rlen), O.random(rlen)))
+end
+
+warn 'random sequence from OpenSSL'
+openssl = JSON.decode(DATA)
+warn( 'SSL rand table length: '..table_size(openssl))
+local openssl_hammings = { }
+for i=1,SAMPLES*2,2 do
+    -- I.warn({ i=i, l=openssl[i], r=openssl[i+1] })
+    table.insert(openssl_hammings, O.hamming(
+                     O.from_hex(openssl[i]), O.from_hex(openssl[i+1])))
+end
+
+print "BBS+ \t PRNG \t RORG \t OSSL"
+for i=1,SAMPLES do
+    print(bbs_hammings[i]..
+          " \t "..prng_hammings[i]..
+          " \t "..extrng_hammings[i]..
+          " \t "..openssl_hammings[i]
+    )
+end
+
+
+warn("Shannon "..prev:entropy())

--- a/test/benchmark/bbs/hamming.sh
+++ b/test/benchmark/bbs/hamming.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+# entropy benchmark of BBS+ - for info see:
+# https://news.dyne.org/benchmark-of-the-bbs-signature-scheme-v06/
+
+# 272 is the byte length of a BBS+ proof
+
+set -e # fail on any error
+
+ZENROOM=../../../src/zenroom
+if ! [ -x ${ZENROOM} ]; then ZENROOM=`which zenroom`; fi
+if ! [ -x ${ZENROOM} ]; then
+	>&2 echo "Zenroom binary not found, please install from Zenroom.org"
+	exit 1
+fi
+>&2 echo "Zenroom binary used: ${ZENROOM}"
+
+gen_openssl() {
+	local ds=$(( ${1} * 2 ))
+	>&2 echo "Generating OpenSSL samples: $ds"
+	echo -n '['
+	for i in `seq ${ds}`; do
+		echo -n "\"`openssl rand -hex 272`\","
+		>&2 echo -n '.'
+	done
+	>&2 echo '.'
+	echo "\"00\"]"
+}
+
+seed_random_org() {
+	>&2 echo "Getting a new seed from random.org"
+	echo -n '{"seed":"'
+	curl -sL "https://www.random.org/cgi-bin/randbyte?nbytes=64&format=h" \
+		| sed 's/ //g;' | tr -d '\n'
+	echo '"}'
+}
+
+calculate_hamming() {
+	local SAMPLES=${1:-10}
+	>&2 echo "Calculating hamming distance with samples: $SAMPLES"
+	[ -r openssl${SAMPLES}.json ] || \
+		gen_openssl ${SAMPLES} > openssl${SAMPLES}.json
+	seed_random_org        > random_org.json
+	>&2 cat random_org.json
+	BBS_HAMMING_SAMPLES=${SAMPLES} \
+					   ${ZENROOM} -l common.lua \
+					   -a openssl${SAMPLES}.json -k random_org.json \
+					   hamming.lua > "hamming_samples${SAMPLES}.txt"
+	if [ $? != 0 ]; then
+		>&2 echo "Calculation error: hamming_samples${SAMPLES}.txt"
+		return 1
+	fi
+}
+
+render_hamming() {
+	SAMPLES=${1:-10}
+	FILE=hamming_samples${SAMPLES}
+	if ! [ -s ${FILE}.txt ]; then
+		>&2 echo "Hamming samples file is empty: ${FILE}.txt"
+	else
+		>&2 echo "Rendering hamming distance with samples: $SAMPLES"
+		cat <<EOF | gnuplot > ${FILE}.png
+set title "Hamming distance between BBS+ unlinkable proofs (${SAMPLES} samples)"
+set style fill transparent solid 0.25 border
+set terminal pngcairo dashed rounded size 1024,768
+set xlabel "hamming distance in bits"
+set ylabel "frequency"
+plot for[col=1:4] '${FILE}.txt' using 1:col title columnheader smooth frequency with fillsteps linetype col
+EOF
+	fi
+}
+
+[ -r hamming_samples10.txt ] || calculate_hamming 10
+render_hamming 10
+
+[ -r hamming_samples100.txt ] || calculate_hamming 100
+render_hamming 100
+
+[ -r hamming_samples1000.txt ] || calculate_hamming 1000
+render_hamming 1000

--- a/test/zencode/random.bats
+++ b/test/zencode/random.bats
@@ -16,6 +16,16 @@ EOF
     assert_output '{"dest":"XdjAYj+RY95+uyYMI8fR3+fmP5LyQaN54vyTTVKxZyA=","random":"XdjAYj+RY95+uyYMI8fR3+fmP5LyQaN54vyTTVKxZyA="}'
 }
 
+@test "Avoid regression bugs in random" {
+    cat <<EOF | zexe prng_regression.zen
+Given nothing
+When I create the random object of '32' bytes
+Then print the 'random object' as 'hex'
+EOF
+    save_output "prng_regression.out"
+    assert_output '{"random_object":"5dd8c0623f9163de7ebb260c23c7d1dfe7e63f92f241a379e2fc934d52b16720"}'
+}
+
 @test "Read seed for random" {
     cat <<EOF | save_asset zeroseed.json
 {"zeroseed": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}
@@ -23,18 +33,18 @@ EOF
     cat <<EOF | zexe seed.zen zeroseed.json
 Given I have a 'hex' named 'zeroseed'
 
-When I create the random object of '16' bytes
+When I create the random object of '32' bytes
 and I rename 'random object' to 'first'
 
 When I seed the random with 'zeroseed'
-and I create the random object of '16' bytes
+and I create the random object of '32' bytes
 
 When I verify 'random object' is equal to 'first'
 
-Then print string 'random seed OK'
+Then print the 'random object' as 'hex'
 EOF
     save_output "seed.out"
-    assert_output '{"output":["random_seed_OK"]}'
+    assert_output '{"random_object":"5dd8c0623f9163de7ebb260c23c7d1dfe7e63f92f241a379e2fc934d52b16720"}'
 }
 
 @test "Random from array" {


### PR DESCRIPTION
This small PR adds the `random_seed(OCTET)` global Lua function that allows to re-seed the PRNG in Zenroom at any moment during runtime.

It also improves an error message in the JSON pre-parser and updates a bit the random generation code.

At last it adds the new BBS+ benchmark on which I'm working for this article
https://news.dyne.org/benchmark-of-the-bbs-signature-scheme-v06/