### PR TITLE
build: gate zkcc to enabled targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ node-wasm: ## WebAssembly (WASM) for Javascript in-browser (Emscripten)
 
 check: ## Run tests using the current binary executable build
 	meson setup meson/ build/ -D \
-	"tests=['determinism','vectors','lua','zencode','blockchain','bindings','api']"
+	"tests=['determinism','vectors','lua','zkcc','zencode','blockchain','bindings','api']"
 	ninja -C meson test
 
 wrap-js: # Generate the ./zenroom exec wrapper on node-wasm builds
@@ -101,7 +101,7 @@ check-rs:
 
 check-osx: ## Run tests using the OSX binary executable build
 	meson setup meson/ build/ -D \
-	"tests=['determinism','vectors','lua','zencode','bindings']"
+	"tests=['determinism','vectors','lua','zkcc','zencode','bindings']"
 	ninja -C meson test
 
 install: destbin=${DESTDIR}${PREFIX}/bin

--- a/build/android.mk
+++ b/build/android.mk
@@ -15,6 +15,9 @@ ifdef RELEASE
 	cflags += -O3 ${ZEN_INCLUDES}
 endif
 include build/plugins.mk
+
+LUA_EMBED_EXCLUDES += crypto_zkcc.lua
+
 include build/deps.mk
 
 all: deps libzenroom.so

--- a/build/apple-ios.mk
+++ b/build/apple-ios.mk
@@ -17,6 +17,8 @@ platform := ios
 # activate CCACHE etc.
 include build/plugins.mk
 
+LUA_EMBED_EXCLUDES += crypto_zkcc.lua
+
 # TODO: from some error output in recent XCode we get a list of archs:
 # i386,x86_64,x86_64h,arm64,arm64e
 # we haven't met yet the need to activate all, contact us if you do.

--- a/build/deps.mk
+++ b/build/deps.mk
@@ -12,6 +12,7 @@
 embed-lua: lua_embed_opts := $(if ${COMPILE_LUA}, compile)
 embed-lua:
 	@echo "Embedding all files in src/lua"
+	LUA_EMBED_EXCLUDES="${LUA_EMBED_EXCLUDES}" \
 	./build/embed-lualibs ${lua_embed_opts}
 	@echo "File generated: src/lualibs_detected.c"
 

--- a/build/embed-lualibs
+++ b/build/embed-lualibs
@@ -31,6 +31,7 @@ const unsigned int fakelen = 0;
 #else
 EOF
 libs=$(find src/lua -type f -name '*.lua')
+embed_excludes="${LUA_EMBED_EXCLUDES}"
 
 # emscripten doesn't supports embedding this way
 # will use --preload-file instead
@@ -44,6 +45,9 @@ scenarios=""
 
 for i in ${libs}; do
     p=$(basename $i)
+    case " ${embed_excludes} " in
+        *" ${p} "*) continue ;;
+    esac
     n=$(echo "$p" | cut -d'.' -f1)
     f="lualib_${n}.c"
     echo "+ $i $opts"

--- a/build/init.mk
+++ b/build/init.mk
@@ -21,8 +21,8 @@ ZEN_INCLUDES += -Isrc -Ilib/lua54/src -Ilib -I/usr/local/include	\
 -Ilib/ed25519-donna -Ilib/longfellow-zk -Wall -Wextra
 
 BUILD_DEPS ?= apply-patches milagro lua54 embed-lua mlkem	\
-				quantum-proof ed25519-donna longfellow-zk	\
-				zk-circuit-lang zstd
+				quantum-proof ed25519-donna longfellow-zk zstd
+ZKCC_BUILD_DEPS := zk-circuit-lang
 
 pwd := $(shell pwd)
 mil := ${pwd}/build/milagro
@@ -47,8 +47,8 @@ ldadd += ${pwd}/lib/mlkem/test/build/libmlkem.a
 # ldadd += /usr/local/lib/libmdoc.a
 ldadd += ${pwd}/lib/longfellow-zk/liblongfellow-zk.a
 ldadd += ${pwd}/lib/zstd/libzstd.a
-ldadd += ${pwd}/lib/zk-circuit-lang/libzk-circuit-lang.a
 ldadd += -lstdc++
+ZKCC_LDADD := ${pwd}/lib/zk-circuit-lang/libzk-circuit-lang.a
 
 # ----------------
 # zenroom defaults

--- a/build/meson.build
+++ b/build/meson.build
@@ -57,6 +57,14 @@ foreach test_suite : tests
 endforeach
 endif
 
+if suite.contains('zkcc')
+  test('lua_zkcc',
+       bats_bin,
+       args: [test_dir+'lua/zkcc.bats'],
+       timeout: 240
+      )
+endif
+
 ## BATS tests in test/zencode
 if suite.contains('zencode')
   # excluded tests

