### PR TITLE
fix: use debug encoding on debug heap dump

### DIFF
--- a/src/lua/zencode_debug.lua
+++ b/src/lua/zencode_debug.lua
@@ -85,7 +85,8 @@ local function debug_heap_dump()
 				CODEC = CODEC,
 				WHEN = ack,
 				THEN = OUT,
-				CACHE = CACHE})))
+				CACHE = CACHE},
+                CONF.debug.encoding.name)))
 	  if LOGFMT == 'JSON' then tmp = '"'..tmp..'",' end
 	  printerr(tmp)
    else -- CONF.debug.format == 'log'

--- a/src/lua/zencode_when.lua
+++ b/src/lua/zencode_when.lua
@@ -237,7 +237,7 @@ end)
 local function move_or_copy_to(src, dest, enc)
     empty(dest)
     if not enc then
-        ACK[dest] = deepcopy(ACK[src])
+        ACK[dest] = deepcopy(have(src))
         new_codec(dest, { }, src)
     else
         ACK[dest] = apply_encoding(src, enc, "string")


### PR DESCRIPTION
- fix: use debug encoding on debug heap dump
- fix: in "copy to" statement check for source existance
