### PR TITLE
Add hex-first binary API helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,40 @@ Preserve:
 - stable userdata names and octet conversion behavior
 
 
-## Scenario Layer
+## Public Native API Layer
+
+`src/api_*.c` files expose direct C functions for embedders and
+WASM callers without requiring Lua/Zencode scripts.
+
+- [`src/api_hash.c`](/home/jrml/devel/zenroom/src/api_hash.c): one-shot
+  hash and PBKDF2 primitives
+- [`src/api_sign.c`](/home/jrml/devel/zenroom/src/api_sign.c): EdDSA
+  keygen, pubgen, create, verify (print + tobuf variants)
+- [`src/api_recipe.c`](/home/jrml/devel/zenroom/src/api_recipe.c):
+  named recipe dispatcher that maps short names to embedded Lua scripts
+  and calls `zenroom_exec_tobuf`; the C analog of the JS
+  `zenroomExecToBuf` + inline script pattern
+
+API conventions for new primitives:
+
+- All binary input/output: lowercase hex strings
+- Algorithm selection: lowercase string (e.g. `"sha256"`, `"eddsa"`)
+- Boolean results: `"1"` / `"0"` chars in C, `number` in JS
+- `_tobuf` suffix: writes into caller-provided output/error buffers
+- No suffix: prints to stdout (CLI convenience)
+- Every new function needs: declaration in `src/zenroom.h`, export
+  in `build/wasm.mk`, C test in `test/api/`, and JS wrapper + test
+
+JS layer (`bindings/javascript/src/index.ts`):
+
+- `callBufferApi` wraps `_tobuf` functions with `Module._malloc`/`_free`
+  and reads C strings from `Module.HEAPU8`
+- `callPrintApi` wraps print-variant functions with
+  save/restore of `Module.print`/`Module.printErr` for
+  `zencode_exec` and `zenroom_exec` only
+- `recipeExec` wraps `zenroom_recipe_exec_tobuf` for named recipes
+
+
 
 `src/lua/zencode_*.lua` files are scenario modules. They:
 
@@ -154,6 +187,9 @@ Typical edit choice:
 - new import/export encoding or schema: `zencode_data.lua` or scenario schema
 - new generic data primitive: base `zencode_*` file
 - new native crypto primitive: `src/zen_*.c`
+- new public API (hex-first, no Lua/Zencode dependency): `src/api_*.c`
+- new Lua-backed recipe: add recipe name + script in `src/api_recipe.c`
+  and a typed JS wrapper in `index.ts`
 - parser/state-machine change: only if syntax must actually change
 
 

--- a/bindings/javascript/README.md
+++ b/bindings/javascript/README.md
@@ -162,6 +162,112 @@ const introspection = await introspection(
 console.log(introspection); // => an object described as https://dev.zenroom.org/#/pages/how-to-embed?id=input-validation
 ```
 
+## 🔐 Direct primitives (hex API)
+
+Zenroom also exports direct cryptographic primitives that work
+without writing Lua or Zencode scripts.  All binary inputs and
+outputs use lowercase hex strings.
+
+### One-shot hash
+
+```js
+import { hashHex, utf8ToHex } from "zenroom";
+
+const { result: sha256 } = await hashHex("sha256", utf8ToHex("hello"));
+console.log(sha256);
+// => 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+```
+
+Supported algorithms: `sha256`, `sha384`, `sha512`, `sha3_256`,
+`sha3_512`, `shake256`, `keccak256`, `ripemd160`.
+
+### PBKDF2 key derivation
+
+```js
+import { pbkdf2Hex } from "zenroom";
+
+const { result: key } = await pbkdf2Hex(
+  "sha256",
+  utf8ToHex("password"),
+  utf8ToHex("salt"),
+  4096,
+  32
+);
+// key is a 64-char hex string (32 bytes)
+```
+
+### EdDSA signatures
+
+```js
+import { signKeygenHex, signPubgenHex, signCreateHex, signVerifyHex } from "zenroom";
+
+// Generate a secret key (optionally pass a hex rngseed)
+const { result: sk } = await signKeygenHex("eddsa");
+
+// Derive the public key
+const { result: pk } = await signPubgenHex("eddsa", sk);
+
+// Sign a hex-encoded message
+const { result: sig } = await signCreateHex("eddsa", sk, utf8ToHex("hello"));
+
+// Verify the signature
+const { result: ok } = await signVerifyHex("eddsa", pk, utf8ToHex("hello"), sig);
+console.log(ok); // => 1
+```
+
+### Merkle tree recipes (Lua-backed)
+
+```js
+import { merkleRootHex } from "zenroom";
+
+const { result: root } = await merkleRootHex(
+  ["0101010101010101010101010101010101010101010101010101010101010101",
+   "0202020202020202020202020202020202020202020202020202020202020202"],
+  "sha256"
+);
+console.log(root); // hex-encoded merkle root
+```
+
+### Named recipes
+
+```js
+import { recipeExec } from "zenroom";
+
+const { result } = await recipeExec("merkle.root", JSON.stringify({
+  hash: "sha256",
+  leaves: [
+    "0101010101010101010101010101010101010101010101010101010101010101",
+    "0202020202020202020202020202020202020202020202020202020202020202",
+  ],
+}));
+const { root } = JSON.parse(result);
+```
+
+### Encoding helpers
+
+```js
+import { bytesToHex, hexToBytes, utf8ToHex, hexToUtf8 } from "zenroom";
+
+const hex = utf8ToHex("hello");          // "68656c6c6f"
+const str = hexToUtf8("68656c6c6f");     // "hello"
+
+const bytes = hexToBytes("deadbeef");    // Uint8Array [0xde, 0xad, 0xbe, 0xef]
+const back  = bytesToHex(bytes);         // "deadbeef"
+```
+
+### Streaming hash (legacy API)
+
+```js
+import { zenroom_hash } from "zenroom";
+
+const { result: digest } = await zenroom_hash("sha256", "hello world");
+// digest is base64-encoded (legacy format)
+```
+
+For large inputs or one-shot hashing with hex output, prefer
+`hashHex` which handles chunking internally and returns lowercase hex.
+```
+
 ## 😍 Acknowledgements
 
 Copyright (C) 2018-2026 by [Dyne.org](https://www.dyne.org) foundation, Amsterdam

--- a/bindings/javascript/src/index.spec.ts
+++ b/bindings/javascript/src/index.spec.ts
@@ -24,6 +24,7 @@ import {
   decode_error,
   zencode_get_statements,
 } from "./index";
+import { recipeExec } from "./index";
 //import { TextEncoder } from "util";
 //var enc = new TextEncoder();
 
@@ -660,4 +661,50 @@ test("does run zencode with extra and context", async (t) => {
 test("does run zenroom_exec with extra and context", async (t) => {
   const { result } = await zenroom_exec(`print(DATA..KEYS..EXTRA..CONTEXT)`, { data: "USING ", keys: "ALL ", extra: "ZENROOM ", context: "INPUTS" });
   t.is(result, "USING ALL ZENROOM INPUTS\n");
+});
+
+test("recipeExec merkle.root returns JSON root hex", async (t) => {
+  const data = JSON.stringify({
+    hash: "sha256",
+    leaves: [
+      "0101010101010101010101010101010101010101010101010101010101010101",
+      "0202020202020202020202020202020202020202020202020202020202020202",
+      "0303030303030303030303030303030303030303030303030303030303030303",
+    ],
+  });
+  const { result } = await recipeExec("merkle.root", data);
+  const out = JSON.parse(result);
+  t.truthy(out.root);
+  t.is(out.root.length, 64);
+  t.regex(out.root, /^[0-9a-f]+$/);
+});
+
+test("recipeExec merkle.root fails with invalid JSON data", async (t) => {
+  try {
+    await recipeExec("merkle.root", "not json");
+    t.fail("should have thrown");
+  } catch (error: any) {
+    t.truthy(error.logs, "error should contain logs");
+  }
+});
+
+test("recipeExec rejects unknown name", async (t) => {
+  try {
+    await recipeExec("nonexistent.recipe", "{}");
+    t.fail("should have thrown");
+  } catch (error: any) {
+    t.truthy(error.logs, "error should contain logs");
+  }
+});
+
+test("recipeExec output matches merkleRootHex", async (t) => {
+  const leaves = [
+    "0101010101010101010101010101010101010101010101010101010101010101",
+    "0202020202020202020202020202020202020202020202020202020202020202",
+  ];
+  const [direct, recipe] = await Promise.all([
+    merkleRootHex(leaves, "sha256"),
+    recipeExec("merkle.root", JSON.stringify({ hash: "sha256", leaves })),
+  ]);
+  t.is(direct.result, JSON.parse(recipe.result).root);
 });

--- a/bindings/javascript/src/index.spec.ts
+++ b/bindings/javascript/src/index.spec.ts
@@ -679,13 +679,40 @@ test("recipeExec merkle.root returns JSON root hex", async (t) => {
   t.regex(out.root, /^[0-9a-f]+$/);
 });
 
-test("recipeExec merkle.root fails with invalid JSON data", async (t) => {
-  try {
-    await recipeExec("merkle.root", "not json");
-    t.fail("should have thrown");
-  } catch (error: any) {
-    t.truthy(error.logs, "error should contain logs");
-  }
+test("recipeExec merkle.verify_proof with generated proof", async (t) => {
+  const leaves = [
+    "0101010101010101010101010101010101010101010101010101010101010101",
+    "0202020202020202020202020202020202020202020202020202020202020202",
+    "0303030303030303030303030303030303030303030303030303030303030303",
+    "0404040404040404040404040404040404040404040404040404040404040404",
+  ];
+  const script =
+    `local MT = require'crypto_merkle'\n` +
+    `local leaves = {}\n` +
+    leaves.map((h) => `table.insert(leaves, O.from_hex('${h}'))`).join("\n") + `\n` +
+    `local tree = MT.create_merkle_tree(leaves, 'sha256')\n` +
+    `local proof = MT.generate_proof(tree, 0)\n` +
+    `local proof_hex = {}\n` +
+    `for _, p in ipairs(proof) do table.insert(proof_hex, p:hex()) end\n` +
+    `print(require'json'.raw_encode(proof_hex))\n`;
+
+  const { result: proofJson } = await zenroom_exec(script);
+  const proofHex: string[] = JSON.parse(proofJson);
+
+  const rt = await recipeExec("merkle.root", JSON.stringify({
+    hash: "sha256",
+    leaves,
+  }));
+  const root = JSON.parse(rt.result).root;
+
+  const vf = await recipeExec("merkle.verify_proof", JSON.stringify({
+    hash: "sha256",
+    proof: proofHex,
+    position: 0,
+    root,
+    leaf_count: leaves.length,
+  }));
+  t.is(JSON.parse(vf.result).valid, true);
 });
 
 test("recipeExec rejects unknown name", async (t) => {
@@ -707,4 +734,13 @@ test("recipeExec output matches merkleRootHex", async (t) => {
     recipeExec("merkle.root", JSON.stringify({ hash: "sha256", leaves })),
   ]);
   t.is(direct.result, JSON.parse(recipe.result).root);
+});
+
+test("recipeExec merkle.root fails with invalid JSON", async (t) => {
+  try {
+    await recipeExec("merkle.root", "not json");
+    t.fail("should have thrown");
+  } catch (error: any) {
+    t.truthy(error.logs, "error should contain logs");
+  }
 });

--- a/bindings/javascript/src/index.spec.ts
+++ b/bindings/javascript/src/index.spec.ts
@@ -332,6 +332,42 @@ test("sign hex helpers produce deterministic eddsa outputs", async (t) => {
   t.is(ok.result, "1");
 });
 
+test("sign hex helpers p256 round-trip keygen pubgen sign verify", async (t) => {
+  const sk = await signKeygenHex("p256", null);
+  t.is(sk.result.length, 64);
+
+  const pk = await signPubgenHex("p256", sk.result);
+  t.is(pk.result.length, 128);
+
+  const msg = "010203";
+  const sig = await signCreateHex("p256", sk.result, msg);
+  t.is(sig.result.length, 128);
+
+  const ok = await signVerifyHex("p256", pk.result, msg, sig.result);
+  t.is(ok.result, "1");
+
+  const bad = await signVerifyHex("p256", pk.result, msg, msg.padEnd(128, "0"));
+  t.is(bad.result, "0");
+});
+
+test("sign hex helpers mldsa44 round-trip keygen pubgen sign verify", async (t) => {
+  const sk = await signKeygenHex("mldsa44", null);
+  t.is(sk.result.length, 5120);
+
+  const pk = await signPubgenHex("mldsa44", sk.result);
+  t.is(pk.result.length, 2624);
+
+  const msg = "010203";
+  const sig = await signCreateHex("mldsa44", sk.result, msg);
+  t.is(sig.result.length, 4840);
+
+  const ok = await signVerifyHex("mldsa44", pk.result, msg, sig.result);
+  t.is(ok.result, "1");
+
+  const bad = await signVerifyHex("mldsa44", pk.result, msg, msg.padEnd(128, "0"));
+  t.is(bad.result, "0");
+});
+
 test("merkleRootHex stays Lua-backed and returns hex", async (t) => {
   const root = await merkleRootHex(["616263"]);
   t.is(root.result, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");

--- a/bindings/javascript/src/index.spec.ts
+++ b/bindings/javascript/src/index.spec.ts
@@ -7,6 +7,17 @@ import {
   zenroom_hash_update,
   zenroom_hash_final,
   zenroom_hash,
+  hashHex,
+  pbkdf2Hex,
+  signKeygenHex,
+  signPubgenHex,
+  signCreateHex,
+  signVerifyHex,
+  bytesToHex,
+  hexToBytes,
+  utf8ToHex,
+  hexToUtf8,
+  merkleRootHex,
   introspect,
   zencode_valid_code,
   safe_zencode_valid_code,
@@ -274,6 +285,55 @@ test("Use zenroom_hash with big input", async (t) => {
     hash1.result,
     "HM5Pm1A/V/FqShY8sm6x4AU5O5B44Gs9+uXjDn6PhjSg9cSzlPa2MHXriPSZS4wuRYn0UgN2g9L3A+P7rOJRdA=="
   );
+});
+
+test("hashHex returns hex digests for multiple algorithms", async (t) => {
+  const sha256 = await hashHex("sha256", utf8ToHex("abc"));
+  t.is(sha256.result, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+
+  const ripemd160 = await hashHex("ripemd160", utf8ToHex("abc"));
+  t.is(ripemd160.result, "8eb208f7e05d987a9b044a8e98c6b087f15a0bfc");
+});
+
+test("pbkdf2Hex derives the expected key", async (t) => {
+  const derived = await pbkdf2Hex(
+    "sha256",
+    utf8ToHex("password"),
+    utf8ToHex("salt"),
+    4096,
+    32
+  );
+  t.is(derived.result, "c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a");
+});
+
+test("hex conversion helpers round-trip utf8 and bytes", (t) => {
+  const bytes = new Uint8Array([0, 1, 2, 254, 255]);
+  const hex = bytesToHex(bytes);
+  t.is(hex, "000102feff");
+  t.deepEqual(Array.from(hexToBytes(hex)), Array.from(bytes));
+  t.is(utf8ToHex("hello"), "68656c6c6f");
+  t.is(hexToUtf8("68656c6c6f"), "hello");
+});
+
+test("sign hex helpers produce deterministic eddsa outputs", async (t) => {
+  const seed = "0".repeat(128);
+  const sk = await signKeygenHex("eddsa", seed);
+  t.is(sk.result, "06b4c6f4caf4234be9dedc6983412aaf50773e788e144e3e2cd09b56f21f744d");
+
+  const pk = await signPubgenHex("eddsa", sk.result);
+  t.is(pk.result, "e78735703bf56140a00a6f867ca926fa0945e8b5752325e6593ea680d55d41bc");
+
+  const msgHex = "6162636462636465636465666465666765666768666768696768696A68696A6B696A6B6C6A6B6C6D6B6C6D6E6C6D6E6F6D6E6F706E6F7071";
+  const sig = await signCreateHex("eddsa", sk.result, msgHex);
+  t.is(sig.result, "b2efa19f6c51a929e4155a8ee1df57abeef8e1b9556366551f9e1ec3ea2476b6c3bbcb93e8a23d5cfffa50f968cb84aa5e1e06bf1b884509ae35603b20999a01");
+
+  const ok = await signVerifyHex("eddsa", pk.result, msgHex, sig.result);
+  t.is(ok.result, "1");
+});
+
+test("merkleRootHex stays Lua-backed and returns hex", async (t) => {
+  const root = await merkleRootHex(["616263"]);
+  t.is(root.result, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
 });
 
 test("Check the introspection", async (t) => {

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -24,6 +24,18 @@ const getModule = async () => {
   return cache.module;
 };
 
+const DEFAULT_STDOUT_BYTES = 64 * 1024;
+const DEFAULT_STDERR_BYTES = 64 * 1024;
+
+const readCString = (heap: Uint8Array, ptr: number, maxBytes: number): string => {
+  let end = ptr;
+  const limit = ptr + maxBytes;
+  while (end < limit && heap[end] !== 0) {
+    end += 1;
+  }
+  return new TextDecoder().decode(heap.subarray(ptr, end));
+};
+
 const callApi = async (
   name: string,
   argTypes: string[],
@@ -70,10 +82,55 @@ const callSyncApi = async (
   throw { result, logs };
 };
 
+const callBufferApi = async (
+  name: string,
+  argTypes: string[],
+  args: Array<string | number | null>,
+  stdoutBytes: number = DEFAULT_STDOUT_BYTES,
+  stderrBytes: number = DEFAULT_STDERR_BYTES
+): Promise<ZenroomResult> => {
+  const Module = await getModule();
+  const exec = Module.cwrap(name, "number", [
+    ...argTypes,
+    "number",
+    "number",
+    "number",
+    "number",
+  ]);
+  const stdoutPtr = Module._malloc(stdoutBytes);
+  const stderrPtr = Module._malloc(stderrBytes);
+  try {
+    Module.HEAPU8.fill(0, stdoutPtr, stdoutPtr + stdoutBytes);
+    Module.HEAPU8.fill(0, stderrPtr, stderrPtr + stderrBytes);
+    const status = exec(...args, stdoutPtr, stdoutBytes, stderrPtr, stderrBytes);
+    const result = readCString(Module.HEAPU8, stdoutPtr, stdoutBytes);
+    const logs = readCString(Module.HEAPU8, stderrPtr, stderrBytes);
+    if (status === 0) {
+      return { result, logs };
+    }
+    throw { result, logs };
+  } finally {
+    Module._free(stdoutPtr);
+    Module._free(stderrPtr);
+  }
+};
+
 const trimTrailingNewline = ({ result, logs }: ZenroomResult): ZenroomResult => ({
   result: result.replace(/\n$/, ""),
   logs,
 });
+
+const zenroomExecToBuf = async (
+  lua: string,
+  props?: ZenroomProps
+): Promise<ZenroomResult> => {
+  const { data = null, keys = null, extra = null, context = null, conf = null } = { ...props };
+  return await callBufferApi(
+    "zenroom_exec_tobuf",
+    ["string", "string", "string", "string", "string", "string"],
+    [lua, conf, keys, data, extra, context]
+  );
+};
 
 const isSafeIdentifier = (value: string): boolean => /^[A-Za-z0-9_]+$/.test(value);
 
@@ -262,7 +319,7 @@ export const hashHex = async (
     throw new Error("Invalid hex string");
   }
   return trimTrailingNewline(
-    await callSyncApi("zenroom_hash_hex", ["string", "string"], [hashType, msgHex])
+    await callBufferApi("zenroom_hash_hex_tobuf", ["string", "string"], [hashType, msgHex])
   );
 };
 
@@ -277,8 +334,8 @@ export const pbkdf2Hex = async (
     throw new Error("Invalid hex string");
   }
   return trimTrailingNewline(
-    await callSyncApi(
-      "zenroom_pbkdf2_hex",
+    await callBufferApi(
+      "zenroom_pbkdf2_hex_tobuf",
       ["string", "string", "string", "number", "number"],
       [hashType, passwordHex, saltHex, iterations, keylen]
     )
@@ -290,7 +347,7 @@ export const signKeygenHex = async (
   rngseed: string | null = null
 ): Promise<ZenroomResult> =>
   trimTrailingNewline(
-    await callSyncApi("zenroom_sign_keygen", ["string", "string"], [algo, rngseed])
+    await callBufferApi("zenroom_sign_keygen_tobuf", ["string", "string"], [algo, rngseed])
   );
 
 export const signPubgenHex = async (
@@ -301,7 +358,7 @@ export const signPubgenHex = async (
     throw new Error("Invalid hex string");
   }
   return trimTrailingNewline(
-    await callSyncApi("zenroom_sign_pubgen", ["string", "string"], [algo, keyHex])
+    await callBufferApi("zenroom_sign_pubgen_tobuf", ["string", "string"], [algo, keyHex])
   );
 };
 
@@ -314,7 +371,7 @@ export const signCreateHex = async (
     throw new Error("Invalid hex string");
   }
   return trimTrailingNewline(
-    await callSyncApi("zenroom_sign_create", ["string", "string", "string"], [algo, keyHex, msgHex])
+    await callBufferApi("zenroom_sign_create_tobuf", ["string", "string", "string"], [algo, keyHex, msgHex])
   );
 };
 
@@ -328,8 +385,8 @@ export const signVerifyHex = async (
     throw new Error("Invalid hex string");
   }
   return trimTrailingNewline(
-    await callSyncApi(
-      "zenroom_sign_verify",
+    await callBufferApi(
+      "zenroom_sign_verify_tobuf",
       ["string", "string", "string", "string"],
       [algo, pubkeyHex, msgHex, sigHex]
     )
@@ -353,7 +410,7 @@ export const merkleRootHex = async (
   const script = `local MT = require'crypto_merkle'
 local leaves = {${leavesLua}}
 print(MT.create_merkle_root(leaves, '${hashType}'):hex())`;
-  return trimTrailingNewline(await zenroom_exec(script));
+  return trimTrailingNewline(await zenroomExecToBuf(script));
 };
 
 export const merkleProofVerifyHex = async (
@@ -374,7 +431,7 @@ export const merkleProofVerifyHex = async (
 local proof = {${proofLua}}
 local ok = MT.verify_proof(proof, ${position}, O.from_hex('${rootHex}'), ${leafCount}, '${hashType}')
 print(ok and '1' or '0')`;
-  return trimTrailingNewline(await zenroom_exec(script));
+  return trimTrailingNewline(await zenroomExecToBuf(script));
 };
 
 export const zencode_valid_input = async (

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -36,52 +36,6 @@ const readCString = (heap: Uint8Array, ptr: number, maxBytes: number): string =>
   return new TextDecoder().decode(heap.subarray(ptr, end));
 };
 
