### PR TITLE
feat: add support for array and key as a variable in "copy/move from to" statement

### DIFF
--- a/src/lua/zencode_array.lua
+++ b/src/lua/zencode_array.lua
@@ -27,22 +27,27 @@ When("create new array", function()
 	new_codec('new array', {zentype='a'})
 end)
 
-When("create copy of element '' from array ''", function(pos, arr)
-	empty 'copy'
-	local src, src_codec = have(arr)
-	zencode_assert(src_codec.zentype == "a", "Not an array: "..arr)
-	local num = tonumber(mayhave(pos) or pos)
-	zencode_assert(num, "Argument is not a position number: "..pos)
-	zencode_assert(src[num], "No element found in: "..arr.."["..pos.."]")
-	ACK.copy = src[num]
-	local n_codec = { encoding = src_codec.encoding }
-	-- table of schemas can only contain elements
-	if src_codec.schema then
-		n_codec.schema = src_codec.schema
-		n_codec.zentype = "e"
-	end
-	new_codec('copy', n_codec)
-end)
+When(deprecated(
+		"create copy of element '' from array ''",
+		"copy '' from '' to ''",
+		function(pos, arr)
+			empty 'copy'
+			local src, src_codec = have(arr)
+			zencode_assert(src_codec.zentype == "a", "Not an array: "..arr)
+			local num = tonumber(mayhave(pos) or pos)
+			zencode_assert(num, "Argument is not a position number: "..pos)
+			zencode_assert(src[num], "No element found in: "..arr.."["..pos.."]")
+			ACK.copy = src[num]
+			local n_codec = { encoding = src_codec.encoding }
+			-- table of schemas can only contain elements
+			if src_codec.schema then
+				n_codec.schema = src_codec.schema
+				n_codec.zentype = "e"
+			end
+			new_codec('copy', n_codec)
+		end
+	)
+)
 
 local function _insert_in(what, dest)
 	local d, d_codec = have(dest)

--- a/src/lua/zencode_when.lua
+++ b/src/lua/zencode_when.lua
@@ -316,15 +316,44 @@ When("copy contents of '' named '' in ''", function(src,name,dst)
     end
 end)
 
-local function move_or_copy_from_to(ele, source, new)
+local function move_or_copy_from_to(key_name, source, new)
     local src, src_codec = have(source)
-    zencode_assert(src[ele], "Object not found: "..ele.." inside "..source)
+    local key, key_enc = mayhave(key_name)
+    if src_codec.zentype == 'a' then
+        if key then
+            if key_enc.encoding == "string" then
+                key = key:str()
+            elseif key_enc.encoding == "integer" then
+                key = key:decimal()
+            elseif key_enc.encoding == "float" then
+                key = key:__tostring()
+            else
+                error("Invalid array key encoding: "..key_enc.encoding, 2)
+            end
+        else
+            key = key_name
+        end
+        local pos = tonumber(key)
+        if not pos then error("Invalid array index: "..key, 2) end
+        key = pos
+    else
+        if key then
+            if key_enc.encoding == "string" then
+                key = key:str()
+            else
+                error("Invalid dictionary key encoding: "..key_enc.encoding, 2)
+            end
+        else
+            key = key_name
+        end
+    end
+    if not src[key] then error("Object not found: "..key.." inside "..source, 2) end
     if ACK[new] then
         error("Cannot overwrite existing object: "..new.."\n"..
               "To copy/move element in existing element use:\n"..
               "When I move/copy '' from '' in ''", 2)
     end
-    ACK[new] = deepcopy(src[ele])
+    ACK[new] = deepcopy(src[key])
     local n_codec = { encoding = src_codec.encoding }
     -- table of schemas can only contain elements
     if src_codec.schema then
@@ -332,13 +361,18 @@ local function move_or_copy_from_to(ele, source, new)
         n_codec.zentype = "e"
     end
     new_codec(new, n_codec)