--- a/build/meson.options
+++ b/build/meson.options
@@ -1,4 +1,4 @@
 option('tests', type : 'array',
 				 choices : ['determinism', 'vectors', 'lua', 'zencode',
-				            'blockchain', 'bindings', 'api', 'benchmark'],
+				            'zkcc', 'blockchain', 'bindings', 'api', 'benchmark'],
 				 value : ['lua', 'zencode'])

--- a/build/musl.mk
+++ b/build/musl.mk
@@ -11,28 +11,32 @@ system := Linux
 # activate CCACHE etc.
 include build/plugins.mk
 
+TARGET_BUILD_DEPS := ${BUILD_DEPS} ${ZKCC_BUILD_DEPS}
+TARGET_LDADD := ${ldadd} ${ZKCC_LDADD}
+cflags += -DZEN_ENABLE_ZKCC=1
+
 all: deps zenroom lua-exec zencode-exec
 
-deps: ${BUILD_DEPS}
+deps: ${TARGET_BUILD_DEPS}
 
 aux_source  := src/zencode-exec
 cli_sources := src/cli-zenroom.o src/repl.o
 zenroom: ${ZEN_SOURCES} ${cli_sources}
 	$(info === Building the zenroom CLI)
 	${cxx} ${cflags} ${ZEN_SOURCES} ${cli_sources} \
-		-o $@ ${ldflags} ${ldadd}
+		-o $@ ${ldflags} ${TARGET_LDADD}
 
 lua-exec: ${ZEN_SOURCES}
 	$(info === Building the lua-exec utility)
 	${zenroom_cc} ${cflags} -DLUA_EXEC \
 		-c ${aux_source}.c -o ${aux_source}.o
 	${cxx} ${cflags} ${ZEN_SOURCES} ${aux_source}.o \
-		-o $@ ${ldflags} ${ldadd}
+		-o $@ ${ldflags} ${TARGET_LDADD}
 
 zencode-exec: ${ZEN_SOURCES}
 	$(info === Building the zencode-exec utility)
 	${zenroom_cc} ${cflags} -c ${aux_source}.c -o ${aux_source}.o
 	${cxx} ${cflags} ${ZEN_SOURCES} ${aux_source}.o \
-		-o $@ ${ldflags} ${ldadd}
+		-o $@ ${ldflags} ${TARGET_LDADD}
 
 include build/deps.mk

--- a/build/posix.mk
+++ b/build/posix.mk
@@ -29,9 +29,20 @@ endif
 # activate CCACHE etc.
 include build/plugins.mk
 
+TARGET_BUILD_DEPS := ${BUILD_DEPS}
+TARGET_LDADD := ${ldadd}
+
+ifndef LIBRARY
+TARGET_BUILD_DEPS += ${ZKCC_BUILD_DEPS}
+TARGET_LDADD += ${ZKCC_LDADD}
+cflags += -DZEN_ENABLE_ZKCC=1
+else
+LUA_EMBED_EXCLUDES += crypto_zkcc.lua
+endif
+
 all: deps zenroom lua-exec zencode-exec
 
-deps: ${BUILD_DEPS}
+deps: ${TARGET_BUILD_DEPS}
 
 # main() for zencode-exec and lua-exec
 aux_source  := src/zencode-exec
@@ -39,7 +50,7 @@ cli_sources := src/cli-zenroom.o src/repl.o
 zenroom: ${ZEN_SOURCES} ${cli_sources}
 	$(info === Building the zenroom CLI)
 	${cxx} ${cflags} ${ZEN_SOURCES} ${cli_sources} \
-		-o $@ ${ldflags} ${ldadd} -lreadline
+		-o $@ ${ldflags} ${TARGET_LDADD} -lreadline
 
 lua-exec: cflags += -DLUA_EXEC
 lua-exec: ${ZEN_SOURCES}
@@ -47,23 +58,23 @@ lua-exec: ${ZEN_SOURCES}
 	${zenroom_cc} ${cflags} -DLUA_EXEC \
 		-c ${aux_source}.c -o ${aux_source}.o
 	${cxx} ${cflags} ${ZEN_SOURCES} ${aux_source}.o \
-		-o $@ ${ldflags} ${ldadd}
+		-o $@ ${ldflags} ${TARGET_LDADD}
 
 zencode-exec: ${ZEN_SOURCES}
 	$(info === Building the zencode-exec utility)
 	${zenroom_cc} ${cflags} -c ${aux_source}.c -o ${aux_source}.o
 	${cxx} ${cflags} ${ZEN_SOURCES} ${aux_source}.o \