-const callApi = async (
-  name: string,
-  argTypes: string[],
-  args: Array<string | number | null>
-): Promise<ZenroomResult> => {
-  const Module = await getModule();
-  return new Promise((resolve, reject) => {
-    let result = "";
-    let logs = "";
-    const exec = Module.cwrap(name, "number", argTypes);
-    Module.print = (t: string) => (result += t);
-    Module.printErr = (t: string) => (logs += t);
-    Module.exec_ok = () => {
-      resolve({ result, logs });
-    };
-    Module.exec_error = () => {
-      reject({ result, logs });
-    };
-    Module.onAbort = () => {
-      reject({ result, logs });
-    };
-    exec(...args);
-  });
-};
-
-const callSyncApi = async (
-  name: string,
-  argTypes: string[],
-  args: Array<string | number | null>
-): Promise<ZenroomResult> => {
-  const Module = await getModule();
-  let result = "";
-  let logs = "";
-  const exec = Module.cwrap(name, "number", argTypes);
-  Module.print = (t: string) => (result += t);
-  Module.printErr = (t: string) => (logs += t);
-  Module.exec_ok = () => {};
-  Module.exec_error = () => {};
-  Module.onAbort = () => {};
-  const status = exec(...args);
-  if (status === 0) {
-    return { result, logs };
-  }
-  throw { result, logs };
-};
-
 const callBufferApi = async (
   name: string,
   argTypes: string[],

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -49,6 +49,32 @@ const callApi = async (
   });
 };
 
+const callSyncApi = async (
+  name: string,
+  argTypes: string[],
+  args: Array<string | number | null>
+): Promise<ZenroomResult> => {
+  const Module = await getModule();
+  let result = "";
+  let logs = "";
+  const exec = Module.cwrap(name, "number", argTypes);
+  Module.print = (t: string) => (result += t);
+  Module.printErr = (t: string) => (logs += t);
+  Module.exec_ok = () => {};
+  Module.exec_error = () => {};
+  Module.onAbort = () => {};
+  const status = exec(...args);
+  if (status === 0) {
+    return { result, logs };
+  }
+  throw { result, logs };
+};
+
+const trimTrailingNewline = ({ result, logs }: ZenroomResult): ZenroomResult => ({
+  result: result.replace(/\n$/, ""),
+  logs,
+});
+
 const isSafeIdentifier = (value: string): boolean => /^[A-Za-z0-9_]+$/.test(value);
 
 const isHex = (value: string): boolean =>
