### PR TITLE
feat: first mod of sd-jwt to support algo setting in sig

### DIFF
--- a/src/lua/crypto_sd_jwt.lua
+++ b/src/lua/crypto_sd_jwt.lua
@@ -47,6 +47,7 @@ local function export_str_dict(obj)
 		 end
 	  elseif tv == 'zenroom.octet' then res = v:str()
 	  elseif tv == 'boolean' then res = v
+      -- elseif iszen(tv) then res = v:octet():str()
 	  else
  		 error("Invalid value found in SD-JWT array: "..tv)
 	  end
@@ -139,10 +140,10 @@ end
 -- but we are in zenroom and if I print the same object I obtain the
 -- same representation, thus I can keep the object and print it only
 -- on export, yay!
-function sd_jwt.create_jwt_es256(payload, sk)
+function sd_jwt.create_jwt(payload, sk, algo)
     local header, b64header, b64payload, hmac
     header = {
-        alg=O.from_string("ES256"),
+        alg=O.from_string(algo.name),
         typ=O.from_string("vc+sd-jwt")
     }
     local payload_str = export_str_dict(payload)
@@ -150,7 +151,7 @@ function sd_jwt.create_jwt_es256(payload, sk)
     local header_str = export_str_dict(header)
     b64header = O.from_string(JSON.raw_encode(header_str, true)):url64()
 
-    local signature = ES256.sign(sk, O.from_string(b64header .. "." .. b64payload))
+    local signature = algo.sign(sk, O.from_string(b64header .. "." .. b64payload))
     return {
         header=header,
         payload=payload,

--- a/src/lua/zencode_es256.lua
+++ b/src/lua/zencode_es256.lua
@@ -20,7 +20,7 @@
 --
 --]]
 
-local ES256 = require('es256')
+ES256 = require_once('es256')
 
 local function public_key_f(obj)
 	local res = schema_get(obj, '.')

--- a/src/lua/zencode_sd_jwt.lua
+++ b/src/lua/zencode_sd_jwt.lua
@@ -381,13 +381,43 @@ When("create selective disclosure of ''", function(sdr_name)
 end)
 
 When("create signed selective disclosure of ''", function(sdp_name)
-    local p256 = havekey'es256'
-    local sdp = have(sdp_name)
+    local p256 <const> = havekey'es256'
+    local sdp <const> = have(sdp_name)
+    ACK.signed_selective_disclosure =
+        {
+            jwt = SD_JWT.create_jwt(
+                sdp.payload, p256,
+                { sign = ES256.sign,
+                  name = 'ES256' }),
+            disclosures = sdp.disclosures,
+        }
+    new_codec('signed_selective_disclosure')
+end)
 
-    ACK.signed_selective_disclosure = {
-        jwt=SD_JWT.create_jwt_es256(sdp.payload, p256),
-        disclosures=sdp.disclosures,
-    }
+When("create signed selective disclosure of '' with ''",
+     function(sdp_name, algo)
+    local sk <const> = havekey(algo:lower())
+    local sdp <const> = have(sdp_name)
+    local alg <const> = algo:upper()
+    local crypto = { }
+    if alg == 'ES256' then
+        crypto.sign = ES256.sign
+    elseif alg == 'EDDSA' then
+        crypto.sign = ED.sign
+    elseif alg == 'MLDSA44' then
+        crypto.sign = QP.mldsa44_signature
+    elseif alg == 'SECP256K1' then
+        crypto.sign = ECDH.sign
+    end
+    if not crypto.sign then
+        error("Unsupported SD-JWT signature: "..algo)
+    end
+    crypto.name = alg
+    ACK.signed_selective_disclosure =
+        {
+            jwt = SD_JWT.create_jwt(sdp.payload, sk, crypto),
+            disclosures = sdp.disclosures,
+        }
     new_codec('signed_selective_disclosure')
 end)
 

--- a/test/zencode/sd_jwt.bats
+++ b/test/zencode/sd_jwt.bats
@@ -14,7 +14,7 @@ SUBDOC=sd_jwt
         "credential_configurations_supported":{
             "IdentityCredential":{
                 "credential_signing_alg_values_supported":[
-                    "ES256"
+                    "ES256", "EDDSA", "MLDSA44"
                 ],
                 "cryptographic_binding_methods_supported":[
                     "jwk",
@@ -32,7 +32,7 @@ SUBDOC=sd_jwt
                 "proof_types_supported":{
                     "jwt":{
                         "proof_signing_alg_values_supported":[
-                            "ES256"
+                            "ES256", "EDDSA", "MLDSA44"
                         ]
                     }
                 },


### PR DESCRIPTION
The statement: `create signed selective disclosure of '' with ''` is now added to specify a string with name of algo, which is parsed internally with uppercase strings of algos set in sd-jwt structures