### PR TITLE
fix: normalize big import when using BIG.new with numbers and handle better big numbers and strings in input

### DIFF
--- a/src/zen_big.c
+++ b/src/zen_big.c
@@ -266,6 +266,7 @@ static void _algebraic_sum(big *c, big *a, big *b, char *failed_msg) {
     @return a new Big number
     @function BIG.new
 */
+static int big_from_decimal_string(lua_State *L);
 static int newbig(lua_State *L) {
 	BEGIN();
 	char *failed_msg = NULL;
@@ -294,8 +295,19 @@ static int newbig(lua_State *L) {
 		if((int)n>0)
 			BIG_inc(c->val, (int)n);
 		BIG_norm(c->val);
-		return 1; }
+		return 1;
+	}
 
+	const char *type = luaL_typename(L, 1);
+	if(strlen(type) > 5) {
+		if (strncmp("number",type,6)==0) {
+			zerror(L, "BIG.new number input support only 32 bit integers, use strings for larger numbers");
+			return 0;
+		}
+		if(strncmp("string",type,6)==0) {
+			return big_from_decimal_string(L);
+		}
+	}
 	// octet argument, import
 	const octet *o = o_arg(L, 1);
 	if(!o) {

--- a/src/zen_big.c
+++ b/src/zen_big.c
@@ -293,6 +293,7 @@ static int newbig(lua_State *L) {
 		BIG_zero(c->val);
 		if((int)n>0)
 			BIG_inc(c->val, (int)n);
+		BIG_norm(c->val);
 		return 1; }
 
 	// octet argument, import

--- a/test/lua/big_gregorian_epoch_timestamp.lua
+++ b/test/lua/big_gregorian_epoch_timestamp.lua
@@ -1,0 +1,11 @@
+-- test from isse #1075 (https://github.com/dyne/Zenroom/issues/1075)
+
+-- example of computing the number of seconds since 1582-10-15 (Gregorian epoch timestamp)
+local fixed_actual_timestamp = BIG.new(1748958809) -- BIG.new(os.time(os.date("!*t")))
+local days = BIG.new(141427) -- 1582-10-15 to 1970-01-01
+local seconds_per_day = BIG.new(86400) -- 24 * 60 * 60
+local gregorian_epoch_timestamp = days * seconds_per_day + fixed_actual_timestamp
+
+local correct_result = BIG.new('13968251609')
+assert(gregorian_epoch_timestamp == correct_result, "Gregorian epoch timestamp calculation is incorrect "..
+    "Expected: " .. tostring(correct_result) .. ", got: " .. tostring(gregorian_epoch_timestamp))

--- a/test/lua/primitives.bats
+++ b/test/lua/primitives.bats
@@ -5,6 +5,7 @@ load ../bats_setup
     Z big_decimal.lua
     Z big_shift.lua
     Z big_to_fixed_oct.lua
+    Z big_gregorian_epoch_timestamp.lua
     Z export_float.lua
     Z export_time.lua
     Z time_arithmetics.lua


### PR DESCRIPTION
- **fix: normalize big import when using BIG.new with numbers**
- **fix(zen_big): BIG.new detect when number grater than 32 bits are imported and throw an error and handle also string inputs**