+    return src_codec.zentype == 'a', key
 end
 
 When("copy '' from '' to ''", move_or_copy_from_to)
 
 When("move '' from '' to ''", function(ele, source, new)
-    move_or_copy_from_to(ele, source, new)
-    ACK[source][ele] = nil
+    local is_array, to_remove = move_or_copy_from_to(ele, source, new)
+    if is_array then
+        table.remove(ACK[source], to_remove)
+    else
+        ACK[source][to_remove] = nil
+    end
 end)
 
 When("split rightmost '' bytes of ''", function(len, src)

--- a/test/zencode/array.bats
+++ b/test/zencode/array.bats
@@ -892,7 +892,7 @@ EOF
 Given I have a 'string array' named 'array'
 
 When I create the size of 'array'
-and I create the copy of element 'size' from array 'array'
+and I copy 'size' from 'array' to 'copy'
 
 Then print the 'copy'
 EOF
@@ -1014,7 +1014,7 @@ EOF
     cat << EOF | zexe copy_from_schema_array.zen copy_from_schema_array.data
 Scenario 'ethereum': copy element
 Given I have a 'ethereum address signature pair array' named 'addresses_signatures'
-When I create the copy of element '1' from array 'addresses_signatures'
+When I copy '1' from 'addresses_signatures' to 'copy'
 Then print the 'copy'
 EOF
     save_output 'copy_from_schema_array.json'

--- a/test/zencode/cookbook_when.bats
+++ b/test/zencode/cookbook_when.bats
@@ -253,8 +253,7 @@ When I copy 'myFirstArray' to 'copyOfMyFirstArray'
 # You can copy a certain element from an array, to a new object named "copy", with the
 # same encoding of the array, in the root level of the data. 
 # We are immeediately renaming the outout for your convenience.
-When I create the copy of element '3' from array 'myFourthArray'
-and I rename the 'copy' to 'copyOfElement3OfmyFourthArray'
+When I copy '3' from 'myFourthArray' to 'copyOfElement3OfmyFourthArray'
 
 # SPLIT (leftmost, rightmost)
 # The "split" statements, take as input the name of a string and a numeric value,
@@ -525,7 +524,7 @@ When I create the variance of elements in array 'mySecondNumberArray'
 # COPY ELEMENT
 # This statement creates a an object named "copy" containing
 # the given element of the array
-When I create the copy of element '2' from array 'mySecondNumberArray'
+When I copy '2' from 'mySecondNumberArray' to 'copy'
 
 # REMOVE
 # The "remove" statement does the opposite of the one above:

--- a/test/zencode/when.bats
+++ b/test/zencode/when.bats
@@ -453,3 +453,55 @@ EOF
     save_output move_from_to_existing_obj.out.json
     assert_output '{"new_ecdh_siganture_with_string_encoding":{"r":"d2tYw0FFyVU7UjX+IRpiN8SLkLR4S8bYZmCwI2rzurI=","s":"vUljXtnKkBqle/Ik7y3GfMa1o3wEIi4lRC+b/KmVbaI="},"string_from_base64":"hello my friend"}'
 }
+
+@test "move or copy from a dictiopnary and array" {
+    cat <<EOF | save_asset copy_move_from_to.data.json
+{
+    "dict_from": {
+        "str_1": "hello",
+        "str_2": "world",
+        "str_3": "!"
+    },
+    "array_from": [
+        "hello",
+        "world",
+        "!"
+    ],
+    "str_pos_for_dict": "str_3",
+    "str_pos_for_array": "3",
+    "int_pos": "3",
+    "float_pos": 3
+}
+EOF
+    cat <<EOF | zexe copy_move_from_to.zen copy_move_from_to.data.json
+Given I  have a 'string dictionary' named 'dict_from'
+and I have a 'string array' named 'array_from'
+and I have a 'integer' named 'int_pos'
+and I have a 'string' named 'str_pos_for_array'
+and I have a 'string' named 'str_pos_for_dict'
+and I have a 'float' named 'float_pos'
+
+
+When I copy 'str_2' from 'dict_from' to 'string_copied_from_dict'
+When I copy 'str_pos_for_dict' from 'dict_from' to 'string_copied_from_dict_with_str_pos'
+
+When I copy '2' from 'array_from' to 'string_copied_from_array'
+When I copy 'str_pos_for_array' from 'array_from' to 'string_copied_from_array_with_str_pos'
+When I copy 'int_pos' from 'array_from' to 'string_copied_from_array_with_int_pos'
+When I copy 'float_pos' from 'array_from' to 'string_copied_from_array_with_float_pos'
+
+When I move 'str_1' from 'dict_from' to 'string_moved_from_dict'
+When I move 'str_pos_for_dict' from 'dict_from' to 'string_moved_from_dict_with_str_pos'
+
+When I move 'str_pos_for_array' from 'array_from' to 'string_moved_from_array_with_str_pos'
+and I copy 'string_moved_from_array_with_str_pos' in 'array_from'
+When I move 'int_pos' from 'array_from' to 'string_moved_from_array_with_int_pos'
+and I copy 'string_moved_from_array_with_int_pos' in 'array_from'
+When I move 'float_pos' from 'array_from' to 'string_moved_from_array_with_float_pos'
+When I move '1' from 'array_from' to 'string_moved_from_array'
+
+Then print the data
+EOF
+    save_output copy_move_from_to.out.json
+    assert_output '{"array_from":["world"],"dict_from":{"str_2":"world"},"float_pos":3,"int_pos":"3","str_pos_for_array":"3","str_pos_for_dict":"str_3","string_copied_from_array":"world","string_copied_from_array_with_float_pos":"!","string_copied_from_array_with_int_pos":"!","string_copied_from_array_with_str_pos":"!","string_copied_from_dict":"world","string_copied_from_dict_with_str_pos":"!","string_moved_from_array":"hello","string_moved_from_array_with_float_pos":"!","string_moved_from_array_with_int_pos":"!","string_moved_from_array_with_str_pos":"!","string_moved_from_dict":"hello","string_moved_from_dict_with_str_pos":"!"}'
+}


### PR DESCRIPTION
deprecate "create copy of element '' from array ''" in favour of the latter
