### PR TITLE
fix: minus sign in parathesis

### DIFF
--- a/src/lua/zencode_when.lua
+++ b/src/lua/zencode_when.lua
@@ -716,8 +716,9 @@ When("create result of ''", function(expr)
   -- infix to RPN
   local rpn = {}
   local operators = {}
+  local last_token
   for k, v in pairs(tokens) do
-    if v == '-' and (#rpn == 0 or operators[#operators] == '(') then
+    if v == '-' and (#rpn == 0 or last_token == '(' ) then
         table.insert(operators, '~') -- unary minus (change sign)
     elseif priorities[v] then
       while #operators > 0 and operators[#operators] ~= '('
@@ -739,6 +740,7 @@ When("create result of ''", function(expr)
     else
       table.insert(rpn, v)
     end
+    last_token=v
   end
 
   -- all remaining operators have to be applied

--- a/test/zencode/numbers.bats
+++ b/test/zencode/numbers.bats
@@ -381,10 +381,12 @@ When I create the result of 'the solution / (a + b + 1)'
 and I rename 'result' to 'expr8'
 When I create the result of '-a * (-b -c - (-c+d))'
 and I rename 'result' to 'expr9'
+When I create the result of '-b * a * ( b - a )'
+and I rename 'result' to 'expr10'
 Then print data
 EOF
     save_output 'expressions.out'
-    assert_output '{"a":"1","b":"2","c":"-3","d":"4","expr1":"-1","expr2":"-1","expr3":"-43","expr4":"7011","expr5":"-44","expr6":"17","expr7":"-404","expr8":"10","expr9":"6","the_solution":"42"}'
+    assert_output '{"a":"1","b":"2","c":"-3","d":"4","expr1":"-1","expr10":"-2","expr2":"-1","expr3":"-43","expr4":"7011","expr5":"-44","expr6":"17","expr7":"-404","expr8":"10","expr9":"6","the_solution":"42"}'
 
 }
 


### PR DESCRIPTION
first minus sign in paranthesis was always considered as unary minus also in case like (a-b) leading to errors
