### PR TITLE
fix: add -lm in android.mk

### DIFF
--- a/build/android.mk
+++ b/build/android.mk
@@ -19,4 +19,4 @@ libzenroom.so: deps ${ZEN_SOURCES} bindings/java/zenroom_jni.o
 	APP_STL=c++_static ANDROID_ABI=${ANDROID_ABI} \
 	${COMPILER} ${cflags} -shared ${ZEN_SOURCES} \
 		bindings/java/zenroom_jni.o \
-		-o $@ ${ldflags} ${ldadd} -llog
+		-o $@ ${ldflags} ${ldadd} -llog -lm


### PR DESCRIPTION
Attempt to fix: 



Process: com.example.zencode, PID: 11293
                                                                                                    java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "log2" referenced by "/data/app/~~LIsElfhvdxiIBmiDZeFmCw==/com.example.zencode-6UJi7EjxckO2sS-T1fg0NA==/lib/x86_64/libzenroom.so"