### PR TITLE
fix(zencode_jws): require crypto_jose

### DIFF
--- a/src/lua/zencode_jws.lua
+++ b/src/lua/zencode_jws.lua
@@ -21,6 +21,7 @@
 --]]
 
 local W3C = require_once "crypto_w3c"
+local JOSE = require_once "crypto_jose"
 
 -- When(deprecated(
 --         "create jws signature of ''",


### PR DESCRIPTION
this is needed when scenario 'jws' is used
