### PR TITLE
fix: add -llog to android .so build

### DIFF
--- a/build/android.mk
+++ b/build/android.mk
@@ -19,4 +19,4 @@ libzenroom.so: deps ${ZEN_SOURCES} bindings/java/zenroom_jni.o
 	APP_STL=c++_static ANDROID_ABI=${ANDROID_ABI} \
 	${COMPILER} ${cflags} -shared ${ZEN_SOURCES} \
 		bindings/java/zenroom_jni.o \
-		-o $@ ${ldflags} ${ldadd}
+		-o $@ ${ldflags} ${ldadd} -llog


### PR DESCRIPTION
attempt to fix "cannot locate symbol "__android_log_print""