### PR TITLE
For docker image FROM python:3.9 need xxd also

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ ready to deploy.
 
 ## Build
 
-Dependencies: makefile, cmake, zsh, gcc, libreadline-dev
+Dependencies: makefile, cmake, zsh, gcc, libreadline-dev, xxd
 
 Optional: musl-libc, emscripten for wasm builds
 


### PR DESCRIPTION
Changes in ReadMe file about Dependencies from xxd

I use docker image FROM python:3.9
in order to install the package via github, because I think to add additional code to one lua file of the project and so that the changes are available via Python 3.8+ module zenroom