### PR TITLE
Add readline-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM alpine:latest
 
 ADD . /
 
-RUN apk add --no-cache zsh linux-headers build-base cmake
+RUN apk add --no-cache zsh linux-headers build-base cmake readline-dev
 RUN make linux
 RUN cp /src/zenroom /usr/local/bin/zenroom
 


### PR DESCRIPTION
We add readline-dev to Dockerfile

RUN apk add --no-cache zsh linux-headers build-base cmake readline-dev

An error occurred while compiling the image:

**cannot find -lreadline: No such file or directory**

`In file included from zencode-exec.c:30:
/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
    1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
      |  ^~~~~~~
gcc -O2 -fstack-protector-all -D_FORTIFY_SOURCE=2 -fno-strict-overflow -fPIE -fPIC -I. -I../lib/lua54/src -I../lib/milagro-crypto-c/build/include -I../lib/milagro-crypto-c/include -I../lib/ed25519-donna -I../lib/mimalloc/include -Wall -Wextra zenroom.o zen_error.o lua_functions.o lua_modules.o lualibs_detected.o lua_shims.o encoding.o base58.o rmd160.o segwit_addr.o zen_memory.o mutt_sprintf.o zen_io.o zen_parse.o repl.o zen_config.o zen_octet.o zen_ecp.o zen_ecp2.o zen_big.o zen_fp12.o zen_random.o zen_hash.o zen_ecdh_factory.o zen_ecdh.o zen_aes.o zen_qp.o zen_ed.o zen_float.o zen_time.o api_hash.o randombytes.o cortex_m.o p256-m.o zen_p256.o zen_rsa.o zen_bbs.o cli-zenroom.o -o zenroom -lm -lpthread -lreadline //lib/lua54/src/liblua.a //lib/milagro-crypto-c/build/lib/libamcl_curve_BLS381.a //lib/milagro-crypto-c/build/lib/libamcl_pairing_BLS381.a //lib/milagro-crypto-c/build/lib/libamcl_curve_SECP256K1.a //lib/milagro-crypto-c/build/lib/libamcl_rsa_2048.a //lib/milagro-crypto-c/build/lib/libamcl_rsa_4096.a //lib/milagro-crypto-c/build/lib/libamcl_core.a //lib/pqclean/libqpz.a //lib/ed25519-donna/libed25519.a //lib/mimalloc/build/libmimalloc-static.a
/usr/lib/gcc/x86_64-alpine-linux-musl/13.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lreadline: No such file or directory
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:71: linux] Error 1
make[1]: Leaving directory '/src'
make: *** [//build/linux.mk:29: linux] Error 2
The command '/bin/sh -c make linux' returned a non-zero code: 2`