-		-o $@ ${ldflags} ${ldadd}
+		-o $@ ${ldflags} ${TARGET_LDADD}
 
 libzenroom.so: deps ${ZEN_SOURCES}
 	$(info === Building the zenroom shared library)
 	${cxx} ${cflags} -shared ${ZEN_SOURCES} \
-		-o $@ ${ldflags} ${ldadd}
+		-o $@ ${ldflags} ${TARGET_LDADD}
 
 # OSX specific target
 libzenroom.dylib: deps ${ZEN_SOURCES}
 	$(info === Building the zenroom shared dynamic library)
 	${cxx} ${cflags} -shared ${ZEN_SOURCES} -dynamiclib \
-		-o $@ ${ldflags} ${ldadd}
+		-o $@ ${ldflags} ${TARGET_LDADD}
 
 include build/deps.mk

--- a/build/posix.mk
+++ b/build/posix.mk
@@ -38,6 +38,8 @@ TARGET_LDADD += ${ZKCC_LDADD}
 cflags += -DZEN_ENABLE_ZKCC=1
 else
 LUA_EMBED_EXCLUDES += crypto_zkcc.lua
+ZEN_SOURCES := $(filter-out src/lua_modules.o,${ZEN_SOURCES}) \
+	src/lua_modules_library.o
 endif
 
 all: deps zenroom lua-exec zencode-exec
@@ -65,6 +67,14 @@ zencode-exec: ${ZEN_SOURCES}
 	${zenroom_cc} ${cflags} -c ${aux_source}.c -o ${aux_source}.o
 	${cxx} ${cflags} ${ZEN_SOURCES} ${aux_source}.o \
 		-o $@ ${ldflags} ${TARGET_LDADD}
+
+src/lua_modules_library.o: src/lua_modules.c
+	${zenroom_cc} ${cflags} -c $< -o $@ \
+		-DVERSION=\"${VERSION}\" \
+		-DCURRENT_YEAR=\"${CURRENT_YEAR}\" \
+		-DCOMMIT=\"${COMMIT}\" \
+		-DBRANCH=\"${BRANCH}\" \
+		-DCFLAGS="${cflags}"
 
 libzenroom.so: deps ${ZEN_SOURCES}
 	$(info === Building the zenroom shared library)

--- a/build/tests.mk
+++ b/build/tests.mk
@@ -15,7 +15,10 @@ bats_file = @test/bats/bin/bats $(1).bats
 # temporary target for testing the tests
 check-bats: prepare-executables
 	@cp -v src/zenroom test/zenroom
-	$(call bats, test/lua)
+	$(call bats, test/lua/native.bats)
+	$(call bats, test/lua/primitives.bats)
+	$(call bats, test/lua/crypto.bats)
+	$(call bats, test/lua/zkcc.bats)
 	$(call bats, test/determinism)
 	$(call bats, test/zencode)
 
@@ -38,7 +41,10 @@ luacheck:
 check-osx: test-exec := ./src/zenroom
 check-osx: prepare-executables
 	@cp -v ${test-exec} test/zenroom
-	$(call bats, test/lua)
+	$(call bats, test/lua/native.bats)
+	$(call bats, test/lua/primitives.bats)
+	$(call bats, test/lua/crypto.bats)
+	$(call bats, test/lua/zkcc.bats)
 	$(call bats, test/determinism)
 	rm -f /tmp/zenroom-test-summary.txt
 	$(call crypto-integration,${test-exec})
@@ -51,7 +57,10 @@ check-linux: test-exec := ./src/zenroom
 check-linux: prepare-executables
 	@cp -v ${test-exec} test/zenroom
 	rm -f /tmp/zenroom-test-summary.txt
-	$(call bats, test/lua)
+	$(call bats, test/lua/native.bats)
+	$(call bats, test/lua/primitives.bats)
+	$(call bats, test/lua/crypto.bats)
+	$(call bats, test/lua/zkcc.bats)
 	$(call bats, test/determinism)
 	$(call crypto-integration,${test-exec})
 	$(call zencode-integration,${test-exec})

--- a/build/wasm.mk
+++ b/build/wasm.mk
@@ -27,6 +27,7 @@ longfellow_cflags := -I ${pwd}/src -I. -I../zstd -fPIC -DLIBRARY -msimd128
 zk-circuit-lang_cxxflags := -I ${pwd}/src -I. -I../zstd -fPIC -DLIBRARY -msimd128 -I ../lua54/src -I../longfellow-zk
 
 system := Javascript