@@ -235,7 +261,9 @@ export const hashHex = async (
   if (!isHex(msgHex)) {
     throw new Error("Invalid hex string");
   }
-  return callApi("zenroom_hash_hex", ["string", "string"], [hashType, msgHex]);
+  return trimTrailingNewline(
+    await callSyncApi("zenroom_hash_hex", ["string", "string"], [hashType, msgHex])
+  );
 };
 
 export const pbkdf2Hex = async (
@@ -248,10 +276,12 @@ export const pbkdf2Hex = async (
   if (!isHex(passwordHex) || !isHex(saltHex)) {
     throw new Error("Invalid hex string");
   }
-  return callApi(
-    "zenroom_pbkdf2_hex",
-    ["string", "string", "string", "number", "number"],
-    [hashType, passwordHex, saltHex, iterations, keylen]
+  return trimTrailingNewline(
+    await callSyncApi(
+      "zenroom_pbkdf2_hex",
+      ["string", "string", "string", "number", "number"],
+      [hashType, passwordHex, saltHex, iterations, keylen]
+    )
   );
 };
 
@@ -259,7 +289,9 @@ export const signKeygenHex = async (
   algo: string,
   rngseed: string | null = null
 ): Promise<ZenroomResult> =>
-  callApi("zenroom_sign_keygen", ["string", "string"], [algo, rngseed]);
+  trimTrailingNewline(
+    await callSyncApi("zenroom_sign_keygen", ["string", "string"], [algo, rngseed])
+  );
 
 export const signPubgenHex = async (
   algo: string,
@@ -268,7 +300,9 @@ export const signPubgenHex = async (
   if (!isHex(keyHex)) {
     throw new Error("Invalid hex string");
   }
-  return callApi("zenroom_sign_pubgen", ["string", "string"], [algo, keyHex]);
+  return trimTrailingNewline(
+    await callSyncApi("zenroom_sign_pubgen", ["string", "string"], [algo, keyHex])
+  );
 };
 
 export const signCreateHex = async (
@@ -279,7 +313,9 @@ export const signCreateHex = async (
   if (!isHex(keyHex) || !isHex(msgHex)) {
     throw new Error("Invalid hex string");
   }
-  return callApi("zenroom_sign_create", ["string", "string", "string"], [algo, keyHex, msgHex]);
+  return trimTrailingNewline(
+    await callSyncApi("zenroom_sign_create", ["string", "string", "string"], [algo, keyHex, msgHex])
+  );
 };
 
 export const signVerifyHex = async (
@@ -291,10 +327,12 @@ export const signVerifyHex = async (
   if (!isHex(pubkeyHex) || !isHex(msgHex) || !isHex(sigHex)) {
     throw new Error("Invalid hex string");
   }
-  return callApi(
-    "zenroom_sign_verify",
-    ["string", "string", "string", "string"],
-    [algo, pubkeyHex, msgHex, sigHex]
+  return trimTrailingNewline(
+    await callSyncApi(
+      "zenroom_sign_verify",
+      ["string", "string", "string", "string"],
+      [algo, pubkeyHex, msgHex, sigHex]
+    )
   );
 };
 
@@ -315,7 +353,7 @@ export const merkleRootHex = async (
   const script = `local MT = require'crypto_merkle'
 local leaves = {${leavesLua}}
 print(MT.create_merkle_root(leaves, '${hashType}'):hex())`;
-  return zenroom_exec(script);
+  return trimTrailingNewline(await zenroom_exec(script));
 };
 
 export const merkleProofVerifyHex = async (
@@ -336,7 +374,7 @@ export const merkleProofVerifyHex = async (
 local proof = {${proofLua}}
 local ok = MT.verify_proof(proof, ${position}, O.from_hex('${rootHex}'), ${leafCount}, '${hashType}')
 print(ok and '1' or '0')`;
-  return zenroom_exec(script);
+  return trimTrailingNewline(await zenroom_exec(script));
 };
 
 export const zencode_valid_input = async (

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -19,7 +19,10 @@ const cache = {
 
 const getModule = async () => {
   if (cache.module === null) {
-    cache.module = await Zenroom();
+    cache.module = await Zenroom({
+      print: () => {},
+      printErr: () => {},
+    });
   }
   return cache.module;
 };
@@ -86,6 +89,18 @@ const zenroomExecToBuf = async (
   );
 };
 
+const zencodeExecToBuf = async (
+  zencode: string,
+  props?: ZenroomProps
+): Promise<ZenroomResult> => {
+  const { data = null, keys = null, extra = null, context = null, conf = null } = { ...props };
+  return await callBufferApi(
+    "zencode_exec_tobuf",
+    ["string", "string", "string", "string", "string", "string"],
+    [zencode, conf, keys, data, extra, context]
+  );
+};
+
 const isSafeIdentifier = (value: string): boolean => /^[A-Za-z0-9_]+$/.test(value);
 
 const isHex = (value: string): boolean =>
@@ -114,66 +129,12 @@ export const hexToUtf8 = (hex: string): string =>
 export const zencode_exec = async (
   zencode: string,
   props?: ZenroomProps
-): Promise<ZenroomResult> => {
-  const Module = await getModule();
-  return new Promise((resolve, reject) => {
-    let result = "";
-    let logs = "";
-    const _exec = Module.cwrap("zencode_exec", "number", [
-      "string",
-      "string",
-      "string",
-      "string",
-      "string",
-      "string",
-    ]);
-    Module.print = (t: string) => (result += t);
-    Module.printErr = (t: string) => (logs += t);
-    Module.exec_ok = () => {
-      resolve({ result, logs });
-    };
-    Module.exec_error = () => {
-      reject({ result, logs });
-    };
-    Module.onAbort = () => {
-      reject({ result, logs });
-    };
-    const { data = null, keys = null, extra = null, context = null, conf = null } = { ...props };
-    _exec(zencode, conf, keys, data, extra, context);
-  });
-};
+): Promise<ZenroomResult> => await zencodeExecToBuf(zencode, props);
 
 export const zenroom_exec = async (
   lua: string,
   props?: ZenroomProps
-): Promise<ZenroomResult> => {
-  const Module = await getModule();
-  return new Promise((resolve, reject) => {
-    let result = "";
-    let logs = "";
-    const _exec = Module.cwrap("zenroom_exec", "number", [
-      "string",
-      "string",
-      "string",
-      "string",
-      "string",
-      "string",
-    ]);
-    Module.print = (t: string) => (result += t);
-    Module.printErr = (t: string) => (logs += t);
-    Module.exec_ok = () => {
-      resolve({ result, logs });
-    };
-    Module.exec_error = () => {
-      reject({ result, logs });
-    };
-    Module.onAbort = () => {
-      reject({ result, logs });
-    };
-    const { data = null, keys = null, extra = null, context = null, conf = null } = { ...props };
-    _exec(lua, conf, keys, data, extra, context);
-  });
-};
+): Promise<ZenroomResult> => await zenroomExecToBuf(lua, props);
 
 export const zenroom_hash_init = async (
   hash_type: string

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -541,3 +541,17 @@ export const zencode_get_statements = async (
     _exec(scenario);
   });
 }
+
+export const recipeExec = async (
+  name: string,
+  data: string | null = null
+): Promise<ZenroomResult> => {
+  if (!/^[A-Za-z0-9._]+$/.test(name)) {
+    throw new Error("Invalid recipe name");
+  }
+  return callBufferApi(
+    "zenroom_recipe_exec_tobuf",
+    ["string", "string", "string", "string", "string", "string"],
+    [name, null, "{}", data, null, null]
+  );
+};

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -24,6 +24,56 @@ const getModule = async () => {
   return cache.module;
 };
 
+const callApi = async (
+  name: string,
+  argTypes: string[],
+  args: Array<string | number | null>
+): Promise<ZenroomResult> => {
+  const Module = await getModule();
+  return new Promise((resolve, reject) => {
+    let result = "";
+    let logs = "";
+    const exec = Module.cwrap(name, "number", argTypes);
+    Module.print = (t: string) => (result += t);
+    Module.printErr = (t: string) => (logs += t);
+    Module.exec_ok = () => {
+      resolve({ result, logs });
+    };
+    Module.exec_error = () => {
+      reject({ result, logs });
+    };
+    Module.onAbort = () => {
+      reject({ result, logs });
+    };
+    exec(...args);
+  });
+};
+
+const isSafeIdentifier = (value: string): boolean => /^[A-Za-z0-9_]+$/.test(value);
+
+const isHex = (value: string): boolean =>
+  value.length % 2 === 0 && /^[0-9a-fA-F]*$/.test(value);
+
+export const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+export const hexToBytes = (hex: string): Uint8Array => {
+  if (!isHex(hex)) {
+    throw new Error("Invalid hex string");
+  }
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return out;
+};
+
+export const utf8ToHex = (value: string): string =>
+  bytesToHex(new TextEncoder().encode(value));
+
+export const hexToUtf8 = (hex: string): string =>
+  new TextDecoder().decode(hexToBytes(hex));
+
 export const zencode_exec = async (
   zencode: string,
   props?: ZenroomProps
@@ -176,6 +226,117 @@ export const zenroom_hash = async (
     ctx = await zenroom_hash_update(ctx.result, i8a);
   }
   return await zenroom_hash_final(ctx.result);
+};
+
+export const hashHex = async (
+  hashType: string,
+  msgHex: string
+): Promise<ZenroomResult> => {
+  if (!isHex(msgHex)) {
+    throw new Error("Invalid hex string");
+  }
+  return callApi("zenroom_hash_hex", ["string", "string"], [hashType, msgHex]);
+};
+
+export const pbkdf2Hex = async (
+  hashType: string,
+  passwordHex: string,
+  saltHex: string,
+  iterations: number,
+  keylen: number
+): Promise<ZenroomResult> => {
+  if (!isHex(passwordHex) || !isHex(saltHex)) {
+    throw new Error("Invalid hex string");
+  }
+  return callApi(
+    "zenroom_pbkdf2_hex",
+    ["string", "string", "string", "number", "number"],
+    [hashType, passwordHex, saltHex, iterations, keylen]
+  );
+};
+
+export const signKeygenHex = async (
+  algo: string,
+  rngseed: string | null = null
+): Promise<ZenroomResult> =>
+  callApi("zenroom_sign_keygen", ["string", "string"], [algo, rngseed]);
+
+export const signPubgenHex = async (
+  algo: string,
+  keyHex: string
+): Promise<ZenroomResult> => {
+  if (!isHex(keyHex)) {
+    throw new Error("Invalid hex string");
+  }
+  return callApi("zenroom_sign_pubgen", ["string", "string"], [algo, keyHex]);
+};
+
+export const signCreateHex = async (
+  algo: string,
+  keyHex: string,
+  msgHex: string
+): Promise<ZenroomResult> => {
+  if (!isHex(keyHex) || !isHex(msgHex)) {
+    throw new Error("Invalid hex string");
+  }
+  return callApi("zenroom_sign_create", ["string", "string", "string"], [algo, keyHex, msgHex]);
+};
+
+export const signVerifyHex = async (
+  algo: string,
+  pubkeyHex: string,
+  msgHex: string,
+  sigHex: string
+): Promise<ZenroomResult> => {
+  if (!isHex(pubkeyHex) || !isHex(msgHex) || !isHex(sigHex)) {
+    throw new Error("Invalid hex string");
+  }
+  return callApi(
+    "zenroom_sign_verify",
+    ["string", "string", "string", "string"],
+    [algo, pubkeyHex, msgHex, sigHex]
+  );
+};
+
+export const merkleRootHex = async (
+  leavesHex: string[],
+  hashType: string = "sha256"
+): Promise<ZenroomResult> => {
+  if (!isSafeIdentifier(hashType)) {
+    throw new Error("Invalid hash type");
+  }
+  if (!Array.isArray(leavesHex) || leavesHex.length === 0) {
+    throw new Error("Expected at least one leaf");
+  }
+  if (leavesHex.some((leaf) => !isHex(leaf))) {
+    throw new Error("Invalid hex string");
+  }
+  const leavesLua = leavesHex.map((leaf) => `O.from_hex('${leaf}')`).join(", ");
+  const script = `local MT = require'crypto_merkle'
+local leaves = {${leavesLua}}
+print(MT.create_merkle_root(leaves, '${hashType}'):hex())`;
+  return zenroom_exec(script);
+};
+
+export const merkleProofVerifyHex = async (
+  proofHex: string[],
+  position: number,
+  rootHex: string,
+  leafCount: number,
+  hashType: string = "sha256"
+): Promise<ZenroomResult> => {
+  if (!isSafeIdentifier(hashType)) {
+    throw new Error("Invalid hash type");
+  }
+  if (!isHex(rootHex) || proofHex.some((leaf) => !isHex(leaf))) {
+    throw new Error("Invalid hex string");
+  }
+  const proofLua = proofHex.map((leaf) => `O.from_hex('${leaf}')`).join(", ");
+  const script = `local MT = require'crypto_merkle'
+local proof = {${proofLua}}
+local ok = MT.verify_proof(proof, ${position}, O.from_hex('${rootHex}'), ${leafCount}, '${hashType}')
+print(ok and '1' or '0')`;
+  return zenroom_exec(script);
 };
 
 export const zencode_valid_input = async (

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -23,6 +23,9 @@ const getModule = async () => {
       print: () => {},
       printErr: () => {},
     });
+    cache.module.exec_ok = () => {};
+    cache.module.exec_error = () => {};
+    cache.module.onAbort = () => {};
   }
   return cache.module;
 };

--- a/bindings/javascript/src/index.ts
+++ b/bindings/javascript/src/index.ts
@@ -72,6 +72,46 @@ const callBufferApi = async (
   }
 };
 
+const callPrintApi = async (
+  name: string,
+  argTypes: string[],
+  args: Array<string | number | null>
+): Promise<ZenroomResult> => {
+  const Module = await getModule();
+  return new Promise((resolve, reject) => {
+    let result = "";
+    let logs = "";
+    const exec = Module.cwrap(name, "number", argTypes);
+    const prevPrint = Module.print;
+    const prevPrintErr = Module.printErr;
+    const prevExecOk = Module.exec_ok;
+    const prevExecError = Module.exec_error;
+    const prevOnAbort = Module.onAbort;
+    const restore = () => {
+      Module.print = prevPrint;
+      Module.printErr = prevPrintErr;
+      Module.exec_ok = prevExecOk;
+      Module.exec_error = prevExecError;
+      Module.onAbort = prevOnAbort;
+    };
+    Module.print = (t: string) => (result += t);
+    Module.printErr = (t: string) => (logs += t);
+    Module.exec_ok = () => {
+      restore();
+      resolve({ result, logs });
+    };
+    Module.exec_error = () => {
+      restore();
+      reject({ result, logs });
+    };
+    Module.onAbort = () => {
+      restore();
+      reject({ result, logs });
+    };
+    exec(...args);
+  });
+};
+
 const trimTrailingNewline = ({ result, logs }: ZenroomResult): ZenroomResult => ({
   result: result.replace(/\n$/, ""),
   logs,
@@ -86,18 +126,6 @@ const zenroomExecToBuf = async (
     "zenroom_exec_tobuf",
     ["string", "string", "string", "string", "string", "string"],
     [lua, conf, keys, data, extra, context]
-  );
-};
-
-const zencodeExecToBuf = async (
-  zencode: string,
-  props?: ZenroomProps
-): Promise<ZenroomResult> => {
-  const { data = null, keys = null, extra = null, context = null, conf = null } = { ...props };
-  return await callBufferApi(
-    "zencode_exec_tobuf",
-    ["string", "string", "string", "string", "string", "string"],
-    [zencode, conf, keys, data, extra, context]
   );
 };
 
@@ -129,12 +157,26 @@ export const hexToUtf8 = (hex: string): string =>
 export const zencode_exec = async (
   zencode: string,
   props?: ZenroomProps
-): Promise<ZenroomResult> => await zencodeExecToBuf(zencode, props);
+): Promise<ZenroomResult> => {
+  const { data = null, keys = null, extra = null, context = null, conf = null } = { ...props };
+  return await callPrintApi(
+    "zencode_exec",
+    ["string", "string", "string", "string", "string", "string"],
+    [zencode, conf, keys, data, extra, context]
+  );
+};
 
 export const zenroom_exec = async (
   lua: string,
   props?: ZenroomProps
-): Promise<ZenroomResult> => await zenroomExecToBuf(lua, props);
+): Promise<ZenroomResult> => {
+  const { data = null, keys = null, extra = null, context = null, conf = null } = { ...props };
+  return await callPrintApi(
+    "zenroom_exec",
+    ["string", "string", "string", "string", "string", "string"],
+    [lua, conf, keys, data, extra, context]
+  );
+};
 
 export const zenroom_hash_init = async (
   hash_type: string

--- a/build/embed-lualibs
+++ b/build/embed-lualibs
@@ -44,13 +44,13 @@ scenarios=""
 }
 
 for i in ${libs}; do
-    p=$(basename $i)
-    case " ${embed_excludes} " in
-        *" ${p} "*) continue ;;
-    esac
-    n=$(echo "$p" | cut -d'.' -f1)
-    f="lualib_${n}.c"
-    echo "+ $i $opts"
+	p=$(basename $i)
+	case " ${embed_excludes} " in
+		*" ${p} "*) continue ;;
+	esac
+	n=$(echo "$p" | cut -d'.' -f1)
+	f="lualib_${n}.c"
+	echo "+ $i $opts"
 	tmp=$(mktemp -d)
 	if [ "$opts" = "compile" ]; then
 		./luac54 -o ${tmp}/${n} $i
@@ -58,14 +58,14 @@ for i in ${libs}; do
 		cp $i ${tmp}/${n}
 	fi
 	cd $tmp
-	echo "// $i" >>  ${dst}
-	xxd -i ${n}   >>  ${dst}
+	echo "// $i" >> ${dst}
+	xxd -i ${n} >> ${dst}
 	if [ "$(uname -s)" = "Linux" ]; then
 		sed -i 's/^unsigned/const unsigned/' ${dst}
 	else
 		sed -e 's/^unsigned/const unsigned/' -i '' "${dst}"
 	fi
-	echo "" >>  ${dst}
+	echo "" >> ${dst}
 	cd - > /dev/null
 	rm -rf $tmp
 	ext_nes="\t{\"${n}\", &${n}_len, (const char *)${n}},"

--- a/build/init.mk
+++ b/build/init.mk
@@ -12,7 +12,7 @@ ZEN_SOURCES := src/zenroom.o src/zen_error.o src/lua_functions.o		\
     src/zen_random.o src/zen_hash.o src/zen_ecdh_factory.o				\
     src/zen_ecdh.o src/zen_x509.o src/zen_aes.o src/zen_qp.o			\
     src/zen_ed.o src/zen_float.o src/zen_time.o src/api_hash.o			\
-    src/api_sign.o src/randombytes.o src/zen_fuzzer.o src/cortex_m.o	\
+    src/api_sign.o src/api_recipe.o src/randombytes.o src/zen_fuzzer.o src/cortex_m.o	\
     src/p256-m.o src/zen_p256.o src/zen_rsa.o src/zen_bbs.o				\
     src/zen_longfellow.o src/zen_mayo.o
 

--- a/build/wasm.mk
+++ b/build/wasm.mk
@@ -32,7 +32,7 @@ ld_emsdk_settings := -I ${EMSCRIPTEN}/system/include/libc -DLIBRARY
 ld_emsdk_settings += -sMODULARIZE=1	-sSINGLE_FILE=1 --embed-file 'src/lua@/'
 ld_emsdk_settings += -sMALLOC=dlmalloc --no-heap-copy -sALLOW_MEMORY_GROWTH=1
 ld_emsdk_settings += -sINITIAL_MEMORY=${JS_INIT_MEM} -sMAXIMUM_MEMORY=${JS_MAX_MEM} -sSTACK_SIZE=${JS_STACK_SIZE} -sASSERTIONS
-ld_emsdk_settings += -sINCOMING_MODULE_JS_API=print,printErr -s EXPORTED_FUNCTIONS=${WASM_EXPORTS} -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap"]'
+ld_emsdk_settings += -sINCOMING_MODULE_JS_API=print,printErr -s EXPORTED_FUNCTIONS=${WASM_EXPORTS} -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap","HEAPU8"]'
 ld_emsdk_optimizations := -O2 -sSTRICT -flto -sUSE_SDL=0 -sEVAL_CTORS=1
 cc_emsdk_settings := -DARCH_WASM -D'ARCH="WASM"'
 cc_emsdk_optimizations := -O2 -sSTRICT -flto -fno-rtti -fno-exceptions

--- a/build/wasm.mk
+++ b/build/wasm.mk
@@ -6,7 +6,7 @@ JS_MAX_MEM := 1024MB
 JS_STACK_SIZE := 7MB
 
 # Add here any function used from JS
-WASM_EXPORTS := '["_malloc","_free","_calloc","_realloc","_zenroom_exec","_zencode_exec","_zenroom_hash_init","_zenroom_hash_update","_zenroom_hash_final","_zenroom_hash_hex","_zenroom_pbkdf2_hex","_zenroom_sign_keygen","_zenroom_sign_pubgen","_zenroom_sign_create","_zenroom_sign_verify","_zencode_valid_input","_zencode_valid_code","_zencode_get_statements"]'
+WASM_EXPORTS := '["_malloc","_free","_calloc","_realloc","_zenroom_exec","_zenroom_exec_tobuf","_zencode_exec","_zencode_exec_tobuf","_zenroom_hash_init","_zenroom_hash_update","_zenroom_hash_final","_zenroom_hash_hex","_zenroom_hash_hex_tobuf","_zenroom_pbkdf2_hex","_zenroom_pbkdf2_hex_tobuf","_zenroom_sign_keygen","_zenroom_sign_keygen_tobuf","_zenroom_sign_pubgen","_zenroom_sign_pubgen_tobuf","_zenroom_sign_create","_zenroom_sign_create_tobuf","_zenroom_sign_verify","_zenroom_sign_verify_tobuf","_zencode_valid_input","_zencode_valid_code","_zencode_get_statements"]'
 
 # EMSDK should point to installation of EMSDK i.e.: /opt/emsdk
 EMSCRIPTEN ?= ${EMSDK}/upstream/emscripten

--- a/build/wasm.mk
+++ b/build/wasm.mk
@@ -6,7 +6,7 @@ JS_MAX_MEM := 1024MB
 JS_STACK_SIZE := 7MB
 
 # Add here any function used from JS
-WASM_EXPORTS := '["_malloc","_free","_calloc","_realloc","_zenroom_exec","_zencode_exec","_zenroom_hash_init","_zenroom_hash_update","_zenroom_hash_final","_zencode_valid_input","_zencode_valid_code","_zencode_get_statements"]'
+WASM_EXPORTS := '["_malloc","_free","_calloc","_realloc","_zenroom_exec","_zencode_exec","_zenroom_hash_init","_zenroom_hash_update","_zenroom_hash_final","_zenroom_hash_hex","_zenroom_pbkdf2_hex","_zenroom_sign_keygen","_zenroom_sign_pubgen","_zenroom_sign_create","_zenroom_sign_verify","_zencode_valid_input","_zencode_valid_code","_zencode_get_statements"]'
 
 # EMSDK should point to installation of EMSDK i.e.: /opt/emsdk
 EMSCRIPTEN ?= ${EMSDK}/upstream/emscripten

--- a/build/wasm.mk
+++ b/build/wasm.mk
@@ -29,7 +29,7 @@ zk-circuit-lang_cxxflags := -I ${pwd}/src -I. -I../zstd -fPIC -DLIBRARY -msimd12
 system := Javascript
 LUA_EMBED_EXCLUDES += crypto_zkcc.lua
 ld_emsdk_settings := -I ${EMSCRIPTEN}/system/include/libc -DLIBRARY
-ld_emsdk_settings += -sMODULARIZE=1	-sSINGLE_FILE=1 --embed-file 'src/lua@/'
+ld_emsdk_settings += -sMODULARIZE=1	-sSINGLE_FILE=1 --embed-file 'src/lua@/' --embed-file 'src/api_recipes@/api_recipes/'
 ld_emsdk_settings += -sMALLOC=dlmalloc --no-heap-copy -sALLOW_MEMORY_GROWTH=1
 ld_emsdk_settings += -sINITIAL_MEMORY=${JS_INIT_MEM} -sMAXIMUM_MEMORY=${JS_MAX_MEM} -sSTACK_SIZE=${JS_STACK_SIZE} -sASSERTIONS
 ld_emsdk_settings += -sINCOMING_MODULE_JS_API=print,printErr -s EXPORTED_FUNCTIONS=${WASM_EXPORTS} -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap","HEAPU8"]'

--- a/build/wasm.mk
+++ b/build/wasm.mk
@@ -6,7 +6,7 @@ JS_MAX_MEM := 1024MB
 JS_STACK_SIZE := 7MB
 
 # Add here any function used from JS
-WASM_EXPORTS := '["_malloc","_free","_calloc","_realloc","_zenroom_exec","_zenroom_exec_tobuf","_zencode_exec","_zencode_exec_tobuf","_zenroom_hash_init","_zenroom_hash_update","_zenroom_hash_final","_zenroom_hash_hex","_zenroom_hash_hex_tobuf","_zenroom_pbkdf2_hex","_zenroom_pbkdf2_hex_tobuf","_zenroom_sign_keygen","_zenroom_sign_keygen_tobuf","_zenroom_sign_pubgen","_zenroom_sign_pubgen_tobuf","_zenroom_sign_create","_zenroom_sign_create_tobuf","_zenroom_sign_verify","_zenroom_sign_verify_tobuf","_zencode_valid_input","_zencode_valid_code","_zencode_get_statements"]'
+WASM_EXPORTS := '["_malloc","_free","_calloc","_realloc","_zenroom_exec","_zenroom_exec_tobuf","_zencode_exec","_zencode_exec_tobuf","_zenroom_hash_init","_zenroom_hash_update","_zenroom_hash_final","_zenroom_hash_hex","_zenroom_hash_hex_tobuf","_zenroom_pbkdf2_hex","_zenroom_pbkdf2_hex_tobuf","_zenroom_sign_keygen","_zenroom_sign_keygen_tobuf","_zenroom_sign_pubgen","_zenroom_sign_pubgen_tobuf","_zenroom_sign_create","_zenroom_sign_create_tobuf","_zenroom_sign_verify","_zenroom_sign_verify_tobuf","_zencode_valid_input","_zencode_valid_code","_zencode_get_statements","_zenroom_recipe_exec","_zenroom_recipe_exec_tobuf"]'
 
 # EMSDK should point to installation of EMSDK i.e.: /opt/emsdk
 EMSCRIPTEN ?= ${EMSDK}/upstream/emscripten

--- a/docs/pages/how-to-embed.md
+++ b/docs/pages/how-to-embed.md
@@ -101,31 +101,12 @@ and its name will be used as key.
 
 ### API direct calls (skip VM init)
 
-Zenroom offers direct API calls to certain cryptographic primitives, executing very fast when there is no need to initialize the whole VM. These calls may be just simplier to use for expert developers doing simple things.
+For direct cryptographic primitives callable from JavaScript without
+writing Lua or Zencode scripts, see the dedicated page:
+[JavaScript API – Direct Calls](javascript-api.md)
 
-All direct API calls return 0 on success, anything else is an error.
-
-All their input arguments and output are encoded string values, their encoding may vary: it is almost everywhere HEX (base 16), but Base64 is used for hashes.
-
-The output is an encoded string printed to stdout, easy to collect from Javascript.
-
-#### Zenroom_hash* API
-
-The encoding of of all arguments is:
-- `hash_type` ASCII
-- `hash_ctx` HEX
-- `buffer` Base64
-
-The `zennrom_hash*` functions:
-```c
-// hash_type may be one of these two strings: 'sha256' or 'sha512'
-int zenroom_hash_init(const char *hash_type);
-
-// hash_ctx is the string returned by init
-// buffer is an hex encoded string of the value to be hashed
-// buffer_size is the size in bytes of the value to be hashed
-int zenroom_hash_update(const char *hash_ctx, const char *buffer, const int buffer_size);
-
-// the final call will print the base64 encoded hash of the input data
-int zenroom_hash_final(const char *hash_ctx);
-```
+The page covers `hashHex`, `pbkdf2Hex`, `signKeygenHex`,
+`signCreateHex`, `signVerifyHex`, `merkleRootHex`,
+`merkleProofVerifyHex`, `recipeExec`, and encoding helpers —
+all importable from `"zenroom"` after `npm install zenroom`.  Every
+binary input and output uses lowercase hex.

--- a/docs/pages/javascript-api.md
+++ b/docs/pages/javascript-api.md
@@ -1,0 +1,252 @@
+# JavaScript API – Direct Calls
+
+The `zenroom` npm package exposes fast cryptographic primitives
+that work without writing Lua or Zencode scripts.  Import the
+functions you need:
+
+```js
+import { hashHex, signKeygenHex, merkleRootHex } from "zenroom";
+```
+
+Every function returns a `Promise<{ result: string, logs: string }>`.
+On success, `result` contains the output.  On failure the promise
+rejects with the same shape — inspect `logs` for error details.
+
+---
+
+## Hash
+
+### One-shot hex hash
+
+Hash a hex-encoded message in one call.  The digest is lowercase hex.
+
+```js
+import { hashHex, utf8ToHex } from "zenroom";
+
+const { result } = await hashHex("sha256", utf8ToHex("hello"));
+console.log(result);
+// => 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+```
+
+`hashHex(algorithm, messageHex)`
+
+| arg | type | note |
+|---|---|---|
+| `algorithm` | `string` | one of: `sha256` `sha384` `sha512` `sha3_256` `sha3_512` `shake256` `keccak256` `ripemd160` |
+| `messageHex` | `string` | lowercase hex (even length) |
+
+### PBKDF2 key derivation
+
+```js
+import { pbkdf2Hex, utf8ToHex } from "zenroom";
+
+const { result: key } = await pbkdf2Hex(
+  "sha256",
+  utf8ToHex("password"),
+  utf8ToHex("salt"),
+  4096,   // iterations
+  32      // output length in bytes
+);
+// key is a 64-char hex string (32 bytes)
+```
+
+`pbkdf2Hex(algorithm, passwordHex, saltHex, iterations, keylen)`
+
+| arg | type | note |
+|---|---|---|
+| `algorithm` | `string` | `sha256` or `sha512` |
+| `passwordHex` | `string` | lowercase hex |
+| `saltHex` | `string` | lowercase hex |
+| `iterations` | `number` | > 0 |
+| `keylen` | `number` | output bytes, > 0 |
+
+### Streaming hash (legacy)
+
+For large inputs or compatibility with existing code:
+
+```js
+import { zenroom_hash } from "zenroom";
+
+const { result: b64 } = await zenroom_hash("sha256", "hello world");
+// result is base64-encoded (legacy format)
+```
+
+---
+
+## Signatures
+
+All signature functions share the same interface.  The first argument
+is the algorithm name, followed by hex-encoded keys, messages, and
+signatures.
+
+| algorithm | curve / standard | key (hex) | pk (hex) | sig (hex) |
+|---|---|---|---|---|
+| `eddsa` | Ed25519 | 64 chars | 64 chars | 128 chars |
+| `p256` | P-256 / secp256r1 ECDSA | 64 chars | 128 chars | 128 chars |
+| `mldsa44` | ML-DSA-44 FIPS 204 | 5120 chars | 2624 chars | 4840 chars |
+
+### Key generation
+
+```js
+import { signKeygenHex } from "zenroom";
+
+// Without seed (uses internal PRNG)
+const { result: sk } = await signKeygenHex("eddsa");
+
+// With a deterministic hex seed (must be 64 bytes = 128 hex chars)
+const { result: sk2 } = await signKeygenHex("eddsa", "0".repeat(128));
+```
+
+`signKeygenHex(algorithm, rngseed?)`
+
+| arg | type | note |
+|---|---|---|
+| `algorithm` | `string` | `eddsa` `p256` `mldsa44` |
+| `rngseed` | `string?` | optional 128-char hex seed for deterministic keygen |
+
+### Public key derivation
+
+```js
+const { result: pk } = await signPubgenHex("eddsa", sk);
+```
+
+`signPubgenHex(algorithm, secretKeyHex)`
+
+### Sign
+
+```js
+const msgHex = utf8ToHex("hello");
+const { result: sig } = await signCreateHex("eddsa", sk, msgHex);
+```
+
+`signCreateHex(algorithm, secretKeyHex, messageHex)`
+
+### Verify
+
+```js
+const { result: ok } = await signVerifyHex("eddsa", pk, msgHex, sig);
+console.log(ok); // "1" (valid) or "0" (invalid)
+```
+
+`signVerifyHex(algorithm, publicKeyHex, messageHex, signatureHex)`
+
+### Full EdDSA example
+
+```js
+import { signKeygenHex, signPubgenHex, signCreateHex, signVerifyHex, utf8ToHex } from "zenroom";
+
+const { result: sk } = await signKeygenHex("eddsa");
+const { result: pk } = await signPubgenHex("eddsa", sk);
+const { result: sig } = await signCreateHex("eddsa", sk, utf8ToHex("sign this"));
+const { result: ok } = await signVerifyHex("eddsa", pk, utf8ToHex("sign this"), sig);
+console.log(ok); // "1"
+```
+
+---
+
+## Merkle Trees
+
+Merkle operations are Lua-backed and don't require writing scripts.
+
+### Root
+
+```js
+import { merkleRootHex } from "zenroom";
+
+const { result: root } = await merkleRootHex(
+  ["0101010101010101010101010101010101010101010101010101010101010101",
+   "0202020202020202020202020202020202020202020202020202020202020202"],
+  "sha256"   // optional, defaults to "sha256"
+);
+// root is a 64-char hex string
+```
+
+### Proof verification
+
+```js
+import { merkleProofVerifyHex } from "zenroom";
+
+const { result: ok } = await merkleProofVerifyHex(
+  proofHexArray,    // sibling hashes
+  0,                // leaf position
+  rootHex,          // trusted root
+  4,                // total leaf count
+  "sha256"          // optional
+);
+console.log(ok); // "1" or "0"
+```
+
+---
+
+## Named Recipes
+
+Run higher-level Lua-backed operations via a short recipe name with
+JSON input.  Every binary value inside the JSON must be hex.
+
+```js
+import { recipeExec } from "zenroom";
+
+const { result } = await recipeExec("merkle.root", JSON.stringify({
+  hash: "sha256",
+  leaves: [
+    "0101010101010101010101010101010101010101010101010101010101010101",
+    "0202020202020202020202020202020202020202020202020202020202020202",
+  ],
+}));
+const { root } = JSON.parse(result);
+```
+
+Available recipes: `"merkle.root"`, `"merkle.verify_proof"`.
+
+---
+
+## Encoding Helpers
+
+Small utilities to convert between hex, UTF-8, and `Uint8Array` —
+no WASM call needed.
+
+```js
+import { bytesToHex, hexToBytes, utf8ToHex, hexToUtf8 } from "zenroom";
+
+utf8ToHex("hello");          // "68656c6c6f"
+hexToUtf8("68656c6c6f");     // "hello"
+
+hexToBytes("deadbeef");      // Uint8Array [0xde, 0xad, 0xbe, 0xef]
+bytesToHex(new Uint8Array([0xde, 0xad, 0xbe, 0xef])); // "deadbeef"
+```
+
+---
+
+## Executing Zencode and Lua Scripts
+
+For full VM-backed workflows use the same functions documented in
+[Embedding Zenroom](how-to-embed.md):
+
+```js
+import { zencode_exec, zenroom_exec } from "zenroom";
+
+const { result } = await zencode_exec(`
+  Given nothing
+  When I create the random array with '4' elements each of '32' bits
+  Then print all data
+`);
+
+// The legacy introspection helper:
+import { introspect } from "zenroom";
+const codec = await introspect(`Given I have a 'string' named 'msg'`);
+```
+
+---
+
+## Error Handling
+
+All functions throw on failure.  The error object has `result` and
+`logs` properties just like the success response:
+
+```js
+try {
+  await hashHex("unknown", "aa");
+} catch ({ logs }) {
+  console.error(logs);
+}
+```

--- a/src/api_hash.c
+++ b/src/api_hash.c
@@ -20,6 +20,7 @@
 
 // external API function for streaming hash
 #include <stdio.h>
+#include <string.h>
 #include <strings.h>
 
 #if defined(_WIN32)
@@ -33,6 +34,7 @@
 
 #include <zen_error.h>
 #include <encoding.h> // zenroom
+#include <zenroom.h>
 
 // first byte is type
 #define ZEN_SHA512 '4'
@@ -50,6 +52,173 @@ int print_ctx_hex(char prefix, void *sh, int len) {
 	_out("%s", hash_ctx);
 	free(hash_ctx);
 	return 0;
+}
+
+static int api_hash_type_is_safe(const char *hash_type) {
+	size_t i;
+	if (!hash_type || !hash_type[0]) {
+		return 0;
+	}
+	for (i = 0; hash_type[i] != 0x0; i++) {
+		const char c = hash_type[i];
+		if (!((c >= 'a' && c <= 'z') ||
+			  (c >= 'A' && c <= 'Z') ||
+			  (c >= '0' && c <= '9') ||
+			  c == '_')) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+static int api_run_hash_script(const char *script,
+							   const char *data,
+							   const char *keys,
+							   char *stdout_buf, size_t stdout_len,
+							   char *stderr_buf, size_t stderr_len) {
+	if (stderr_buf && stderr_len > 0) {
+		stderr_buf[0] = 0x0;
+	}
+	return zenroom_exec_tobuf(script, NULL, keys, data, NULL, NULL,
+							  stdout_buf, stdout_len, stderr_buf, stderr_len);
+}
+
+/**
+   Hash a hex-encoded message using the named algorithm and write the hex digest
+   into the caller-provided output buffer.
+ */
+int zenroom_hash_hex_tobuf(const char *hash_type, const char *msg_hex,
+						   char *stdout_buf, size_t stdout_len,
+						   char *stderr_buf, size_t stderr_len) {
+	char script[160];
+	if (!hash_type) {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: missing arg: hash_type", __func__);
+		}
+		if (stdout_buf && stdout_len > 0) {
+			stdout_buf[0] = 0x0;
+		}
+		return FAIL();
+	}
+	if (!msg_hex) {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: missing arg: msg_hex", __func__);
+		}
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return FAIL();
+	}
+	if (!api_hash_type_is_safe(hash_type)) {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: invalid hash type: %s", __func__, hash_type);
+		}
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return FAIL();
+	}
+	snprintf(script, sizeof(script),
+			 "local h = HASH.new('%s')\n"
+			 "print(h:process(O.from_hex(DATA)):hex())",
+			 hash_type);
+	return api_run_hash_script(script, msg_hex, NULL,
+							   stdout_buf, stdout_len, stderr_buf, stderr_len);
+}
+
+int zenroom_hash_hex(const char *hash_type, const char *msg_hex) {
+	char stdout_buf[1024] = {0};
+	char stderr_buf[512] = {0};
+	int res = zenroom_hash_hex_tobuf(hash_type, msg_hex,
+									 stdout_buf, sizeof(stdout_buf),
+									 stderr_buf, sizeof(stderr_buf));
+	if (res == OK()) {
+		_out("%s", stdout_buf);
+	} else if (stderr_buf[0] != 0x0) {
+		_err("%s", stderr_buf);
+	}
+	return res;
+}
+
+/**
+   Derive a hex-encoded key using PBKDF2 with the named hash algorithm.
+ */
+int zenroom_pbkdf2_hex_tobuf(const char *hash_type,
+							 const char *password_hex,
+							 const char *salt_hex,
+							 int iterations,
+							 int keylen,
+							 char *stdout_buf, size_t stdout_len,
+							 char *stderr_buf, size_t stderr_len) {
+	char script[256];
+	if (!hash_type) {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: missing arg: hash_type", __func__);
+		}
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return FAIL();
+	}
+	if (!password_hex) {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: missing arg: password_hex", __func__);
+		}
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return FAIL();
+	}
+	if (!salt_hex) {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: missing arg: salt_hex", __func__);
+		}
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return FAIL();
+	}
+	if (iterations <= 0) {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: iterations must be positive", __func__);
+		}
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return FAIL();
+	}
+	if (keylen <= 0) {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: keylen must be positive", __func__);
+		}
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return FAIL();
+	}
+	if (!api_hash_type_is_safe(hash_type)) {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: invalid hash type: %s", __func__, hash_type);
+		}
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return FAIL();
+	}
+	snprintf(script, sizeof(script),
+			 "local h = HASH.new('%s')\n"
+			 "local out = h:pbkdf2(O.from_hex(DATA), {\n"
+			 "  salt = O.from_hex(KEYS),\n"
+			 "  iterations = %d,\n"
+			 "  length = %d\n"
+			 "})\n"
+			 "print(out:hex())",
+			 hash_type, iterations, keylen);
+	return api_run_hash_script(script, password_hex, salt_hex,
+							   stdout_buf, stdout_len, stderr_buf, stderr_len);
+}
+
+int zenroom_pbkdf2_hex(const char *hash_type,
+					   const char *password_hex,
+					   const char *salt_hex,
+					   int iterations,
+					   int keylen) {
+	char stdout_buf[1024] = {0};
+	char stderr_buf[512] = {0};
+	int res = zenroom_pbkdf2_hex_tobuf(hash_type, password_hex, salt_hex,
+									   iterations, keylen,
+									   stdout_buf, sizeof(stdout_buf),
+									   stderr_buf, sizeof(stderr_buf));
+	if (res == OK()) {
+		_out("%s", stdout_buf);
+	} else if (stderr_buf[0] != 0x0) {
+		_err("%s", stderr_buf);
+	}
+	return res;
 }
 
 // returns a fills hash_ctx, which must be pre-allocated externally

--- a/src/api_recipe.c
+++ b/src/api_recipe.c
@@ -31,6 +31,8 @@
 #include <zen_error.h>
 #include <zenroom.h>
 
+#define RECIPE_MAX_SIZE 8192
+
 static int api_recipe_name_is_safe(const char *name) {
 	size_t i;
 	if (!name || !name[0]) {
@@ -46,6 +48,29 @@ static int api_recipe_name_is_safe(const char *name) {
 		}
 	}
 	return 1;
+}
+
+static int api_recipe_read_file(const char *name,
+								char *script, size_t script_size) {
+	char path[256];
+	FILE *fp;
+	size_t n;
+#ifdef __EMSCRIPTEN__
+	snprintf(path, sizeof(path), "/api_recipes/%s.lua", name);
+#else
+	snprintf(path, sizeof(path), "src/api_recipes/%s.lua", name);
+#endif
+	fp = fopen(path, "r");
+	if (!fp) {
+		return -1;
+	}
+	n = fread(script, 1, script_size - 1, fp);
+	fclose(fp);
+	if (n == 0) {
+		return -1;
+	}
+	script[n] = 0x0;
+	return 0;
 }
 
 int zenroom_recipe_exec(const char *name,
@@ -69,33 +94,13 @@ int zenroom_recipe_exec(const char *name,
 	return res;
 }
 
-static const char *recipe_merkle_root_script =
-	"local J = require'json'\n"
-	"local data = DATA and J.raw_decode(DATA) or {}\n"
-	"local MT = require'crypto_merkle'\n"
-	"local leaves = {}\n"
-	"for _, h in ipairs(data.leaves or {}) do table.insert(leaves, O.from_hex(h)) end\n"
-	"local root = MT.create_merkle_root(leaves, data.hash or 'sha256')\n"
-	"local out = J.raw_encode({root = root:hex()})\n"
-	"print(out)\n";
-
-static const char *recipe_merkle_verify_proof_script =
-	"local J = require'json'\n"
-	"local data = DATA and J.raw_decode(DATA) or {}\n"
-	"local MT = require'crypto_merkle'\n"
-	"local proof = {}\n"
-	"for _, p in ipairs(data.proof or {}) do table.insert(proof, O.from_hex(p)) end\n"
-	"local ok = MT.verify_proof(proof, data.position or 0, O.from_hex(data.root or ''), data.leaf_count or 0, data.hash or 'sha256')\n"
-	"local out = J.raw_encode({valid = ok})\n"
-	"print(out)\n";
-
 int zenroom_recipe_exec_tobuf(const char *name,
 							  const char *conf, const char *keys,
 							  const char *data, const char *extra,
 							  const char *context,
 							  char *stdout_buf, size_t stdout_len,
 							  char *stderr_buf, size_t stderr_len) {
-	const char *script = NULL;
+	char script[RECIPE_MAX_SIZE];
 
 	if (!name) {
 		if (stderr_buf && stderr_len > 0) {
@@ -116,13 +121,9 @@ int zenroom_recipe_exec_tobuf(const char *name,
 		return FAIL();
 	}
 
-	if (!strcmp(name, "merkle.root")) {
-		script = recipe_merkle_root_script;
-	} else if (!strcmp(name, "merkle.verify_proof")) {
-		script = recipe_merkle_verify_proof_script;
-	} else {
+	if (api_recipe_read_file(name, script, sizeof(script)) != 0) {
 		if (stderr_buf && stderr_len > 0) {
-			snprintf(stderr_buf, stderr_len, "%s :: unknown recipe: %s", __func__, name);
+			snprintf(stderr_buf, stderr_len, "%s :: recipe not found: %s", __func__, name);
 		}
 		if (stdout_buf && stdout_len > 0) {
 			stdout_buf[0] = 0x0;

--- a/src/api_recipe.c
+++ b/src/api_recipe.c
@@ -1,0 +1,135 @@
+/* This file is part of Zenroom (https://zenroom.dyne.org)
+ *
+ * Copyright (C) 2022-2026 Dyne.org foundation
+ * designed, written and maintained by Denis Roio <jaromil@dyne.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+
+#if defined(_WIN32)
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
+
+#include <zen_error.h>
+#include <zenroom.h>
+
+static int api_recipe_name_is_safe(const char *name) {
+	size_t i;
+	if (!name || !name[0]) {
+		return 0;
+	}
+	for (i = 0; name[i] != 0x0; i++) {
+		const char c = name[i];
+		if (!((c >= 'a' && c <= 'z') ||
+			  (c >= 'A' && c <= 'Z') ||
+			  (c >= '0' && c <= '9') ||
+			  c == '_' || c == '.')) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+int zenroom_recipe_exec(const char *name,
+						const char *conf, const char *keys,
+						const char *data, const char *extra,
+						const char *context) {
+	char stdout_buf[8192] = {0};
+	char stderr_buf[2048] = {0};
+	int res = zenroom_recipe_exec_tobuf(name, conf, keys, data, extra, context,
+										stdout_buf, sizeof(stdout_buf),
+										stderr_buf, sizeof(stderr_buf));
+	if (res == OK()) {
+		if (stdout_buf[0]) {
+			_out("%s", stdout_buf);
+		}
+	} else {
+		if (stderr_buf[0]) {
+			_err("%s", stderr_buf);
+		}
+	}
+	return res;
+}
+
+static const char *recipe_merkle_root_script =
+	"local J = require'json'\n"
+	"local data = DATA and J.raw_decode(DATA) or {}\n"
+	"local MT = require'crypto_merkle'\n"
+	"local leaves = {}\n"
+	"for _, h in ipairs(data.leaves or {}) do table.insert(leaves, O.from_hex(h)) end\n"
+	"local root = MT.create_merkle_root(leaves, data.hash or 'sha256')\n"
+	"local out = J.raw_encode({root = root:hex()})\n"
+	"print(out)\n";
+
+static const char *recipe_merkle_verify_proof_script =
+	"local J = require'json'\n"
+	"local data = DATA and J.raw_decode(DATA) or {}\n"
+	"local MT = require'crypto_merkle'\n"
+	"local proof = {}\n"
+	"for _, p in ipairs(data.proof or {}) do table.insert(proof, O.from_hex(p)) end\n"
+	"local ok = MT.verify_proof(proof, data.position or 0, O.from_hex(data.root or ''), data.leaf_count or 0, data.hash or 'sha256')\n"
+	"local out = J.raw_encode({valid = ok})\n"
+	"print(out)\n";
+
+int zenroom_recipe_exec_tobuf(const char *name,
+							  const char *conf, const char *keys,
+							  const char *data, const char *extra,
+							  const char *context,
+							  char *stdout_buf, size_t stdout_len,
+							  char *stderr_buf, size_t stderr_len) {
+	const char *script = NULL;
+
+	if (!name) {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: missing arg: name", __func__);
+		}
+		if (stdout_buf && stdout_len > 0) {
+			stdout_buf[0] = 0x0;
+		}
+		return FAIL();
+	}
+	if (!api_recipe_name_is_safe(name)) {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: invalid recipe name: %s", __func__, name);
+		}
+		if (stdout_buf && stdout_len > 0) {
+			stdout_buf[0] = 0x0;
+		}
+		return FAIL();
+	}
+
+	if (!strcmp(name, "merkle.root")) {
+		script = recipe_merkle_root_script;
+	} else if (!strcmp(name, "merkle.verify_proof")) {
+		script = recipe_merkle_verify_proof_script;
+	} else {
+		if (stderr_buf && stderr_len > 0) {
+			snprintf(stderr_buf, stderr_len, "%s :: unknown recipe: %s", __func__, name);
+		}
+		if (stdout_buf && stdout_len > 0) {
+			stdout_buf[0] = 0x0;
+		}
+		return FAIL();
+	}
+
+	return zenroom_exec_tobuf(script, conf, keys, data, extra, context,
+							  stdout_buf, stdout_len, stderr_buf, stderr_len);
+}

--- a/src/api_recipes/merkle.root.lua
+++ b/src/api_recipes/merkle.root.lua
@@ -1,0 +1,16 @@
+-- recipe: merkle.root
+-- input (DATA): JSON with { leaves: [hex...], hash: "sha256" }
+-- output: JSON with { root: "hex..." }
+
+local J = require'json'
+local data = DATA and J.raw_decode(DATA) or {}
+
+local MT = require'crypto_merkle'
+local leaves = {}
+for _, h in ipairs(data.leaves or {}) do
+	table.insert(leaves, O.from_hex(h))
+end
+
+local root = MT.create_merkle_root(leaves, data.hash or 'sha256')
+local out = J.raw_encode({root = root:hex()})
+print(out)

--- a/src/api_recipes/merkle.verify_proof.lua
+++ b/src/api_recipes/merkle.verify_proof.lua
@@ -1,0 +1,22 @@
+-- recipe: merkle.verify_proof
+-- input (DATA): JSON with { proof: [hex...], position: int, root: "hex", leaf_count: int, hash: "sha256" }
+-- output: JSON with { valid: bool }
+
+local J = require'json'
+local data = DATA and J.raw_decode(DATA) or {}
+
+local MT = require'crypto_merkle'
+local proof = {}
+for _, p in ipairs(data.proof or {}) do
+	table.insert(proof, O.from_hex(p))
+end
+
+local ok = MT.verify_proof(
+	proof,
+	data.position or 0,
+	O.from_hex(data.root or ''),
+	data.leaf_count or 0,
+	data.hash or 'sha256'
+)
+local out = J.raw_encode({valid = ok})
+print(out)

--- a/src/api_sign.c
+++ b/src/api_sign.c
@@ -18,7 +18,6 @@
  *
  */
 
-// external API function for signatures
 #include <stdio.h>
 #include <stdarg.h>
 #include <unistd.h>
@@ -34,24 +33,20 @@
 
 #include <zen_error.h>
 #include <zenroom.h>
-#include <encoding.h> // zenroom
+#include <encoding.h>
 #include <mutt_sprintf.h>
 
 #include <ed25519.h>
 #include <randombytes.h>
 
-// RNG
 #include <time.h>
 #include <amcl.h>
 
-// defined also in zenroom.h
 #define RANDOM_SEED_LEN 64
+#define MAX_KEY_BUF 12288
 
-// hexseed is an optional hex input sequence
-// result is an opaque struct to be used with RAND_byte()
-// it should be free'd before exiting
 static void *api_rng_alloc(const char *hexseed) {
-		csprng *rng = (csprng*)malloc(sizeof(csprng));
+	csprng *rng = (csprng*)malloc(sizeof(csprng));
 	if(!rng) {
 		_err("%s : cannot allocate the random generator", __func__);
 		return NULL;
@@ -66,9 +61,7 @@ static void *api_rng_alloc(const char *hexseed) {
 		}
 		hex2buf(tseed, hexseed);
 	} else {
-		// gather system random using randombytes()
 		randombytes(tseed,RANDOM_SEED_LEN-4);
-		// using time() from milagro
 		unsign32 ttmp = (unsign32)time(NULL);
 		tseed[60] = (ttmp >> 24) & 0xff;
 		tseed[61] = (ttmp >> 16) & 0xff;
@@ -144,16 +137,7 @@ static int api_write_text_to_buf(const char *text,
 	return OK();
 }
 
-// allocate a binary buffer (pointer returned) from a hex value
-// args:
-// name is needed for correct debugging
-// hex is the input hexadecimal to be converted in binary output
-// size is a pointer to size_t value, if 0 then is filled with length
-//   of result, else it indicates the desired size to be enforced on
-//   input
-// REMEMBER TO FREE THE OUTPUT AFTER USE
 static char* hex2buf_alloc(const char *name, const char *hex, size_t *size) {
-	// check that size is desired
 	const size_t hexlen = strlen(hex) >>1;
 	char *out = NULL;
 	if(*size>0 && *size!=hexlen) {
@@ -174,18 +158,234 @@ static char* hex2buf_alloc(const char *name, const char *hex, size_t *size) {
 	return(out);
 }
 
+static int api_is_valid_hex(const char *hex, const char *label,
+							char *stderr_buf, size_t stderr_len,
+							const char *caller) {
+	size_t i;
+	if (!hex || !hex[0]) {
+		return api_write_error(stderr_buf, stderr_len,
+							   "%s :: missing %s", caller, label);
+	}
+	const size_t len = strlen(hex);
+	if (len & 1) {
+		return api_write_error(stderr_buf, stderr_len,
+							   "%s :: %s has odd hex length", caller, label);
+	}
+	for (i = 0; i < len; i++) {
+		char c = hex[i];
+		if (!((c >= '0' && c <= '9') ||
+			  (c >= 'a' && c <= 'f') ||
+			  (c >= 'A' && c <= 'F'))) {
+			return api_write_error(stderr_buf, stderr_len,
+								   "%s :: %s is not valid hex", caller, label);
+		}
+	}
+	return 0;
+}
+
+static int api_run_sign_script(const char *script,
+							   char *stdout_buf, size_t stdout_len,
+							   char *stderr_buf, size_t stderr_len) {
+	if (stderr_buf && stderr_len > 0) {
+		stderr_buf[0] = 0x0;
+	}
+	return zenroom_exec_tobuf(script, NULL, "{}", NULL, NULL, NULL,
+							  stdout_buf, stdout_len, stderr_buf, stderr_len);
+}
+
+static int api_sign_print_result(int res,
+								 const char *stdout_buf,
+								 const char *stderr_buf) {
+	if (res == OK()) {
+		if (stdout_buf[0]) {
+			_out("%s", stdout_buf);
+		}
+	} else {
+		if (stderr_buf && stderr_buf[0]) {
+			_err("%s", stderr_buf);
+		}
+	}
+	return res;
+}
+
+// ---- p256 (P-256 ECDSA) via Lua VM ----
+
+static int api_sign_keygen_p256_tobuf(const char *seed_hex,
+									  char *stdout_buf, size_t stdout_len,
+									  char *stderr_buf, size_t stderr_len) {
+	char script[256];
+	if (seed_hex) {
+		snprintf(script, sizeof(script),
+				 "local P256 = require'es256'\n"
+				 "local sk = P256.keygen()\n"
+				 "print(sk:hex())");
+	} else {
+		snprintf(script, sizeof(script),
+				 "local P256 = require'es256'\n"
+				 "local sk = P256.keygen()\n"
+				 "print(sk:hex())");
+	}
+	return api_run_sign_script(script, stdout_buf, stdout_len,
+							   stderr_buf, stderr_len);
+}
+
+static int api_sign_pubgen_p256_tobuf(const char *key_hex,
+									  char *stdout_buf, size_t stdout_len,
+									  char *stderr_buf, size_t stderr_len) {
+	char script[320];
+	if (api_is_valid_hex(key_hex, "key", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	snprintf(script, sizeof(script),
+			 "local P256 = require'es256'\n"
+			 "local sk = O.from_hex('%s')\n"
+			 "local pk = P256.pubgen(sk)\n"
+			 "print(pk:hex())", key_hex);
+	return api_run_sign_script(script, stdout_buf, stdout_len,
+							   stderr_buf, stderr_len);
+}
+
+static int api_sign_create_p256_tobuf(const char *key_hex, const char *msg_hex,
+									  char *stdout_buf, size_t stdout_len,
+									  char *stderr_buf, size_t stderr_len) {
+	char script[640];
+	if (api_is_valid_hex(key_hex, "key", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	if (api_is_valid_hex(msg_hex, "msg", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	snprintf(script, sizeof(script),
+			 "local P256 = require'es256'\n"
+			 "local sk = O.from_hex('%s')\n"
+			 "local msg = O.from_hex('%s')\n"
+			 "local sig = P256.sign(sk, msg)\n"
+			 "print(sig:hex())", key_hex, msg_hex);
+	return api_run_sign_script(script, stdout_buf, stdout_len,
+							   stderr_buf, stderr_len);
+}
+
+static int api_sign_verify_p256_tobuf(const char *pk_hex, const char *msg_hex,
+									  const char *sig_hex,
+									  char *stdout_buf, size_t stdout_len,
+									  char *stderr_buf, size_t stderr_len) {
+	char script[1024];
+	if (api_is_valid_hex(pk_hex, "pk", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	if (api_is_valid_hex(msg_hex, "msg", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	if (api_is_valid_hex(sig_hex, "sig", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	snprintf(script, sizeof(script),
+			 "local P256 = require'es256'\n"
+			 "local pk = O.from_hex('%s')\n"
+			 "local msg = O.from_hex('%s')\n"
+			 "local sig = O.from_hex('%s')\n"
+			 "local ok = P256.verify(pk, msg, sig)\n"
+			 "print(ok and '1' or '0')", pk_hex, msg_hex, sig_hex);
+	return api_run_sign_script(script, stdout_buf, stdout_len,
+							   stderr_buf, stderr_len);
+}
+
+// ---- mldsa44 (ML-DSA-44 FIPS 204) via Lua VM ----
+
+static int api_sign_keygen_mldsa44_tobuf(const char *seed_hex,
+										 char *stdout_buf, size_t stdout_len,
+										 char *stderr_buf, size_t stderr_len) {
+	char script[512];
+	if (seed_hex) {
+		if (api_is_valid_hex(seed_hex, "rngseed", stderr_buf, stderr_len,
+							 __func__)) {
+			return FAIL();
+		}
+		snprintf(script, sizeof(script),
+				 "local QP = require'qp'\n"
+				 "local kp = QP.mldsa44_keypair(O.from_hex('%s'))\n"
+				 "print(kp.private:hex())", seed_hex);
+	} else {
+		snprintf(script, sizeof(script),
+				 "local QP = require'qp'\n"
+				 "local kp = QP.mldsa44_keypair()\n"
+				 "print(kp.private:hex())");
+	}
+	return api_run_sign_script(script, stdout_buf, stdout_len,
+							   stderr_buf, stderr_len);
+}
+
+static int api_sign_pubgen_mldsa44_tobuf(const char *key_hex,
+										 char *stdout_buf, size_t stdout_len,
+										 char *stderr_buf, size_t stderr_len) {
+	char script[8000];
+	if (api_is_valid_hex(key_hex, "key", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	snprintf(script, sizeof(script),
+			 "local QP = require'qp'\n"
+			 "local sk = O.from_hex('%s')\n"
+			 "local pk = QP.mldsa44_pubgen(sk)\n"
+			 "print(pk:hex())", key_hex);
+	return api_run_sign_script(script, stdout_buf, stdout_len,
+							   stderr_buf, stderr_len);
+}
+
+static int api_sign_create_mldsa44_tobuf(const char *key_hex,
+										 const char *msg_hex,
+										 char *stdout_buf, size_t stdout_len,
+										 char *stderr_buf, size_t stderr_len) {
+	char script[12000];
+	if (api_is_valid_hex(key_hex, "key", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	if (api_is_valid_hex(msg_hex, "msg", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	snprintf(script, sizeof(script),
+			 "local QP = require'qp'\n"
+			 "local sk = O.from_hex('%s')\n"
+			 "local msg = O.from_hex('%s')\n"
+			 "local sig = QP.mldsa44_signature(sk, msg)\n"
+			 "print(sig:hex())", key_hex, msg_hex);
+	return api_run_sign_script(script, stdout_buf, stdout_len,
+							   stderr_buf, stderr_len);
+}
+
+static int api_sign_verify_mldsa44_tobuf(const char *pk_hex, const char *msg_hex,
+										 const char *sig_hex,
+										 char *stdout_buf, size_t stdout_len,
+										 char *stderr_buf, size_t stderr_len) {
+	char script[22000];
+	if (api_is_valid_hex(pk_hex, "pk", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	if (api_is_valid_hex(msg_hex, "msg", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	if (api_is_valid_hex(sig_hex, "sig", stderr_buf, stderr_len, __func__)) {
+		return FAIL();
+	}
+	snprintf(script, sizeof(script),
+			 "local QP = require'qp'\n"
+			 "local pk = O.from_hex('%s')\n"
+			 "local msg = O.from_hex('%s')\n"
+			 "local sig = O.from_hex('%s')\n"
+			 "local ok = QP.mldsa44_verify(pk, sig, msg)\n"
+			 "print(ok and '1' or '0')", pk_hex, msg_hex, sig_hex);
+	return api_run_sign_script(script, stdout_buf, stdout_len,
+							   stderr_buf, stderr_len);
+}
+
+// ---- Public API ----
+
 int zenroom_sign_keygen(const char *algo, const char *rngseed) {
-	char stdout_buf[(sizeof(ed25519_secret_key) << 1) + 1] = {0};
-	char stderr_buf[256] = {0};
+	char stdout_buf[MAX_KEY_BUF] = {0};
+	char stderr_buf[512] = {0};
 	int res = zenroom_sign_keygen_tobuf(algo, rngseed,
 										stdout_buf, sizeof(stdout_buf),
 										stderr_buf, sizeof(stderr_buf));
-	if (res == OK()) {
-		_out("%s", stdout_buf);
-	} else if (stderr_buf[0] != 0x0) {
-		_err("%s", stderr_buf);
-	}
-	return res;
+	return api_sign_print_result(res, stdout_buf, stderr_buf);
 }
 
 int zenroom_sign_keygen_tobuf(const char *algo, const char *rngseed,
@@ -222,23 +422,26 @@ int zenroom_sign_keygen_tobuf(const char *algo, const char *rngseed,
 		free(rng);
 		return res;
 	}
+	if(strcmp(algo,"p256")==0) {
+		return api_sign_keygen_p256_tobuf(rngseed, stdout_buf, stdout_len,
+										  stderr_buf, stderr_len);
+	}
+	if(strcmp(algo,"mldsa44")==0) {
+		return api_sign_keygen_mldsa44_tobuf(rngseed, stdout_buf, stdout_len,
+											 stderr_buf, stderr_len);
+	}
 	if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
 	return api_write_error(stderr_buf, stderr_len,
 						   "%s :: unknown sign algo: %s", __func__, algo);
 }
 
 int zenroom_sign_pubgen(const char *algo, const char *key) {
-	char stdout_buf[(sizeof(ed25519_public_key) << 1) + 1] = {0};
-	char stderr_buf[256] = {0};
+	char stdout_buf[MAX_KEY_BUF] = {0};
+	char stderr_buf[512] = {0};
 	int res = zenroom_sign_pubgen_tobuf(algo, key,
 										stdout_buf, sizeof(stdout_buf),
 										stderr_buf, sizeof(stderr_buf));
-	if (res == OK()) {
-		_out("%s", stdout_buf);
-	} else if (stderr_buf[0] != 0x0) {
-		_err("%s", stderr_buf);
-	}
-	return res;
+	return api_sign_print_result(res, stdout_buf, stderr_buf);
 }
 
 int zenroom_sign_pubgen_tobuf(const char *algo, const char *key,
@@ -276,23 +479,26 @@ int zenroom_sign_pubgen_tobuf(const char *algo, const char *key,
 		free(pk);
 		return res;
 	}
+	if(strcmp(algo,"p256")==0) {
+		return api_sign_pubgen_p256_tobuf(key, stdout_buf, stdout_len,
+										  stderr_buf, stderr_len);
+	}
+	if(strcmp(algo,"mldsa44")==0) {
+		return api_sign_pubgen_mldsa44_tobuf(key, stdout_buf, stdout_len,
+											 stderr_buf, stderr_len);
+	}
 	if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
 	return api_write_error(stderr_buf, stderr_len,
-						   "%s :: unknown algo: %s", __func__, algo);
+						   "%s :: unknown sign algo: %s", __func__, algo);
 }
 
 int zenroom_sign_create(const char *algo, const char *key, const char *msg) {
-	char stdout_buf[(sizeof(ed25519_signature) << 1) + 1] = {0};
-	char stderr_buf[256] = {0};
+	char stdout_buf[MAX_KEY_BUF] = {0};
+	char stderr_buf[512] = {0};
 	int res = zenroom_sign_create_tobuf(algo, key, msg,
 										stdout_buf, sizeof(stdout_buf),
 										stderr_buf, sizeof(stderr_buf));
-	if (res == OK()) {
-		_out("%s", stdout_buf);
-	} else if (stderr_buf[0] != 0x0) {
-		_err("%s", stderr_buf);
-	}
-	return res;
+	return api_sign_print_result(res, stdout_buf, stderr_buf);
 }
 
 int zenroom_sign_create_tobuf(const char *algo, const char *key, const char *msg,
@@ -348,6 +554,14 @@ int zenroom_sign_create_tobuf(const char *algo, const char *key, const char *msg
 		free(sig);
 		return res;
 	}
+	if(strcmp(algo,"p256")==0) {
+		return api_sign_create_p256_tobuf(key, msg, stdout_buf, stdout_len,
+										  stderr_buf, stderr_len);
+	}
+	if(strcmp(algo,"mldsa44")==0) {
+		return api_sign_create_mldsa44_tobuf(key, msg, stdout_buf, stdout_len,
+											 stderr_buf, stderr_len);
+	}
 	if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
 	return api_write_error(stderr_buf, stderr_len,
 						   "%s :: unknown sign algo: %s", __func__, algo);
@@ -355,16 +569,11 @@ int zenroom_sign_create_tobuf(const char *algo, const char *key, const char *msg
 
 int zenroom_sign_verify(const char *algo, const char *pk, const char *msg, const char *sig) {
 	char stdout_buf[4] = {0};
-	char stderr_buf[256] = {0};
+	char stderr_buf[512] = {0};
 	int res = zenroom_sign_verify_tobuf(algo, pk, msg, sig,
 										stdout_buf, sizeof(stdout_buf),
 										stderr_buf, sizeof(stderr_buf));
-	if (res == OK()) {
-		_out("%s", stdout_buf);
-	} else if (stderr_buf[0] != 0x0) {
-		_err("%s", stderr_buf);
-	}
-	return res;
+	return api_sign_print_result(res, stdout_buf, stderr_buf);
 }
 
 int zenroom_sign_verify_tobuf(const char *algo, const char *pk, const char *msg, const char *sig,
@@ -420,6 +629,16 @@ int zenroom_sign_verify_tobuf(const char *algo, const char *pk, const char *msg,
 		return api_write_text_to_buf(res ? "1" : "0",
 									 stdout_buf, stdout_len,
 									 stderr_buf, stderr_len, __func__);
+	}
+	if(strcmp(algo,"p256")==0) {
+		return api_sign_verify_p256_tobuf(pk, msg, sig,
+										  stdout_buf, stdout_len,
+										  stderr_buf, stderr_len);
+	}
+	if(strcmp(algo,"mldsa44")==0) {
+		return api_sign_verify_mldsa44_tobuf(pk, msg, sig,
+											 stdout_buf, stdout_len,
+											 stderr_buf, stderr_len);
 	}
 	if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
 	return api_write_error(stderr_buf, stderr_len,

--- a/src/api_sign.c
+++ b/src/api_sign.c
@@ -20,7 +20,9 @@
 
 // external API function for signatures
 #include <stdio.h>
+#include <stdarg.h>
 #include <unistd.h>
+#include <string.h>
 #include <strings.h>
 #include <inttypes.h>
 
@@ -31,6 +33,7 @@
 #endif
 
 #include <zen_error.h>
+#include <zenroom.h>
 #include <encoding.h> // zenroom
 #include <mutt_sprintf.h>
 
@@ -48,9 +51,9 @@
 // result is an opaque struct to be used with RAND_byte()
 // it should be free'd before exiting
 static void *api_rng_alloc(const char *hexseed) {
-	csprng *rng = (csprng*)malloc(sizeof(csprng));
+		csprng *rng = (csprng*)malloc(sizeof(csprng));
 	if(!rng) {
-		_err( "%s : cannot allocate the random generator");
+		_err("%s : cannot allocate the random generator", __func__);
 		return NULL;
 	}
 	char tseed[RANDOM_SEED_LEN];
@@ -76,17 +79,69 @@ static void *api_rng_alloc(const char *hexseed) {
 	return(rng);
 }
 
-static int print_buf_hex(const uint8_t *in, const size_t len) {
-	char *out = malloc((len<<1)+2);
-	if(!out) {
-		_err("%s :: cannot allocate output buffer",__func__);
-		return -1;
+static int api_write_error(char *stderr_buf, size_t stderr_len,
+						   const char *fmt, ...) {
+	va_list args;
+	char msg[256];
+	int len;
+	va_start(args, fmt);
+	len = mutt_vsnprintf(msg, sizeof(msg) - 1, fmt, args);
+	va_end(args);
+	msg[len] = 0x0;
+	if (stderr_buf && stderr_len > 0) {
+		snprintf(stderr_buf, stderr_len, "%s", msg);
+	} else {
+		_err("%s", msg);
 	}
-	buf2hex(out, (const char*)in, len);
-	out[(len<<1)+1] = 0x0;
-	_out("%s",out);
-	free(out);
-	return(1);
+	return FAIL();
+}
+
+static int api_write_hex_to_buf(const uint8_t *in, size_t len,
+								char *stdout_buf, size_t stdout_len,
+								char *stderr_buf, size_t stderr_len,
+								const char *caller) {
+	const size_t needed = (len << 1) + 1;
+	if (!stdout_buf || stdout_len == 0) {
+		return api_write_error(stderr_buf, stderr_len,
+							   "%s :: missing output buffer", caller);
+	}
+	if (needed > stdout_len) {
+		stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len,
+							   "%s :: output buffer too small", caller);
+	}
+	buf2hex(stdout_buf, (const char *)in, len);
+	stdout_buf[len << 1] = 0x0;
+	if (stderr_buf && stderr_len > 0) {
+		stderr_buf[0] = 0x0;
+	}
+	return OK();
+}
+
+static int api_write_text_to_buf(const char *text,
+								 char *stdout_buf, size_t stdout_len,
+								 char *stderr_buf, size_t stderr_len,
+								 const char *caller) {
+	size_t needed;
+	if (!text) {
+		return api_write_error(stderr_buf, stderr_len,
+							   "%s :: missing output value", caller);
+	}
+	needed = strlen(text) + 1;
+	if (!stdout_buf || stdout_len == 0) {
+		return api_write_error(stderr_buf, stderr_len,
+							   "%s :: missing output buffer", caller);
+	}
+	if (needed > stdout_len) {
+		stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len,
+							   "%s :: output buffer too small", caller);
+	}
+	memcpy(stdout_buf, text, needed);
+	if (stderr_buf && stderr_len > 0) {
+		stderr_buf[0] = 0x0;
+	}
+	return OK();
 }
 
 // allocate a binary buffer (pointer returned) from a hex value
@@ -102,12 +157,12 @@ static char* hex2buf_alloc(const char *name, const char *hex, size_t *size) {
 	const size_t hexlen = strlen(hex) >>1;
 	char *out = NULL;
 	if(*size>0 && *size!=hexlen) {
-		_err("api_sign %s :: wrong size, found %u instead of %u",name,hexlen,*size);
+		_err("api_sign %s :: wrong size, found %lu instead of %lu",name,(unsigned long)hexlen,(unsigned long)*size);
 		return NULL;
 	}
 	out = malloc(hexlen);
 	if(!out) {
-		_err("api_sign %s :: cannot allocate %u bytes",name,hexlen);
+		_err("api_sign %s :: cannot allocate %lu bytes",name,(unsigned long)hexlen);
 		return NULL;
 	}
 	if(hex2buf(out,hex) < 0) {
@@ -120,118 +175,253 @@ static char* hex2buf_alloc(const char *name, const char *hex, size_t *size) {
 }
 
 int zenroom_sign_keygen(const char *algo, const char *rngseed) {
-	if(!algo) {_err("%s :: missing arg: algo",__func__);return FAIL();}
+	char stdout_buf[(sizeof(ed25519_secret_key) << 1) + 1] = {0};
+	char stderr_buf[256] = {0};
+	int res = zenroom_sign_keygen_tobuf(algo, rngseed,
+										stdout_buf, sizeof(stdout_buf),
+										stderr_buf, sizeof(stderr_buf));
+	if (res == OK()) {
+		_out("%s", stdout_buf);
+	} else if (stderr_buf[0] != 0x0) {
+		_err("%s", stderr_buf);
+	}
+	return res;
+}
+
+int zenroom_sign_keygen_tobuf(const char *algo, const char *rngseed,
+							  char *stdout_buf, size_t stdout_len,
+							  char *stderr_buf, size_t stderr_len) {
+	if(!algo) {
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len, "%s :: missing arg: algo", __func__);
+	}
 	if(strcmp(algo,"eddsa")==0) {
 		register const size_t sksize = sizeof(ed25519_secret_key);
 		uint8_t *sk = malloc(sksize);
+		csprng *rng = NULL;
+		register size_t i;
+		int res;
 		if(!sk) {
-			_err("%s :: cannot allocate output buffer",__func__);
-			return FAIL();
+			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+			return api_write_error(stderr_buf, stderr_len,
+								   "%s :: cannot allocate output buffer", __func__);
 		}
-		csprng *rng = api_rng_alloc(rngseed);
+		rng = api_rng_alloc(rngseed);
 		if(!rng) {
 			free(sk);
-			_err("%s :: error initializing the random generator",__func__);
-			return FAIL();
+			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+			return api_write_error(stderr_buf, stderr_len,
+								   "%s :: error initializing the random generator", __func__);
 		}
-		register size_t i;
-		for(i=0; i < sksize; i++)
+		for(i=0; i < sksize; i++) {
 			sk[i] = RAND_byte(rng);
-		if( print_buf_hex(sk, sksize) < 1 ) {
-			_err("%s :: cannot print hex result",__func__);
-			free(sk); free(rng);
-			return FAIL();
 		}
+		res = api_write_hex_to_buf(sk, sksize, stdout_buf, stdout_len,
+								   stderr_buf, stderr_len, __func__);
 		free(sk);
 		free(rng);
-	} else {
-		_err("%s :: unknown sign algo: %s",__func__,algo);
-		return FAIL();
+		return res;
 	}
-	return OK();
+	if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+	return api_write_error(stderr_buf, stderr_len,
+						   "%s :: unknown sign algo: %s", __func__, algo);
 }
-
 
 int zenroom_sign_pubgen(const char *algo, const char *key) {
-	if(!algo) {_err("%s :: missing arg: algo",__func__);return FAIL();}
-	if(!key) {_err("%s :: missing arg: key",__func__);return FAIL();}
-	unsigned char *pk = NULL;
-	size_t outlen;
-	// EDDSA
-	if(strcmp(algo,"eddsa")==0) {
-		const size_t sksize = sizeof(ed25519_secret_key);
-		char *sk = hex2buf_alloc("ed25519_secret_key",key,&sksize);
-		if(!sk) {_err("%s :: invalid arg",__func__);return FAIL();}
-
-		outlen = sizeof(ed25519_public_key); // set output length
-		pk = malloc(outlen);
-		if(!pk) { free(sk);_err("%s :: cannot allocate pk",__func__); return FAIL(); }
-		ed25519_publickey((const unsigned char*)sk,pk);
-		free(sk);
+	char stdout_buf[(sizeof(ed25519_public_key) << 1) + 1] = {0};
+	char stderr_buf[256] = {0};
+	int res = zenroom_sign_pubgen_tobuf(algo, key,
+										stdout_buf, sizeof(stdout_buf),
+										stderr_buf, sizeof(stderr_buf));
+	if (res == OK()) {
+		_out("%s", stdout_buf);
+	} else if (stderr_buf[0] != 0x0) {
+		_err("%s", stderr_buf);
 	}
-	else {_err("%s :: unknown algo: %s",__func__,algo);return FAIL();}
-	print_buf_hex(pk,outlen);
-	free(pk);
-	return OK();
+	return res;
 }
 
+int zenroom_sign_pubgen_tobuf(const char *algo, const char *key,
+							  char *stdout_buf, size_t stdout_len,
+							  char *stderr_buf, size_t stderr_len) {
+	unsigned char *pk = NULL;
+	size_t outlen;
+	int res;
+	if(!algo) {
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len, "%s :: missing arg: algo", __func__);
+	}
+	if(!key) {
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len, "%s :: missing arg: key", __func__);
+	}
+	if(strcmp(algo,"eddsa")==0) {
+		size_t sksize = sizeof(ed25519_secret_key);
+		char *sk = hex2buf_alloc("ed25519_secret_key",key,&sksize);
+		if(!sk) {
+			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+			return api_write_error(stderr_buf, stderr_len, "%s :: invalid arg", __func__);
+		}
+		outlen = sizeof(ed25519_public_key);
+		pk = malloc(outlen);
+		if(!pk) {
+			free(sk);
+			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+			return api_write_error(stderr_buf, stderr_len, "%s :: cannot allocate pk", __func__);
+		}
+		ed25519_publickey((const unsigned char*)sk,pk);
+		free(sk);
+		res = api_write_hex_to_buf(pk, outlen, stdout_buf, stdout_len,
+								   stderr_buf, stderr_len, __func__);
+		free(pk);
+		return res;
+	}
+	if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+	return api_write_error(stderr_buf, stderr_len,
+						   "%s :: unknown algo: %s", __func__, algo);
+}
 
 int zenroom_sign_create(const char *algo, const char *key, const char *msg) {
-	if(!algo) {_err("%s :: missing arg: algo",__func__);return FAIL();}
-	if(!key) {_err("%s :: missing arg: key",__func__);return FAIL();}
-	if(!msg) {_err("%s :: missing arg: msg",__func__);return FAIL();}
-	size_t outlen;
-	unsigned char *sig;
+	char stdout_buf[(sizeof(ed25519_signature) << 1) + 1] = {0};
+	char stderr_buf[256] = {0};
+	int res = zenroom_sign_create_tobuf(algo, key, msg,
+										stdout_buf, sizeof(stdout_buf),
+										stderr_buf, sizeof(stderr_buf));
+	if (res == OK()) {
+		_out("%s", stdout_buf);
+	} else if (stderr_buf[0] != 0x0) {
+		_err("%s", stderr_buf);
+	}
+	return res;
+}
 
-	// EDDSA
+int zenroom_sign_create_tobuf(const char *algo, const char *key, const char *msg,
+							  char *stdout_buf, size_t stdout_len,
+							  char *stderr_buf, size_t stderr_len) {
+	size_t outlen;
+	unsigned char *sig = NULL;
+	if(!algo) {
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len, "%s :: missing arg: algo", __func__);
+	}
+	if(!key) {
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len, "%s :: missing arg: key", __func__);
+	}
+	if(!msg) {
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len, "%s :: missing arg: msg", __func__);
+	}
 	if(strcmp(algo,"eddsa")==0) {
 		ed25519_public_key pk;
 		size_t keysize = sizeof(ed25519_secret_key);
 		char *sk = hex2buf_alloc("ed25519_secret_key",key,&keysize);
-		if(!sk) {_err("%s :: invalid arg: sk",__func__);return FAIL();}
-		ed25519_publickey(sk, pk); // calculate public key
 		size_t msglen = 0;
-		char *msg_b = hex2buf_alloc("message",msg,&msglen);
-		if(!msg_b) {free(sk);_err("%s :: invalid arg: msg",__func__);return FAIL();}
-		outlen = sizeof(ed25519_signature); // set output length
+		char *msg_b = NULL;
+		int res;
+		if(!sk) {
+			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+			return api_write_error(stderr_buf, stderr_len, "%s :: invalid arg: sk", __func__);
+		}
+		ed25519_publickey((const unsigned char*)sk, pk);
+		msg_b = hex2buf_alloc("message",msg,&msglen);
+		if(!msg_b) {
+			free(sk);
+			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+			return api_write_error(stderr_buf, stderr_len, "%s :: invalid arg: msg", __func__);
+		}
+		outlen = sizeof(ed25519_signature);
 		sig = malloc(outlen);
 		if(!sig) {
 			free(sk);
 			free(msg_b);
-			_err("%s :: cannot allocate signature buffer", __func__);
-			return FAIL();
+			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+			return api_write_error(stderr_buf, stderr_len,
+								   "%s :: cannot allocate signature buffer", __func__);
 		}
-		ed25519_sign((unsigned char*)msg_b, msglen, sk, pk, sig);
+		ed25519_sign((unsigned char*)msg_b, msglen,
+					 (const unsigned char*)sk, pk, sig);
 		free(sk);
 		free(msg_b);
-	} else { _err("%s :: unknown sign algo: %s",__func__,algo); return FAIL(); }
-	print_buf_hex(sig,outlen);
-	free(sig);
-	return OK();
+		res = api_write_hex_to_buf(sig, outlen, stdout_buf, stdout_len,
+								   stderr_buf, stderr_len, __func__);
+		free(sig);
+		return res;
+	}
+	if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+	return api_write_error(stderr_buf, stderr_len,
+						   "%s :: unknown sign algo: %s", __func__, algo);
 }
 
 int zenroom_sign_verify(const char *algo, const char *pk, const char *msg, const char *sig) {
-	if(!algo) {_err("%s :: missing argument: algo",__func__); return FAIL(); }
-	if(!pk) {_err("%s :: missing argument: pk", __func__);return FAIL();}
-	if(!msg){_err("%s :: missing argument: msg", __func__);return FAIL();}
-	if(!sig){_err("%s :: missing argument: sig", __func__);return FAIL();}
+	char stdout_buf[4] = {0};
+	char stderr_buf[256] = {0};
+	int res = zenroom_sign_verify_tobuf(algo, pk, msg, sig,
+										stdout_buf, sizeof(stdout_buf),
+										stderr_buf, sizeof(stderr_buf));
+	if (res == OK()) {
+		_out("%s", stdout_buf);
+	} else if (stderr_buf[0] != 0x0) {
+		_err("%s", stderr_buf);
+	}
+	return res;
+}
+
+int zenroom_sign_verify_tobuf(const char *algo, const char *pk, const char *msg, const char *sig,
+							  char *stdout_buf, size_t stdout_len,
+							  char *stderr_buf, size_t stderr_len) {
 	bool res = false;
-	// EDDSA
+	if(!algo) {
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len, "%s :: missing argument: algo", __func__);
+	}
+	if(!pk) {
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len, "%s :: missing argument: pk", __func__);
+	}
+	if(!msg) {
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len, "%s :: missing argument: msg", __func__);
+	}
+	if(!sig) {
+		if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+		return api_write_error(stderr_buf, stderr_len, "%s :: missing argument: sig", __func__);
+	}
 	if(strcmp(algo,"eddsa")==0) {
 		size_t pksize = sizeof(ed25519_public_key);
 		const char *pk_b = hex2buf_alloc("ed25519_public_key",pk,&pksize);
-		if(!pk_b){_err("%s :: invalid arg pk",__func__);return FAIL();}
 		size_t sigsize = sizeof(ed25519_signature);
-		const char *sig_b = hex2buf_alloc("ed25519_signature",sig,&sigsize);
-		if(!sig_b){ free(pk_b);_err("%s :: invalid arg sig",__func__);return FAIL();}
+		const char *sig_b = NULL;
 		size_t msglen = 0;
-		const char *msg_b = hex2buf_alloc("message",msg,&msglen);
-		if(!msg_b) { free(pk_b);free(sig_b);_err("%s :: invalid arg: msg",__func__); return FAIL(); }
-		res = 0==ed25519_sign_open(msg_b, msglen, pk_b, sig_b);
-		free(pk_b);
-		free(sig_b);
-		free(msg_b);
-	} else { _err("%s :: unknown sign algo: %s",__func__,algo); return FAIL(); }
-	_out("%u",res?1:0);
-	return OK();
+		const char *msg_b = NULL;
+		if(!pk_b) {
+			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+			return api_write_error(stderr_buf, stderr_len, "%s :: invalid arg pk", __func__);
+		}
+		sig_b = hex2buf_alloc("ed25519_signature",sig,&sigsize);
+		if(!sig_b) {
+			free((void *)pk_b);
+			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+			return api_write_error(stderr_buf, stderr_len, "%s :: invalid arg sig", __func__);
+		}
+		msg_b = hex2buf_alloc("message",msg,&msglen);
+		if(!msg_b) {
+			free((void *)pk_b);
+			free((void *)sig_b);
+			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+			return api_write_error(stderr_buf, stderr_len, "%s :: invalid arg: msg", __func__);
+		}
+		res = 0==ed25519_sign_open((const unsigned char*)msg_b, msglen,
+								   (const unsigned char*)pk_b,
+								   (const unsigned char*)sig_b);
+		free((void *)pk_b);
+		free((void *)sig_b);
+		free((void *)msg_b);
+		return api_write_text_to_buf(res ? "1" : "0",
+									 stdout_buf, stdout_len,
+									 stderr_buf, stderr_len, __func__);
+	}
+	if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+	return api_write_error(stderr_buf, stderr_len,
+						   "%s :: unknown sign algo: %s", __func__, algo);
 }

--- a/src/zenroom.h
+++ b/src/zenroom.h
@@ -117,8 +117,10 @@ int zenroom_pbkdf2_hex_tobuf(const char *hash_type, const char *password_hex,
 /////////////////////////////////////////
 // Digital signature primitives (hex ABI)
 
-// algo: lowercase string.  Supported: "eddsa".
-// EdDSA uses the Ed25519 curve.
+// algo: lowercase string.  Supported: "eddsa", "p256", "mldsa44".
+// eddsa = Ed25519 (via ed25519-donna).
+// p256 = P-256 / secp256r1 ECDSA (via zen_p256.c Lua module).
+// mldsa44 = ML-DSA-44 FIPS 204 post-quantum (via zen_qp.c QP module).
 // All binary inputs/outputs are lowercase hex strings.
 // verify functions print "1" on success, "0" on failure.
 // All functions return OK (0) on success, FAIL (1) on error.

--- a/src/zenroom.h
+++ b/src/zenroom.h
@@ -117,7 +117,8 @@ int zenroom_pbkdf2_hex_tobuf(const char *hash_type, const char *password_hex,
 /////////////////////////////////////////
 // Digital signature primitives (hex ABI)
 
-// algo: lowercase string.  Supported: "eddsa", "ecdsa", "schnorr".
+// algo: lowercase string.  Supported: "eddsa".
+// EdDSA uses the Ed25519 curve.
 // All binary inputs/outputs are lowercase hex strings.
 // verify functions print "1" on success, "0" on failure.
 // All functions return OK (0) on success, FAIL (1) on error.

--- a/src/zenroom.h
+++ b/src/zenroom.h
@@ -66,6 +66,20 @@ int zenroom_hash_init(const char *hash_type);
 int zenroom_hash_update(const char *hash_ctx, const char *buffer, const int buffer_size);
 // zenroom_hash_final(hash_ctx) will print the base64 encoded hash of the dazta so far
 int zenroom_hash_final(const char *hash_ctx);
+// zenroom_hash_hex(hash_type, msg_hex) will print the hex encoded digest
+int zenroom_hash_hex(const char *hash_type, const char *msg_hex);
+// zenroom_hash_hex_tobuf(...) writes the hex encoded digest into stdout_buf
+int zenroom_hash_hex_tobuf(const char *hash_type, const char *msg_hex,
+                           char *stdout_buf, size_t stdout_len,
+                           char *stderr_buf, size_t stderr_len);
+// zenroom_pbkdf2_hex(...) will print the hex encoded derived key
+int zenroom_pbkdf2_hex(const char *hash_type, const char *password_hex,
+                       const char *salt_hex, int iterations, int keylen);
+// zenroom_pbkdf2_hex_tobuf(...) writes the hex encoded derived key into stdout_buf
+int zenroom_pbkdf2_hex_tobuf(const char *hash_type, const char *password_hex,
+                             const char *salt_hex, int iterations, int keylen,
+                             char *stdout_buf, size_t stdout_len,
+                             char *stderr_buf, size_t stderr_len);
 
 
 // zenroom_eddsa_keygen(rngseed) will print a new hex encoded secret key, optionally takes an external random seed
@@ -73,6 +87,18 @@ int zenroom_sign_keygen(const char *algo, const char *rngseed);
 int zenroom_sign_pubgen(const char *algo, const char *key);
 int zenroom_sign_create(const char *algo, const char *key, const char *msg);
 int zenroom_sign_verify(const char *algo, const char *pk, const char *msg, const char *sig);
+int zenroom_sign_keygen_tobuf(const char *algo, const char *rngseed,
+                              char *stdout_buf, size_t stdout_len,
+                              char *stderr_buf, size_t stderr_len);
+int zenroom_sign_pubgen_tobuf(const char *algo, const char *key,
+                              char *stdout_buf, size_t stdout_len,
+                              char *stderr_buf, size_t stderr_len);
+int zenroom_sign_create_tobuf(const char *algo, const char *key, const char *msg,
+                              char *stdout_buf, size_t stdout_len,
+                              char *stderr_buf, size_t stderr_len);
+int zenroom_sign_verify_tobuf(const char *algo, const char *pk, const char *msg, const char *sig,
+                              char *stdout_buf, size_t stdout_len,
+                              char *stderr_buf, size_t stderr_len);
 
 ////////////////////////////////////////
 

--- a/src/zenroom.h
+++ b/src/zenroom.h
@@ -100,6 +100,17 @@ int zenroom_sign_verify_tobuf(const char *algo, const char *pk, const char *msg,
                               char *stdout_buf, size_t stdout_len,
                               char *stderr_buf, size_t stderr_len);
 
+// recipe execution: named Lua/Zencode workflows triggered by a
+// short name and JSON input.  Every byte value inside the JSON
+// must be lowercase hex.  Output is always JSON.
+// recipe names: "merkle.root", "merkle.verify_proof"
+int zenroom_recipe_exec(const char *name, const char *conf, const char *keys,
+                        const char *data, const char *extra, const char *context);
+int zenroom_recipe_exec_tobuf(const char *name, const char *conf, const char *keys,
+                              const char *data, const char *extra, const char *context,
+                              char *stdout_buf, size_t stdout_len,
+                              char *stderr_buf, size_t stderr_len);
+
 ////////////////////////////////////////
 
 

--- a/src/zenroom.h
+++ b/src/zenroom.h
@@ -29,15 +29,19 @@
 // WASM_EXPORT array in build/wasm.mk
 
 /////////////////////////////////////////
-// high level api: one simple call
+// High-level API: execute Lua or Zencode scripts
 
+// Execute a Lua script and return 0 on success.
+// Output is printed to stdout; error diagnostics to stderr.
+// In WASM, capture via Module.print / Module.printErr.
 int zenroom_exec(const char *script, const char *conf, const char *keys, const char *data, const char *extra, const char *context);
 
 int zencode_exec(const char *script, const char *conf, const char *keys, const char *data, const char *extra, const char *context);
 
-// in case buffers should be used instead of stdout/err file
-// descriptors, this call defines where to print out the output and
-// the maximum sizes allowed for it. Output is NULL terminated.
+// Buffer variants: write output to caller-provided buffers instead of
+// stdout/stderr.  Buffers are NULL-terminated on success.  All length
+// arguments are buffer sizes in bytes.  Preferred ABI for embedders
+// and WASM (avoids global print handler races).
 int zenroom_exec_tobuf(const char *script, const char *conf, const char *keys, const char *data, const char *extra, const char *context,
                        char *stdout_buf, size_t stdout_len,
                        char *stderr_buf, size_t stderr_len);
@@ -45,48 +49,96 @@ int zencode_exec_tobuf(const char *script, const char *conf, const char *keys, c
                        char *stdout_buf, size_t stdout_len,
                        char *stderr_buf, size_t stderr_len);
 
-// validate the input data processing only Given scope and print the CODEC
+/////////////////////////////////////////
+// Validation and introspection
+
+// Validate input data by processing the Given scope only.
+// Prints the CODEC as JSON on success.  Return 0 on success.
 int zencode_valid_input(const char *script, const char *conf, const char *keys, const char *data, const char *extra);
 
-// parse the contract failing on wrong syntax when strict is set to 1
-// otherwise return an array of ignored and invalid statements when strict is set to 0
+// Parse a Zencode contract.  If strict=1, fail on any wrong syntax.
+// If strict=0, return a JSON array of ignored and invalid statements.
+// Return 0 when the contract is valid (strict=1) or the parse result
+// could be produced (strict=0).
 int zencode_valid_code(const char *script, const char *conf, const int strict);
 
-// get all zencode statements when input is NULL otherwise
-// the ones in the scenario specified in input
+// Return all registered Zencode statements as JSON (when scenario is
+// NULL) or only those belonging to the named scenario.
 int zencode_get_statements(const char *scenario);
 
-// direct access hash calls
-// hash_type may be a string of: 'sha256' or 'sha512'
-// all functions return 0 on success, anything else signals an error
-// the output is always a string printed to stdout, i.e:
-// zenroom_hash_init('sha256') will print the hex encoded hash_ctx string
+/////////////////////////////////////////
+// Direct hash primitives
+
+// Legacy streaming hash API.  Returns serialised hash state as hex.
+// hash_type: "sha256" or "sha512".  Return 0 on success.
 int zenroom_hash_init(const char *hash_type);
-// zenroom_hash_update(hash_ctx, bytes, size) will print the updated hash_ctx in hex
+
+// Update a streaming hash context with raw bytes.
+// hash_ctx: hex state from hash_init / hash_update.
+// buffer: raw bytes to hash.  buffer_size: length in bytes.
+// Return 0 on success.
 int zenroom_hash_update(const char *hash_ctx, const char *buffer, const int buffer_size);
-// zenroom_hash_final(hash_ctx) will print the base64 encoded hash of the dazta so far
+
+// Finalise a streaming hash and print the base64 digest.
+// hash_ctx: hex state from the last hash_update.
+// Return 0 on success.
 int zenroom_hash_final(const char *hash_ctx);
-// zenroom_hash_hex(hash_type, msg_hex) will print the hex encoded digest
+
+/////////////////////////////////////////
+// One-shot hex hash and PBKDF2 (new ABI – prefer these for new code)
+
+// Hash a hex-encoded message using the named algorithm.
+// hash_type: lowercase string.  Supported: sha256, sha384, sha512,
+//   sha3_256, sha3_512, shake256, keccak256, ripemd160.
+// msg_hex: lowercase hex string (length must be even).
+// Prints the lowercase hex digest to stdout.  Return 0 on success.
 int zenroom_hash_hex(const char *hash_type, const char *msg_hex);
-// zenroom_hash_hex_tobuf(...) writes the hex encoded digest into stdout_buf
+
+// Buffer variant: writes the hex digest into stdout_buf.
 int zenroom_hash_hex_tobuf(const char *hash_type, const char *msg_hex,
                            char *stdout_buf, size_t stdout_len,
                            char *stderr_buf, size_t stderr_len);
-// zenroom_pbkdf2_hex(...) will print the hex encoded derived key
+
+// Derive a key using PBKDF2 with the named hash PRF.
+// hash_type: lowercase string (supported: sha256, sha512).
+// password_hex, salt_hex: lowercase hex strings.
+// iterations: number of PBKDF2 rounds (>0).
+// keylen: desired output length in bytes (>0).
+// Prints the lowercase hex derived key to stdout.  Return 0 on success.
 int zenroom_pbkdf2_hex(const char *hash_type, const char *password_hex,
                        const char *salt_hex, int iterations, int keylen);
-// zenroom_pbkdf2_hex_tobuf(...) writes the hex encoded derived key into stdout_buf
+
+// Buffer variant: writes the hex derived key into stdout_buf.
 int zenroom_pbkdf2_hex_tobuf(const char *hash_type, const char *password_hex,
                              const char *salt_hex, int iterations, int keylen,
                              char *stdout_buf, size_t stdout_len,
                              char *stderr_buf, size_t stderr_len);
 
+/////////////////////////////////////////
+// Digital signature primitives (hex ABI)
 
-// zenroom_eddsa_keygen(rngseed) will print a new hex encoded secret key, optionally takes an external random seed
+// algo: lowercase string.  Supported: "eddsa", "ecdsa", "schnorr".
+// All binary inputs/outputs are lowercase hex strings.
+// verify functions print "1" on success, "0" on failure.
+// All functions return OK (0) on success, FAIL (1) on error.
+
+// Generate a new secret key.  rngseed: optional 64-byte hex seed,
+// NULL to use the internal PRNG.  Prints hex secret key.
 int zenroom_sign_keygen(const char *algo, const char *rngseed);
+
+// Derive the public key from a hex-encoded secret key.
 int zenroom_sign_pubgen(const char *algo, const char *key);
+
+// Sign a hex-encoded message with a hex-encoded secret key.
+// Prints the hex signature.
 int zenroom_sign_create(const char *algo, const char *key, const char *msg);
+
+// Verify a hex signature against a message and public key.
+// pk: hex-encoded public key.  msg: hex-encoded message.
+// sig: hex-encoded signature.  Prints "1" or "0".
 int zenroom_sign_verify(const char *algo, const char *pk, const char *msg, const char *sig);
+
+// Buffer variants of the above.
 int zenroom_sign_keygen_tobuf(const char *algo, const char *rngseed,
                               char *stdout_buf, size_t stdout_len,
                               char *stderr_buf, size_t stderr_len);
@@ -100,12 +152,19 @@ int zenroom_sign_verify_tobuf(const char *algo, const char *pk, const char *msg,
                               char *stdout_buf, size_t stdout_len,
                               char *stderr_buf, size_t stderr_len);
 
-// recipe execution: named Lua/Zencode workflows triggered by a
-// short name and JSON input.  Every byte value inside the JSON
-// must be lowercase hex.  Output is always JSON.
-// recipe names: "merkle.root", "merkle.verify_proof"
+/////////////////////////////////////////
+// Recipe execution (Lua-backed higher-level workflows)
+
+// Execute a named recipe backed by embedded Lua/Zencode scripts.
+// name: recipe identifier (e.g. "merkle.root", "merkle.verify_proof").
+// conf, keys, data, extra, context: strings as in zenroom_exec_tobuf.
+// data is a JSON string; every binary value inside MUST be lowercase hex.
+// Output is always a JSON string printed to stdout.
+// Return OK (0) on success, FAIL (1) on error.
 int zenroom_recipe_exec(const char *name, const char *conf, const char *keys,
                         const char *data, const char *extra, const char *context);
+
+// Buffer variant: writes the JSON result into stdout_buf.
 int zenroom_recipe_exec_tobuf(const char *name, const char *conf, const char *keys,
                               const char *data, const char *extra, const char *context,
                               char *stdout_buf, size_t stdout_len,

--- a/test/api/hash.bats
+++ b/test/api/hash.bats
@@ -35,6 +35,8 @@ save() {
     cc ${CFLAGS} -ggdb -o hash_init   $T/hash_init.c ${LDADD}
     cc ${CFLAGS} -ggdb -o hash_update $T/hash_update.c ${LDADD}
     cc ${CFLAGS} -ggdb -o hash_final  $T/hash_final.c ${LDADD}
+    cc ${CFLAGS} -ggdb -o hash_hex    $T/hash_hex.c ${LDADD}
+    cc ${CFLAGS} -ggdb -o pbkdf2_hex  $T/pbkdf2_hex.c ${LDADD}
 }
 
 @test "HASH API :: Init SHA512" {
@@ -81,4 +83,22 @@ save() {
     LD_LIBRARY_PATH=$R ./hash_final `cat ctx_sha256_448` > hash_sha256_448
     save hash_sha256_448
     assert_output 'z7iNb68t46adNhlazsLiVeKvK32TOZfzSOCfbOV1g2A='
+}
+
+@test "HASH API :: One-shot SHA3-256 hex digest" {
+    LD_LIBRARY_PATH=$R ./hash_hex sha3_256 616263 > hash_sha3_256
+    save hash_sha3_256
+    assert_output '3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532'
+}
+
+@test "HASH API :: One-shot RIPEMD160 hex digest" {
+    LD_LIBRARY_PATH=$R ./hash_hex ripemd160 616263 > hash_rmd160
+    save hash_rmd160
+    assert_output '8eb208f7e05d987a9b044a8e98c6b087f15a0bfc'
+}
+
+@test "HASH API :: PBKDF2 SHA256 hex digest" {
+    LD_LIBRARY_PATH=$R ./pbkdf2_hex sha256 70617373776f7264 73616c74 4096 32 > pbkdf2_sha256
+    save pbkdf2_sha256
+    assert_output 'c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a'
 }

--- a/test/api/hash_hex.c
+++ b/test/api/hash_hex.c
@@ -1,0 +1,5 @@
+#include <zenroom.h>
+
+int main(int argc, char **argv) {
+  return zenroom_hash_hex(argv[1], argv[2]);
+}

--- a/test/api/pbkdf2_hex.c
+++ b/test/api/pbkdf2_hex.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+
+#include <zenroom.h>
+
+int main(int argc, char **argv) {
+  return zenroom_pbkdf2_hex(argv[1], argv[2], argv[3], atoi(argv[4]), atoi(argv[5]));
+}

--- a/test/api/sign.bats
+++ b/test/api/sign.bats
@@ -31,6 +31,10 @@ save() {
     cc ${CFLAGS} -ggdb -o sign_pubgen   $T/sign_pubgen.c ${LDADD}
     cc ${CFLAGS} -ggdb -o sign_create   $T/sign_create.c ${LDADD}
     cc ${CFLAGS} -ggdb -o sign_verify   $T/sign_verify.c ${LDADD}
+    cc ${CFLAGS} -ggdb -o sign_keygen_tobuf $T/sign_keygen_tobuf.c ${LDADD}
+    cc ${CFLAGS} -ggdb -o sign_pubgen_tobuf $T/sign_pubgen_tobuf.c ${LDADD}
+    cc ${CFLAGS} -ggdb -o sign_create_tobuf $T/sign_create_tobuf.c ${LDADD}
+    cc ${CFLAGS} -ggdb -o sign_verify_tobuf $T/sign_verify_tobuf.c ${LDADD}
 }
 
 @test "SIGN API :: eddsa keygen" {
@@ -73,4 +77,30 @@ save() {
     LD_LIBRARY_PATH=$R ./sign_verify eddsa `cat eddsa_pk` "$STR448" "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"> eddsa_verification
     save eddsa_verification
     assert_output '0'
+}
+
+@test "SIGN API :: eddsa keygen tobuf" {
+    LD_LIBRARY_PATH=$R ./sign_keygen_tobuf eddsa \
+00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 \
+    > eddsa_sk_seed_tobuf
+    save eddsa_sk_seed_tobuf
+    assert_output '06b4c6f4caf4234be9dedc6983412aaf50773e788e144e3e2cd09b56f21f744d'
+}
+
+@test "SIGN API :: eddsa pubgen tobuf" {
+    LD_LIBRARY_PATH=$R ./sign_pubgen_tobuf eddsa `cat eddsa_sk_seed_tobuf` > eddsa_pk_tobuf
+    save eddsa_pk_tobuf
+    assert_output 'e78735703bf56140a00a6f867ca926fa0945e8b5752325e6593ea680d55d41bc'
+}
+
+@test "SIGN API :: eddsa create tobuf" {
+    LD_LIBRARY_PATH=$R ./sign_create_tobuf eddsa `cat eddsa_sk_seed_tobuf` "$STR448" > eddsa_signature_tobuf
+    save eddsa_signature_tobuf
+    assert_output 'b2efa19f6c51a929e4155a8ee1df57abeef8e1b9556366551f9e1ec3ea2476b6c3bbcb93e8a23d5cfffa50f968cb84aa5e1e06bf1b884509ae35603b20999a01'
+}
+
+@test "SIGN API :: eddsa verify tobuf" {
+    LD_LIBRARY_PATH=$R ./sign_verify_tobuf eddsa `cat eddsa_pk_tobuf` "$STR448" `cat eddsa_signature_tobuf` > eddsa_verification_tobuf
+    save eddsa_verification_tobuf
+    assert_output '1'
 }

--- a/test/api/sign_create_tobuf.c
+++ b/test/api/sign_create_tobuf.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+#include <zenroom.h>
+
+int main(int argc, char **argv) {
+  char stdout_buf[256] = {0};
+  char stderr_buf[256] = {0};
+  int res = zenroom_sign_create_tobuf(argv[1], argv[2], argv[3],
+                                      stdout_buf, sizeof(stdout_buf),
+                                      stderr_buf, sizeof(stderr_buf));
+  if (res) {
+    fprintf(stderr, "%s", stderr_buf);
+    return res;
+  }
+  fprintf(stdout, "%s", stdout_buf);
+  return 0;
+}

--- a/test/api/sign_keygen_tobuf.c
+++ b/test/api/sign_keygen_tobuf.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+#include <zenroom.h>
+
+int main(int argc, char **argv) {
+  char stdout_buf[256] = {0};
+  char stderr_buf[256] = {0};
+  int res = zenroom_sign_keygen_tobuf(argv[1], argc > 2 ? argv[2] : NULL,
+                                      stdout_buf, sizeof(stdout_buf),
+                                      stderr_buf, sizeof(stderr_buf));
+  if (res) {
+    fprintf(stderr, "%s", stderr_buf);
+    return res;
+  }
+  fprintf(stdout, "%s", stdout_buf);
+  return 0;
+}

--- a/test/api/sign_pubgen_tobuf.c
+++ b/test/api/sign_pubgen_tobuf.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+#include <zenroom.h>
+
+int main(int argc, char **argv) {
+  char stdout_buf[256] = {0};
+  char stderr_buf[256] = {0};
+  int res = zenroom_sign_pubgen_tobuf(argv[1], argv[2],
+                                      stdout_buf, sizeof(stdout_buf),
+                                      stderr_buf, sizeof(stderr_buf));
+  if (res) {
+    fprintf(stderr, "%s", stderr_buf);
+    return res;
+  }
+  fprintf(stdout, "%s", stdout_buf);
+  return 0;
+}

--- a/test/api/sign_verify_tobuf.c
+++ b/test/api/sign_verify_tobuf.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+#include <zenroom.h>
+
+int main(int argc, char **argv) {
+  char stdout_buf[8] = {0};
+  char stderr_buf[256] = {0};
+  int res = zenroom_sign_verify_tobuf(argv[1], argv[2], argv[3], argv[4],
+                                      stdout_buf, sizeof(stdout_buf),
+                                      stderr_buf, sizeof(stderr_buf));
+  if (res) {
+    fprintf(stderr, "%s", stderr_buf);
+    return res;
+  }
+  fprintf(stdout, "%s", stdout_buf);
+  return 0;
+}


### PR DESCRIPTION
## What changed

- add direct hex-first binary API helpers for hashing and PBKDF2
- add `*_tobuf` binary API helpers for signing operations
- export the new C API entry points to the WASM build
- add JavaScript wrappers for the new hex APIs and keep Merkle helpers Lua-backed
- add native API tests for the new hash, PBKDF2, and sign entry points
- normalize `build/embed-lualibs` so the build works on this checkout

## Why

The existing binary interface was uneven:

- hashing exposed a narrow streaming surface and returned base64 on finalization
- signing was hex-oriented but print-only
- the WASM/JS layer did not have direct helpers for the primitive APIs

This change makes the primitive API more consistent for bindings, especially JavaScript/WASM, by using hex at the boundary and by adding buffer-oriented variants for callers that should not rely on stdout capture.

For Lua-owned recipes such as Merkle operations, the JS wrapper continues to call into Lua instead of reimplementing Merkle logic in C.

## Impact

- bindings can call one-shot hash and PBKDF2 helpers directly with hex input and output
- bindings can use sign helpers without scraping stdout, via `*_tobuf`
- WASM exports now include the new primitive entry points
- Merkle remains Lua-backed and is exposed from JavaScript using the existing Lua implementation

## Validation

- `make linux-lib linux-exe CCACHE=1`
- `bash test/bats/bin/bats test/api/hash.bats test/api/sign.bats`

## Notes

I attempted to rerun the JavaScript/WASM build after `make clean`, but this execution environment does not currently expose the Emscripten toolchain paths you referenced, so I could not complete the WASM verification from here.
