### PR TITLE
Fix/improve debug

### DIFF
--- a/src/lua/inspect.lua
+++ b/src/lua/inspect.lua
@@ -368,12 +368,23 @@ function Inspector:putValue(v, exp)
 	 self:putTable(v, exporter)
   elseif iszen(tv) then
 	 if tv == "zenroom.octet" then
-		if #v == 0 then self:puts("octet[0] (null)")
-		else self:puts("octet[" .. #v .. "] " .. exporter(v))
-		end
+         local len <const> = #v
+         if len == 0 then
+             self:puts("octet[0] (null)")
+         elseif self.schema and ( len == 16 or len == 32 or len == 64 ) then
+             self:puts("octet[" .. #v .. "] " .. O.to_hex(v))
+         elseif self.schema and len < 31 then
+             self:puts("octet[" .. #v .. "] " .. O.to_string(v))
+         else
+             self:puts("octet[" .. #v .. "] " .. exporter(v))
+         end
 	 elseif tv == "zenroom.big" then
-		local i = v:octet()
-		self:puts("int[" .. #i.. "] " .. exporter(v, "integer"))
+         local i <const> = v:octet()
+         if self.schema and #i < 8 then
+             self:puts("dec[" .. #i .."] ".. BIG.to_decimal(v))
+         else
+             self:puts("int[" .. #i.. "] " .. exporter(v, "integer"))
+         end
 	 elseif tv == "zenroom.float" then
 		self:puts("float " .. exporter(v, "float")) -- exporter(i))
 	 elseif tv == "zenroom.time" then
@@ -426,6 +437,7 @@ function inspect.inspect(root, options)
   end
 
   local inspector = setmetatable({
+    schema           = schema,
     depth            = depth,
     level            = 0,
     buffer           = {},

--- a/src/lua/zencode.lua
+++ b/src/lua/zencode.lua
@@ -830,6 +830,7 @@ function ZEN:run()
 function zenguard(val, key) -- AKA watchdog
    local tv <const> = type(val)
    if not (tv == 'boolean' or iszen(tv)) then
+	   ZEN:debug()
       error("Zenguard detected an invalid value in HEAP: "
 	    ..key.." ("..type(val)..")", 3)
       return nil

--- a/src/lua/zencode_debug.lua
+++ b/src/lua/zencode_debug.lua
@@ -72,16 +72,18 @@ When("trace", function() ZEN:debug_traceback() end)
 Then("trace", function() ZEN:debug_traceback() end)
 
 local function debug_heap_schema()
-    warn(I.inspect(
-             {
-                 a_GIVEN_in = IN,
-                 c_WHEN_ack = ACK,
-                 c_CODEC_ack = CODEC,
-                 c_CACHE_ack = CACHE,
-                 d_THEN_out = OUT
-             },
-       { schema = true }
-   )) -- print only keys without values
+    local _heap <const> = I.inspect({
+        a_CODEC_ack = CODEC,
+        b_GIVEN_in = IN,
+        c_WHEN_ack = ACK,
+        d_THEN_out = OUT
+    },{ schema = true })
+    -- print only keys without values
+    if CONF.debug.format == 'compact' and LOGFMT == 'JSON' then
+        printerr('"J64 HEAP: '..OCTET.from_string(_heap):base64()..'",')
+    else
+        warn(_heap)
+    end
 end
 
 local function debug_heap_dump()

--- a/src/lua/zencode_debug.lua
+++ b/src/lua/zencode_debug.lua
@@ -71,6 +71,19 @@ Given("trace", function() ZEN:debug_traceback() end)
 When("trace", function() ZEN:debug_traceback() end)
 Then("trace", function() ZEN:debug_traceback() end)
 
+local function debug_heap_schema()
+    warn(I.inspect(
+             {
+                 a_GIVEN_in = IN,
+                 c_WHEN_ack = ACK,
+                 c_CODEC_ack = CODEC,
+                 c_CACHE_ack = CACHE,
+                 d_THEN_out = OUT
+             },
+       { schema = true }
+   )) -- print only keys without values
+end
+
 local function debug_heap_dump()
    local ack <const> = ACK
    local keyring = ack.keyring
@@ -92,25 +105,18 @@ local function debug_heap_dump()
    else -- CONF.debug.format == 'log'
 	  -- ack.keyring = '(hidden)'
 	  if keyring then
-		 I.schema({KEYRING = keyring})
-		 ack.keyring = '(hidden)'
+          I.inspect({KEYRING = ack.keyring}, { schema = true })
+          ack.keyring = '(hidden)'
 	  end
-	  I.warn({a_GIVEN_in = IN,
-			  c_WHEN_ack = ack,
-			  c_CODEC_ack = CODEC,
-			  c_CACHE_ack = CACHE,
-			  d_THEN_out = OUT})
+      I.inspect({a_GIVEN_in = IN,
+                 c_WHEN_ack = ack,
+                 c_CODEC_ack = CODEC,
+                 c_CACHE_ack = CACHE,
+                 d_THEN_out = OUT},
+          { schema = true }
+      )
    end
    ack.keyring = keyring
-end
-
-local function debug_heap_schema()
-   I.schema({SCHEMA = {a_GIVEN_in = IN,
-					   c_WHEN_ack = ACK,
-					   c_CODEC_ack = CODEC,
-					   c_CACHE_ack = CACHE,
-					   d_THEN_out = OUT}})
-   -- print only keys without values
 end
 
 
@@ -129,16 +135,16 @@ zencode_assert = function(condition, errmsg)
 end
 
 function ZEN:debug()
-	debug_heap_dump()
+	debug_heap_schema()
 	ZEN:debug_traceback()
 end
 
 -- local function debug_obj_dump()
 -- local function debug_obj_schema()
 
-Given("debug", function() ZEN:debug() end)
-When("debug",  function() ZEN:debug() end)
-Then("debug",  function() ZEN:debug() end)
+Given("debug", function() debug_heap_schema() ZEN:debug_traceback() end)
+When("debug",  function() debug_heap_schema() ZEN:debug_traceback() end)
+Then("debug",  function() debug_heap_schema() ZEN:debug_traceback() end)
 
 Given("schema", function() debug_heap_schema() end)
 When("schema",  function() debug_heap_schema() end)


### PR DESCRIPTION
All debug printing (and J64 dumps) will omit big data and print it only when recognized to be short (as string) or 32/64 bytes octets (as hex for hashes) and a few more heuristics that may grow in time to print error dumps in a nicer and more human way