### PR TITLE
refactor(hash): improve code readability, try to avoid multiple hash initialization and expose also shake256 in zencode hash statement

### DIFF
--- a/src/lua/zencode_hash.lua
+++ b/src/lua/zencode_hash.lua
@@ -17,37 +17,29 @@
 --If not, see http://www.gnu.org/licenses/agpl.txt
 --
 --Last modified by Denis Roio
---on Friday, 26th November 2021
+--on Monday, 13th January 2025
 --]]
 
 
--- hashing single strings
-When("create hash of ''",function(s)
-        local src = have(s)
-        if luatype(src) == 'table' then
-            src = zencode_serialize(src) -- serialize tables using zenroom's algo
-        end
-        ACK.hash = HASH.new(CONF.hash):process(src)
-	new_codec('hash', { zentype = 'e' })
-    end
-)
+-- hashing
+local valid_hashes <const> = {
+    sha256 = true,
+    sha512 = true,
+    shake256 = true,
+    keccak256 = true
+}
+local function _hash(s, n)
+    local src = have(s)
+    n = n or CONF.hash
+    -- serialize tables using zenroom's algo
+    src = zencode_serialize(src)
+    if not valid_hashes[n] then error("Hash algorithm not known: ".. n) end
+    ACK.hash = HASH[n](src)
+    new_codec('hash', { zentype = 'e' })
+end
 
-When("create hash of '' using ''",function(s, h)
-        local src = have(s)
-        if luatype(src) == 'table' then
-            src = zencode_serialize(src)
-        end
-        if strcasecmp(h, 'sha256') then
-            ACK.hash = sha256(src)
-        elseif strcasecmp(h, 'sha512') then
-            ACK.hash = sha512(src)
-        elseif strcasecmp(h, 'keccak256') then
-            ACK.hash = HASH.keccak256(src)
-        end
-        zencode_assert(ACK.hash, 'Invalid hash: ' .. h)
-	new_codec('hash', { zentype = 'e' })
-    end
-)
+When("create hash of ''", _hash)
+When("create hash of '' using ''", _hash)
 
 When("create hash to point '' of ''",function(curve, object)
     local F = _G[curve]

--- a/src/lua/zenroom_hash.lua
+++ b/src/lua/zenroom_hash.lua
@@ -50,12 +50,12 @@ hash.keccak256 = function(data) return init("keccak256"):process(data) end
 function KDF(data, bits) return init("sha"..tostring(bits or 256)):kdf2(data) end
 
 function hash.dsha256(msg)
-   local _SHA256 = HASH.new('sha256')
+   local _SHA256 = init('sha256')
    return _SHA256:process(_SHA256:process(msg))
 end
 
 function hash.hash160(msg)
-   local _SHA256 = HASH.new('sha256')
+   local _SHA256 = init('sha256')
    local _RMD160 = HASH.new('ripemd160')
    return _RMD160:process(_SHA256:process(msg))
 
@@ -63,12 +63,12 @@ end
 
 --used in BBS+ signature
 hash.hkdf_extract = function(salt, ikm)
-	return HASH.hmac(hash.new('sha256'), salt, ikm)
+	return HASH.hmac(init('sha256'), salt, ikm)
 end
 
 --used in BBS+ signature
 hash.hkdf_expand = function(prk, info, l)
-	local h = hash.new('sha256')
+	local h = init('sha256')
 	local hash_len = 32
 	assert(#prk >= hash_len)
 	assert(l <= 255 * hash_len)

--- a/src/lua/zenroom_hash.lua
+++ b/src/lua/zenroom_hash.lua
@@ -16,8 +16,8 @@
 --GNU Affero General Public License v3.0
 --If not, see http://www.gnu.org/licenses/agpl.txt
 --
---Last modified by Denis Roio
---on Tuesday, 20th July 2021
+--Last modified by Matteo Cristino
+--on Monday, 13th January 2025
 --]]
 
 local hash = require'hash'
@@ -27,7 +27,7 @@ local SHA256 = nil
 local SHA512 = nil
 local SHAKE256 = nil
 local KECCAK256 = nil
-local hash_init_table = {
+local hash_init_table <const> = {
     sha32 = function() SHA256 = SHA256 or hash.new('sha256'); return SHA256 end,
     sha256 = function() SHA256 = SHA256 or hash.new('sha256'); return SHA256 end,
     sha64 = function() SHA512 = SHA512 or hash.new('sha512'); return SHA512 end,
@@ -44,6 +44,8 @@ end
 function sha256(data) return init("sha256"):process(data) end
 function sha512(data) return init("sha512"):process(data) end
 
+hash.sha256 = sha256
+hash.sha512 = sha512
 hash.shake256 = function(data, len) return init("shake256"):process(data, len or 32) end
 hash.keccak256 = function(data) return init("keccak256"):process(data) end
 

--- a/test/zencode/rules.bats
+++ b/test/zencode/rules.bats
@@ -243,7 +243,7 @@ and I create the hash of 'source'
 Then print 'hash'
 EOF
     run $ZENROOM_EXECUTABLE -z set_fail.zen
-    assert_line '[!]  Hash algorithm not known: sha123'
+    assert_line --partial 'Hash algorithm not known: sha123'
 }
 
 # --- Rule invalid --- #


### PR DESCRIPTION
- **refactor(zenroom_hash): improve code readibility in hash initialization**
- **refactor(zenroom_hash): if present use already initialize hash everywhere**
- **refactor: more readable and easy to extend code for hashing statements**