+LUA_EMBED_EXCLUDES += crypto_zkcc.lua
 ld_emsdk_settings := -I ${EMSCRIPTEN}/system/include/libc -DLIBRARY
 ld_emsdk_settings += -sMODULARIZE=1	-sSINGLE_FILE=1 --embed-file 'src/lua@/'
 ld_emsdk_settings += -sMALLOC=dlmalloc --no-heap-copy -sALLOW_MEMORY_GROWTH=1

--- a/build/win-dll.mk
+++ b/build/win-dll.mk
@@ -17,6 +17,8 @@ ldadd += -lstdc++
 # activate CCACHE etc.
 include build/plugins.mk
 
+LUA_EMBED_EXCLUDES += crypto_zkcc.lua
+
 all: ${BUILD_DEPS} stamp-exe-windres zenroom.dll
 
 stamp-exe-windres:

--- a/build/win-exe.mk
+++ b/build/win-exe.mk
@@ -18,7 +18,11 @@ zk-circuit-lang_cxxflags += -Wa,-mbig-obj
 # activate CCACHE etc.
 include build/plugins.mk
 
-all: ${BUILD_DEPS} stamp-exe-windres zenroom.exe zencode-exec.exe
+TARGET_BUILD_DEPS := ${BUILD_DEPS} ${ZKCC_BUILD_DEPS}
+TARGET_LDADD := ${ldadd} ${ZKCC_LDADD}
+cflags += -DZEN_ENABLE_ZKCC=1
+
+all: ${TARGET_BUILD_DEPS} stamp-exe-windres zenroom.exe zencode-exec.exe
 
 stamp-exe-windres:
 	sh build/stamp-exe.sh
@@ -27,11 +31,11 @@ cli_sources := src/cli-zenroom.o src/repl.o
 zenroom.exe: ${ZEN_SOURCES} ${cli_sources}
 	$(info === Linking Windows zenroom.exe)
 	${ld} ${cflags} ${ZEN_SOURCES} ${cli_sources} \
-		-o $@ zenroom.res ${ldflags} ${ldadd}
+		-o $@ zenroom.res ${ldflags} ${TARGET_LDADD}
 
 zencode-exec.exe: ${ZEN_SOURCES} src/zencode-exec.o
 	$(info === Linking Windows zencode-exec.exe)
 	${ld} ${cflags} ${ZEN_SOURCES} src/zencode-exec.o \
-		-o $@ zenroom.res ${ldflags} ${ldadd}
+		-o $@ zenroom.res ${ldflags} ${TARGET_LDADD}
 
 include build/deps.mk

--- a/src/lua_modules.c
+++ b/src/lua_modules.c
@@ -62,7 +62,9 @@ extern int luaopen_p256(lua_State *L);
 extern int luaopen_x509(lua_State *L);
 extern int luaopen_varint(lua_State *L);
 extern int luaopen_longfellow(lua_State *L);
+#ifdef ZEN_ENABLE_ZKCC
 extern int luaopen_zkcore(lua_State *L);
+#endif
 
 // really loaded in lib/lua54/linit.c
 // always align here for correct reference
@@ -203,8 +205,10 @@ int zen_require(lua_State *L) {
 		luaL_requiref(L, s, luaopen_varint, 1); }
 	else if(strcasecmp(s, "longfellow")  ==0) {
 		luaL_requiref(L, s, luaopen_longfellow, 1); }
+#ifdef ZEN_ENABLE_ZKCC
 	else if(strcasecmp(s, "zkcore")  ==0) {
 		luaL_requiref(L, s, luaopen_zkcore, 1); }
+#endif
 	else {
 		// shall we bail out and abort execution here?
 		warning(L, "required extension not found: %s", s);

--- a/test/lua/crypto.bats
+++ b/test/lua/crypto.bats
@@ -45,11 +45,6 @@ load ../bats_setup
     Z parse_regression.lua
     Z ownership_regression.lua
     Z crypto_loader.lua
-    Z zkcc_small.lua
-    Z zkcc_horner_expr.lua
-    Z zkcc_sha256.lua
-    Z zkcc_arith_progression.lua
     Z longfellow_guards.lua
-	Z zkcc_flatsha256_proof.lua
     Z sfpool_regression.lua
 }

--- a/test/lua/zkcc.bats
+++ b/test/lua/zkcc.bats
@@ -1,0 +1,9 @@
+load ../bats_setup
+
+@test "Lua zkcc tests" {
+    Z zkcc_small.lua
+    Z zkcc_horner_expr.lua
+    Z zkcc_sha256.lua
+    Z zkcc_arith_progression.lua
+    Z zkcc_flatsha256_proof.lua
+}


### PR DESCRIPTION
Make zkcc build and test only on certain targets

the zk circuit compiler is not really useful on WASM and mobile targets.