### PR TITLE
feat(sd_jwt): create the key-value table of disclosed informations

### DIFF
--- a/src/lua/zencode_sd_jwt.lua
+++ b/src/lua/zencode_sd_jwt.lua
@@ -478,3 +478,19 @@ IfWhen("verify signed selective disclosure '' issued by '' is valid", function(o
     end
 
 end)
+
+When("create disclosed informations from signed selective disclosure ''", function(ssd_name)
+    local ssd, ssd_c = have(ssd_name)
+    zencode_assert(ssd_c.schema and ssd_c.schema == "signed_selective_disclosure",
+        "Object is not a signed selective disclosure: " .. ssd_name)
+    local disclosed_informations = {}
+    for _, v in pairs(ssd.disclosures) do
+        disclosed_informations[v[2]:str()] = v[3]
+    end
+    ACK.disclosed_informations = disclosed_informations
+    new_codec('disclosed_informations', {
+        encoding = 'string',
+        luatype = 'table',
+        zentype = 'd'
+    })
+end)

--- a/test/zencode/sd_jwt.bats
+++ b/test/zencode/sd_jwt.bats
@@ -528,3 +528,18 @@ EOF
     #test vector from App. A.3 of https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-07.txt
     #issuer key from https://github.com/oauth-wg/oauth-selective-disclosure-jwt/blob/master/examples/settings.yml
 }
+
+@test "create table of disclosed informations" {
+    cat <<EOF | zexe create_disclosed_informations.zen test_A3.out.json
+Scenario 'sd_jwt'
+
+Given I have 'signed_selective_disclosure'
+
+When I create the disclosed informations from signed selective disclosure 'signed_selective_disclosure'
+
+Then print the 'disclosed_informations'
+
+EOF
+    save_output create_disclosed_informations.out.json
+    assert_output '{"disclosed_informations":{"address":{"country_code":"DE","locality":"Irgendwo","postal_code":"12345","street_address":"Sonnenstrasse 23"},"birth_family_name":"Schmidt","birthdate":"1973-01-01","family_name":"Mustermann","first_name":"Erika","is_over_18":true,"is_over_21":true,"is_over_65":false,"nationalities":[{"...":"JuL32QXDzizl-L6CLrfxfjpZsX3O6vsfpCVd1jkwJYg"}]}}'
+}


### PR DESCRIPTION
Utility that will simplify the code in the relying party.

I'm not so sure about the name `disclosed informations`, maybe there is a proper name for this object?
