### PR TITLE
fix(http): separate hostname and port before host checks

### DIFF
--- a/src/lua/zencode_http.lua
+++ b/src/lua/zencode_http.lua
@@ -140,7 +140,12 @@ function is_valid_uri(uri)
         error("invalid uri, missing scheme in '" .. uri .. "'", 2)
     end
     if parsed.authority ~= "" then
-        local host_error = _is_valid_host(parsed.authority)
+        local authority_pattern = "^([^:]+):?(%d*)$"
+        parsed.hostname, parsed.port = parsed.authority:match(authority_pattern)
+        if parsed.port ~= "" and not tonumber(parsed.port) then
+            error("invalid port in '" .. parsed.authority .. "'", 2)
+        end
+        local host_error = _is_valid_host(parsed.hostname)
         if host_error then
             error(host_error, 2)
         end

--- a/test/zencode/http.bats
+++ b/test/zencode/http.bats
@@ -287,3 +287,22 @@ EOF
     save_output 'append_different_values.json'
     assert_output '{"another_url":"openid-credential-issuer://www.example.com?param1=value1&param2=1000&param3=2000&param4=3000","url":"openid-credential-issuer://www.example.com?param1=value1&param2=1000&param3=2000&param4=3000"}'
 }
+
+@test "url with port" {
+    cat <<EOF | save_asset url_with_port.data
+{
+    "url_with_port": "http://127.0.0.1:8080/some/api"
+}
+EOF
+    cat <<EOF | zexe url_with_port.zen url_with_port.data
+Scenario 'http': url with port
+
+Given I have a 'string' named 'url_with_port'
+
+When I create the url from 'url_with_port'
+
+Then print the 'url'
+EOF
+    save_output 'url_with_port.json'
+    assert_output '{"url":"http://127.0.0.1:8080/some/api"}'
+}


### PR DESCRIPTION
- fix(http): separate hostname and port before host checks
- test(http): parse url with port
