### PR TITLE
chore: modified bbs.sign()

### DIFF
--- a/src/lua/crypto_bbs.lua
+++ b/src/lua/crypto_bbs.lua
@@ -381,6 +381,10 @@ OUTPUT: the signature (A,e)
 ]]
 function bbs.sign(ciphersuite, sk, pk, header, messages_octets)
 
+    -- Checking the correctness of the input public key pk 
+    if pk ~= (ECP2.generator() * sk):to_zcash() then
+            error('Error in the public key generation')
+    end
     -- Default values for header and messages.
     if not messages_octets then
             error('Empty message argument in BBS.sign',2)

--- a/src/lua/crypto_bbs.lua
+++ b/src/lua/crypto_bbs.lua
@@ -382,8 +382,8 @@ OUTPUT: the signature (A,e)
 function bbs.sign(ciphersuite, sk, pk, header, messages_octets)
 
     -- Checking the correctness of the input public key pk 
-    if pk ~= (ECP2.generator() * sk):to_zcash() then
-            error('Error in the public key generation')
+    if pk == nil then
+            error('Error: public key mismatch',2)
     end
     -- Default values for header and messages.
     if not messages_octets then


### PR DESCRIPTION
We have modified bbs.sign:
- adding a check that the public key (pk) is not nil
- modifying the error description 

In addition we have noted, according  with the documentation, that is not necessary to have the public key in the input of bbs.sign(). It should be sufficient to generate it into the function since the public key pk is used only in the core.sign() into bbs.sign().
However if we had removed pk from the input of bbs.sign(), the test should have been modified, too.