### PR TITLE
feat(zkcc): BIP340 secp256k1 field selection and Bitcoin-vector proof flow

### DIFF
--- a/build/init.mk
+++ b/build/init.mk
@@ -50,6 +50,7 @@ ldadd += ${pwd}/lib/zstd/libzstd.a
 ldadd += $(pwd)/lib/mayo/libmayo.a
 ldadd += -lstdc++
 ZKCC_LDADD := ${pwd}/lib/zk-circuit-lang/libzk-circuit-lang.a
+ZKCC_LDADD += ${pwd}/lib/longfellow-zk/liblongfellow-zk.a
 
 # ----------------
 # zenroom defaults

--- a/lib/zk-circuit-lang/lfzk_bindings.cc
+++ b/lib/zk-circuit-lang/lfzk_bindings.cc
@@ -16,6 +16,12 @@
 
 #include "lfzk_bindings.h"
 #include "witness_bindings.h"
+#include "circuits/bip340/bip340_guard.h"
+#include "circuits/bip340/bip340_verify.h"
+#include "circuits/bip340/bip340_witness.h"
+#include "ec/p256k1.h"
+#include "algebra/crt.h"
+#include "algebra/crt_convolution.h"
 
 namespace proofs {
 namespace lua {
@@ -66,12 +72,12 @@ static constexpr char kRootY[] =
 	"84087994358540907695740461427818660560182168997182378749313018254450460212"
 	"908";
 
-// Build Dense witness arrays from Lua table of OCTETs
-int lua_build_witness_inputs(lua_State* L) {
+template <class Artifact, class Witness>
+static int lua_build_witness_inputs_impl(lua_State* L) {
 	sol::state_view lua(L);
 	sol::table opts = sol::stack::get<sol::table>(L, 1);
 
-	LuaCircuitArtifact* art = opts["circuit"];
+	Artifact* art = opts["circuit"];
 	if (!art || !art->circuit) {
 		lerror(L, "build_witness_inputs: missing circuit");
 		return 0;
@@ -86,11 +92,10 @@ int lua_build_witness_inputs(lua_State* L) {
 	size_t ninputs = art->circuit->ninputs;
 	size_t npub = art->npub_input();
 
-	LuaWitnessInputs witness(ninputs, npub);
+	Witness witness(ninputs, npub);
 	witness.field = &art->field;
 	const auto& F = art->field;
 
-	// Default all zeros, then set wire 0 = 1
 	for (auto& v : witness.all->v_) v = F.zero();
 	for (auto& v : witness.pub->v_) v = F.zero();
 	if (ninputs > 0) {
@@ -100,7 +105,6 @@ int lua_build_witness_inputs(lua_State* L) {
 		}
 	}
 
-	// Populate provided inputs
 	for (const auto& kv : inputs) {
 		if (!kv.first.is<size_t>()) {
 			lerror(L, "build_witness_inputs: input keys must be numbers");
@@ -127,17 +131,27 @@ int lua_build_witness_inputs(lua_State* L) {
 			return 0;
 		}
 
-		auto nat = nat_from_octet<Fp256Nat>(o);
+		auto nat = nat_from_octet<typename Artifact::Field::N>(o);
 		witness.all->v_[idx] = F.to_montgomery(nat);
 		if (idx < npub) {
 			witness.pub->v_[idx] = witness.all->v_[idx];
 		}
 
 		o_free(L, o);
-		lua_pop(L, 1);  // pop value
+		lua_pop(L, 1);
 	}
 
 	return sol::stack::push(L, std::move(witness));
+}
+
+// Build Dense witness arrays from Lua table of OCTETs
+int lua_build_witness_inputs(lua_State* L) {
+	return lua_build_witness_inputs_impl<LuaCircuitArtifact, LuaWitnessInputs>(L);
+}
+
+int lua_build_witness_inputs_bip340(lua_State* L) {
+	return lua_build_witness_inputs_impl<LuaCircuitArtifactBip340,
+										 LuaWitnessInputsBip340>(L);
 }
 
 // Prove circuit with provided witness
@@ -179,6 +193,71 @@ int lua_prove_circuit(lua_State* L) {
 
 	ZkProof<Field> zk(*art->circuit, kLigeroRate, kLigeroNreq);
 	ZkProver<Field, decltype(rsf)> prover(*art->circuit, F, rsf);
+
+	Transcript tp(seed_buf, seed_len, /*version=*/4);
+	SeededRandomEngine rng(seed_buf, seed_len);
+
+	prover.commit(zk, *witness->all, tp, rng);
+	bool ok = prover.prove(zk, *witness->all, tp);
+	if (!ok) {
+		lerror(L, "prove_circuit: proof generation failed");
+		return 0;
+	}
+
+	std::vector<uint8_t> buf;
+	zk.write(buf, F);
+	push_buffer_to_octet(L, reinterpret_cast<char*>(buf.data()), buf.size());
+	return 1;
+}
+
+int lua_prove_circuit_bip340(lua_State* L) {
+	sol::state_view lua(L);
+	sol::table opts = sol::stack::get<sol::table>(L, 1);
+
+	LuaCircuitArtifactBip340* art = opts["circuit"];
+	LuaWitnessInputsBip340* witness = opts["inputs"];
+
+	if (!art || !art->circuit) {
+		lerror(L, "prove_circuit: missing circuit");
+		return 0;
+	}
+	if (!witness || !witness->all) {
+		lerror(L, "prove_circuit: missing inputs");
+		return 0;
+	}
+
+	uint8_t seed_buf[kSHA256DigestSize] = {0};
+	size_t seed_len = sizeof(seed_buf);
+	if (opts["seed"].valid()) {
+		opts["seed"].push();
+		const octet* seed = o_arg(L, -1);
+		if (seed) {
+			size_t copy_len = o_len(seed) < seed_len ? o_len(seed) : seed_len;
+			memcpy(seed_buf, o_val(seed), copy_len);
+			o_free(L, seed);
+		}
+		lua_pop(L, 1);
+	}
+
+	using Field = Fp256k1Base;
+	using Crt = CRT256<Field>;
+	using ConvolutionFactory = CrtConvolutionFactory<Crt, Field>;
+	using RSFactory = ReedSolomonFactory<Field, ConvolutionFactory>;
+
+	const Field& F = witness->field ? *witness->field : art->field;
+	size_t block_enc = art->circuit->ninputs - art->circuit->npub_in +
+					   art->circuit->nc + 1;
+	auto err = check_crt_block_enc<Crt>(block_enc);
+	if (!err.empty()) {
+		lerror(L, "prove_circuit: %s", err.c_str());
+		return 0;
+	}
+
+	ConvolutionFactory factory(F);
+	RSFactory rsf(factory, F);
+
+	ZkProof<Field> zk(*art->circuit, kLigeroRate, kLigeroNreq, block_enc);
+	ZkProver<Field, RSFactory> prover(*art->circuit, F, rsf);
 
 	Transcript tp(seed_buf, seed_len, /*version=*/4);
 	SeededRandomEngine rng(seed_buf, seed_len);
@@ -259,6 +338,237 @@ int lua_verify_circuit(lua_State* L) {
 
 	lua_pushboolean(L, ok);
 	return 1;
+}
+
+int lua_verify_circuit_bip340(lua_State* L) {
+	sol::state_view lua(L);
+	sol::table opts = sol::stack::get<sol::table>(L, 1);
+
+	LuaCircuitArtifactBip340* art = opts["circuit"];
+	LuaWitnessInputsBip340* witness = opts["public_inputs"];
+
+	if (!art || !art->circuit) {
+		lerror(L, "verify_circuit: missing circuit");
+		return 0;
+	}
+	if (!witness || !witness->pub) {
+		lerror(L, "verify_circuit: missing public inputs");
+		return 0;
+	}
+
+	uint8_t seed_buf[kSHA256DigestSize] = {0};
+	size_t seed_len = sizeof(seed_buf);
+	if (opts["seed"].valid()) {
+		opts["seed"].push();
+		const octet* s = o_arg(L, -1);
+		if (s) {
+			size_t copy_len = o_len(s) < seed_len ? o_len(s) : seed_len;
+			memcpy(seed_buf, o_val(s), copy_len);
+			o_free(L, s);
+		}
+		lua_pop(L, 1);
+	}
+
+	using Field = Fp256k1Base;
+	using Crt = CRT256<Field>;
+	using ConvolutionFactory = CrtConvolutionFactory<Crt, Field>;
+	using RSFactory = ReedSolomonFactory<Field, ConvolutionFactory>;
+
+	const Field& F = witness->field ? *witness->field : art->field;
+	size_t block_enc = art->circuit->ninputs - art->circuit->npub_in +
+					   art->circuit->nc + 1;
+	auto err = check_crt_block_enc<Crt>(block_enc);
+	if (!err.empty()) {
+		lerror(L, "verify_circuit: %s", err.c_str());
+		return 0;
+	}
+
+	ConvolutionFactory factory(F);
+	RSFactory rsf(factory, F);
+
+	opts["proof"].push();
+	const octet* proof_oct = o_arg(L, -1);
+	if (!proof_oct) {
+		lua_pop(L, 1);
+		lerror(L, "verify_circuit: missing proof");
+		return 0;
+	}
+	ReadBuffer rb(reinterpret_cast<const uint8_t*>(o_val(proof_oct)), o_len(proof_oct));
+	ZkProof<Field> zk(*art->circuit, kLigeroRate, kLigeroNreq, block_enc);
+	bool read_ok = zk.read(rb, F);
+	o_free(L, proof_oct);
+	lua_pop(L, 1);
+	if (!read_ok) {
+		lerror(L, "verify_circuit: failed to parse proof");
+		return 0;
+	}
+
+	Transcript tv(seed_buf, seed_len, /*version=*/4);
+	ZkVerifier<Field, RSFactory> verifier(*art->circuit, rsf, kLigeroRate,
+										  kLigeroNreq, block_enc, F);
+	verifier.recv_commitment(zk, tv);
+	bool ok = verifier.verify(zk, *witness->pub, tv);
+
+	lua_pushboolean(L, ok);
+	return 1;
+}
+
+int lua_bip340_circuit(lua_State* L) {
+	using Field = Fp256k1Base;
+	using Backend = CompilerBackend<Field>;
+	using LogicCircuit = Logic<Field, Backend>;
+	using Verify = Bip340Verify<LogicCircuit, Field, P256k1>;
+
+	QuadCircuit<Field> q(p256k1_base);
+	std::unique_ptr<Circuit<Field>> circuit;
+	{
+		const Backend backend(&q);
+		const LogicCircuit logic(&backend, p256k1_base);
+		Verify verify(logic, p256k1);
+
+		auto rx = logic.eltw_input();
+		auto px = logic.eltw_input();
+		auto e = logic.eltw_input();
+
+		typename Verify::Witness witness;
+		q.private_input();
+		witness.input(logic);
+		verify.assert_verify(rx, px, e, witness);
+		circuit = q.mkcircuit(1);
+	}
+
+	if (!circuit) {
+		lerror(L, "bip340_circuit: failed to build circuit");
+		return 0;
+	}
+
+	sol::stack::push(L, LuaCircuitArtifactBip340(std::move(circuit)));
+	return 1;
+}
+
+int lua_bip340_compute_inputs(lua_State* L) {
+	sol::state_view lua(L);
+	LuaCircuitArtifactBip340* art =
+		sol::stack::get<LuaCircuitArtifactBip340*>(L, 1);
+	if (!art || !art->circuit) {
+		lerror(L, "bip340_compute_inputs: missing circuit");
+		return 0;
+	}
+
+	const octet* sig_oct = o_arg(L, 2);
+	const octet* pk_oct = o_arg(L, 3);
+	const octet* msg_oct = o_arg(L, 4);
+	if (!sig_oct || !pk_oct || !msg_oct) {
+		if (sig_oct) o_free(L, sig_oct);
+		if (pk_oct) o_free(L, pk_oct);
+		if (msg_oct) o_free(L, msg_oct);
+		lerror(L, "bip340_compute_inputs: expected circuit, signature, public key, message");
+		return 0;
+	}
+	if (o_len(sig_oct) != 64) {
+		o_free(L, sig_oct);
+		o_free(L, pk_oct);
+		o_free(L, msg_oct);
+		lerror(L, "bip340_compute_inputs: signature must be 64 bytes");
+		return 0;
+	}
+	if (o_len(pk_oct) != 32) {
+		o_free(L, sig_oct);
+		o_free(L, pk_oct);
+		o_free(L, msg_oct);
+		lerror(L, "bip340_compute_inputs: public key must be 32 bytes");
+		return 0;
+	}
+
+	Bip340Witness bip340(p256k1);
+	bool ok = bip340.compute(reinterpret_cast<const uint8_t*>(o_val(sig_oct)),
+							 reinterpret_cast<const uint8_t*>(o_val(pk_oct)),
+							 reinterpret_cast<const uint8_t*>(o_val(msg_oct)),
+							 o_len(msg_oct));
+	if (!ok) {
+		o_free(L, sig_oct);
+		o_free(L, pk_oct);
+		o_free(L, msg_oct);
+		lerror(L, "bip340_compute_inputs: witness computation failed");
+		return 0;
+	}
+
+	auto rx_nat = Bip340Witness::nat_from_be_bytes(
+		reinterpret_cast<const uint8_t*>(o_val(sig_oct)));
+	auto px_nat = Bip340Witness::nat_from_be_bytes(
+		reinterpret_cast<const uint8_t*>(o_val(pk_oct)));
+	auto rx = art->field.to_montgomery(rx_nat);
+	auto px = art->field.to_montgomery(px_nat);
+
+	o_free(L, sig_oct);
+	o_free(L, pk_oct);
+	o_free(L, msg_oct);
+
+	LuaWitnessInputsBip340 prover(art->circuit->ninputs, art->npub_input());
+	LuaWitnessInputsBip340 verifier(art->circuit->ninputs, art->npub_input());
+	prover.field = &art->field;
+	verifier.field = &art->field;
+
+	for (auto& v : prover.all->v_) v = art->field.zero();
+	for (auto& v : prover.pub->v_) v = art->field.zero();
+	for (auto& v : verifier.all->v_) v = art->field.zero();
+	for (auto& v : verifier.pub->v_) v = art->field.zero();
+
+	prover.all->v_[0] = art->field.one();
+	prover.pub->v_[0] = art->field.one();
+	verifier.all->v_[0] = art->field.one();
+	verifier.pub->v_[0] = art->field.one();
+
+	prover.all->v_[1] = rx;
+	prover.all->v_[2] = px;
+	prover.all->v_[3] = bip340.e_;
+	prover.pub->v_[1] = rx;
+	prover.pub->v_[2] = px;
+	prover.pub->v_[3] = bip340.e_;
+	verifier.all->v_[1] = rx;
+	verifier.all->v_[2] = px;
+	verifier.all->v_[3] = bip340.e_;
+	verifier.pub->v_[1] = rx;
+	verifier.pub->v_[2] = px;
+	verifier.pub->v_[3] = bip340.e_;
+
+	size_t idx = art->circuit->npub_in;
+	auto push_private = [&](const auto& elt) {
+		check(idx < prover.all->v_.size(), "bip340 witness index in range");
+		prover.all->v_[idx++] = elt;
+	};
+
+	for (size_t i = 0; i < Bip340Witness::kBits; ++i) {
+		push_private(bip340.bits_s_[i]);
+		if (i < Bip340Witness::kBits - 1) {
+			push_private(bip340.int_sx_[i]);
+			push_private(bip340.int_sy_[i]);
+			push_private(bip340.int_sz_[i]);
+		}
+	}
+	for (size_t i = 0; i < Bip340Witness::kBits; ++i) {
+		push_private(bip340.bits_e_[i]);
+		if (i < Bip340Witness::kBits - 1) {
+			push_private(bip340.int_ex_[i]);
+			push_private(bip340.int_ey_[i]);
+			push_private(bip340.int_ez_[i]);
+		}
+	}
+	push_private(bip340.py_);
+	push_private(bip340.ry_);
+	push_private(bip340.rz_inv_);
+	for (size_t i = 0; i < Bip340Witness::kBits; ++i) {
+		push_private(bip340.bits_ry_[i]);
+	}
+
+	if (idx != art->circuit->ninputs) {
+		lerror(L, "bip340_compute_inputs: witness size mismatch");
+		return 0;
+	}
+
+	sol::stack::push(L, std::move(prover));
+	sol::stack::push(L, std::move(verifier));
+	return 2;
 }
 
 void register_zk_bindings(sol::state_view& lua) {
@@ -369,6 +679,31 @@ void register_zk_bindings(sol::state_view& lua) {
 		"npub", [](LuaWitnessInputs& w) { return w.pub ? w.pub->n1_ : 0; }
 	);
 
+	auto circuit_artifact_bip340 =
+		lua.new_usertype<LuaCircuitArtifactBip340>("CircuitArtifactBip340",
+			sol::no_constructor,
+
+			"__name", sol::property(&LuaCircuitArtifactBip340::__name),
+			"octet", &LuaCircuitArtifactBip340::lua_octet,
+			"circuit_id", &LuaCircuitArtifactBip340::lua_circuit_id,
+			"set_input", &LuaCircuitArtifactBip340::lua_set_input,
+			"get_input", &LuaCircuitArtifactBip340::lua_get_input,
+			"ninput", sol::property(&LuaCircuitArtifactBip340::ninput),
+			"npub_input", sol::property(&LuaCircuitArtifactBip340::npub_input),
+			"depth", sol::property(&LuaCircuitArtifactBip340::depth),
+			"nwires", sol::property(&LuaCircuitArtifactBip340::nwires),
+			"nquad_terms", sol::property(&LuaCircuitArtifactBip340::nquad_terms)
+		);
+
+	auto witness_inputs_bip340 =
+		lua.new_usertype<LuaWitnessInputsBip340>("WitnessInputsBip340",
+			sol::constructors<LuaWitnessInputsBip340(size_t, size_t)>(),
+
+			"__name", sol::property(&LuaWitnessInputsBip340::__name),
+			"ninputs", [](LuaWitnessInputsBip340& w) { return w.all ? w.all->n1_ : 0; },
+			"npub", [](LuaWitnessInputsBip340& w) { return w.pub ? w.pub->n1_ : 0; }
+		);
+
 	// ========================================================================
 	// High-Level Boolean Logic
 	// ========================================================================
@@ -419,6 +754,30 @@ void register_zk_bindings(sol::state_view& lua) {
 		"eq", &LuaEltW::eq,
 		"wire_id", &LuaEltW::wire_id,
 		"to_string", &LuaEltW::to_string
+	);
+
+	auto eltw_bip340 = lua.new_usertype<LuaEltWBip340>("EltWBip340",
+		sol::constructors<>(),
+
+		"__name", sol::property(&LuaEltWBip340::__name),
+		sol::meta_function::addition, &LuaEltWBip340::add,
+		sol::meta_function::subtraction, &LuaEltWBip340::sub,
+		sol::meta_function::multiplication, sol::overload(
+			static_cast<LuaEltWBip340(LuaEltWBip340::*)(const LuaEltWBip340&) const>(
+				&LuaEltWBip340::mul),
+			static_cast<LuaEltWBip340(LuaEltWBip340::*)(const LuaFp256k1Elt&) const>(
+				&LuaEltWBip340::mul_scalar)
+		),
+		sol::meta_function::equal_to, &LuaEltWBip340::eq,
+		sol::meta_function::to_string, &LuaEltWBip340::to_string,
+
+		"add", &LuaEltWBip340::add,
+		"sub", &LuaEltWBip340::sub,
+		"mul", &LuaEltWBip340::mul,
+		"mul_scalar", &LuaEltWBip340::mul_scalar,
+		"eq", &LuaEltWBip340::eq,
+		"wire_id", &LuaEltWBip340::wire_id,
+		"to_string", &LuaEltWBip340::to_string
 	);
 
 	// BitVec8
@@ -707,6 +1066,40 @@ void register_zk_bindings(sol::state_view& lua) {
 		"veq_var", &LuaLogic::veq_var
 	);
 
+	auto logic_bip340 = lua.new_usertype<LuaLogicBip340>("LogicBip340",
+		sol::constructors<LuaLogicBip340()>(),
+
+		"__name", sol::property(&LuaLogicBip340::__name),
+		"zero", &LuaLogicBip340::zero,
+		"one", &LuaLogicBip340::one,
+		"mone", &LuaLogicBip340::mone,
+		"elt", &LuaLogicBip340::elt,
+		"add", &LuaLogicBip340::add,
+		"sub", &LuaLogicBip340::sub,
+		"mul", sol::overload(
+			&LuaLogicBip340::mul,
+			&LuaLogicBip340::mul_scalar
+		),
+		"mul_scalar", &LuaLogicBip340::mul_scalar,
+		"konst", sol::overload(
+			&LuaLogicBip340::konst,
+			&LuaLogicBip340::konst_int
+		),
+		"ax", &LuaLogicBip340::ax,
+		"axy", &LuaLogicBip340::axy,
+		"axpy", &LuaLogicBip340::axpy,
+		"apy", &LuaLogicBip340::apy,
+		"expr", &LuaLogicBip340::expr,
+		"assert0", &LuaLogicBip340::assert0_elt,
+		"assert_eq", &LuaLogicBip340::assert_eq_elt,
+		"eltw_input", &LuaLogicBip340::eltw_input,
+		"private_inputs", &LuaLogicBip340::private_inputs,
+		"begin_full_field", &LuaLogicBip340::begin_full_field,
+		"PRIV", &LuaLogicBip340::PRIV,
+		"FULL", &LuaLogicBip340::FULL,
+		"compile", &LuaLogicBip340::compile
+	);
+
 	// ========================================================================
 	// Router Primitives
 	// ========================================================================
@@ -857,18 +1250,29 @@ int luaopen_zkcore(lua_State* L) {
 
 	// Factory: load circuit artifact from OCTET
 	zkcore_table["load_circuit_artifact"] = &proofs::lua::LuaCircuitArtifact::lua_load_from_octet;
+	zkcore_table["load_circuit_artifact_bip340"] =
+		&proofs::lua::LuaCircuitArtifactBip340::lua_load_from_octet;
 
-	zkcore_table.set_function("create_logic",
+	zkcore_table.set_function("create_logic_p256",
 		sol::factories([]() { return std::make_unique<proofs::lua::LuaLogic>(); }));
-	// Alias: simpler entrypoint
+	zkcore_table.set_function("create_logic_bip340",
+		sol::factories([]() { return std::make_unique<proofs::lua::LuaLogicBip340>(); }));
+	zkcore_table["create_logic"] = zkcore_table["create_logic_p256"];
 	zkcore_table["logic"] = zkcore_table["create_logic"];
 
 	zkcore_table.set_function("create_gf2128_logic",
 		sol::factories([]() { return std::make_unique<proofs::lua::LuaGF2128Logic>(); }));
 
 	zkcore_table["build_witness_inputs"] = &proofs::lua::lua_build_witness_inputs;
+	zkcore_table["build_witness_inputs_bip340"] =
+		&proofs::lua::lua_build_witness_inputs_bip340;
 	zkcore_table["prove_circuit"] = &proofs::lua::lua_prove_circuit;
+	zkcore_table["prove_circuit_bip340"] = &proofs::lua::lua_prove_circuit_bip340;
 	zkcore_table["verify_circuit"] = &proofs::lua::lua_verify_circuit;
+	zkcore_table["verify_circuit_bip340"] = &proofs::lua::lua_verify_circuit_bip340;
+	zkcore_table["bip340_circuit_native"] = &proofs::lua::lua_bip340_circuit;
+	zkcore_table["bip340_compute_inputs_native"] =
+		&proofs::lua::lua_bip340_compute_inputs;
 
 	// Register witness bindings in the ZKCORE table
 	// Push the zkcore_table to the stack first

--- a/lib/zk-circuit-lang/lfzk_bindings.h
+++ b/lib/zk-circuit-lang/lfzk_bindings.h
@@ -23,6 +23,7 @@
 
 #include "sol.hpp"
 #include "ec/p256.h"
+#include "ec/p256k1.h"
 #include "algebra/fp_p256.h"
 #include "algebra/fp2.h"
 #include "gf2k/gf2_128.h"
@@ -71,39 +72,39 @@ static constexpr size_t kLigeroNreq = 128;  // ~86 bits statistical soundness
 // Field Element Wrappers
 // ============================================================================
 
-// Wrapper for Fp256 field elements
-class LuaFp256Elt {
+template <class Field_>
+class LuaFieldEltT {
 public:
-	using Field = Fp256Base;
+	using Field = Field_;
 	using Elt = Field::Elt;
 
 	Elt value;
 	const Field* field;
 
-	LuaFp256Elt(const Elt& v, const Field* f) : value(v), field(f) {}
+	LuaFieldEltT(const Elt& v, const Field* f) : value(v), field(f) {}
 
 	// Arithmetic operations
-	LuaFp256Elt add(const LuaFp256Elt& other) const {
-		return LuaFp256Elt(field->addf(value, other.value), field);
+	LuaFieldEltT add(const LuaFieldEltT& other) const {
+		return LuaFieldEltT(field->addf(value, other.value), field);
 	}
 
-	LuaFp256Elt sub(const LuaFp256Elt& other) const {
-		return LuaFp256Elt(field->subf(value, other.value), field);
+	LuaFieldEltT sub(const LuaFieldEltT& other) const {
+		return LuaFieldEltT(field->subf(value, other.value), field);
 	}
 
-	LuaFp256Elt mul(const LuaFp256Elt& other) const {
-		return LuaFp256Elt(field->mulf(value, other.value), field);
+	LuaFieldEltT mul(const LuaFieldEltT& other) const {
+		return LuaFieldEltT(field->mulf(value, other.value), field);
 	}
 
-	LuaFp256Elt neg() const {
-		return LuaFp256Elt(field->negf(value), field);
+	LuaFieldEltT neg() const {
+		return LuaFieldEltT(field->negf(value), field);
 	}
 
 	// Overloaded operators
-	LuaFp256Elt operator+(const LuaFp256Elt& other) const { return add(other); }
-	LuaFp256Elt operator-(const LuaFp256Elt& other) const { return sub(other); }
-	LuaFp256Elt operator*(const LuaFp256Elt& other) const { return mul(other); }
-	LuaFp256Elt operator-() const { return neg(); }
+	LuaFieldEltT operator+(const LuaFieldEltT& other) const { return add(other); }
+	LuaFieldEltT operator-(const LuaFieldEltT& other) const { return sub(other); }
+	LuaFieldEltT operator*(const LuaFieldEltT& other) const { return mul(other); }
+	LuaFieldEltT operator-() const { return neg(); }
 
 	// String representation
 	std::string to_string() const {
@@ -113,6 +114,9 @@ public:
 	// Type identification for Lua type() function
 	static const char* __name() { return "zkcc.fp256elt"; }
 };
+
+using LuaFp256Elt = LuaFieldEltT<Fp256Base>;
+using LuaFp256k1Elt = LuaFieldEltT<Fp256k1Base>;
 
 // Wrapper for GF2_128 field elements
 class LuaGF2128Elt {
@@ -256,16 +260,17 @@ public:
 };
 
 // Circuit Artifact - compiled/loaded circuit
-class LuaCircuitArtifact {
+template <class Field_, FieldID FieldTag>
+class LuaCircuitArtifactT {
 public:
-	using Field = Fp256Base;
+	using Field = Field_;
 	using CircuitType = Circuit<Field>;
 
 	Field field;
 	std::unique_ptr<CircuitType> circuit;
 	std::vector<typename Field::Elt> inputs;  // Stores both public and private inputs
 
-	LuaCircuitArtifact(std::unique_ptr<CircuitType> compiled)
+	LuaCircuitArtifactT(std::unique_ptr<CircuitType> compiled)
 		: field(), circuit(std::move(compiled)) {
 		if (circuit) {
 			inputs.resize(circuit->ninputs, field.zero());
@@ -273,12 +278,12 @@ public:
 	}
 
 	// Move constructor
-	LuaCircuitArtifact(LuaCircuitArtifact&& other) noexcept
+	LuaCircuitArtifactT(LuaCircuitArtifactT&& other) noexcept
 		: field(), circuit(std::move(other.circuit)), inputs(std::move(other.inputs)) {}
 
 	// Delete copy constructor
-	LuaCircuitArtifact(const LuaCircuitArtifact&) = delete;
-	LuaCircuitArtifact& operator=(const LuaCircuitArtifact&) = delete;
+	LuaCircuitArtifactT(const LuaCircuitArtifactT&) = delete;
+	LuaCircuitArtifactT& operator=(const LuaCircuitArtifactT&) = delete;
 
 	// Metrics
 	size_t ninput() const { return circuit ? circuit->ninputs : 0; }
@@ -289,7 +294,7 @@ public:
 
 	// Export to OCTET
 	static int lua_octet(lua_State* L) {
-		LuaCircuitArtifact* self = sol::stack::get<LuaCircuitArtifact*>(L, 1);
+		LuaCircuitArtifactT* self = sol::stack::get<LuaCircuitArtifactT*>(L, 1);
 
 		if (!self->circuit) {
 			lerror(L,"No circuit artifact");
@@ -297,7 +302,7 @@ public:
 		}
 
 		// Serialize circuit to bytes
-		CircuitRep<Field> rep(self->field, FieldID::P256_ID);
+		CircuitRep<Field> rep(self->field, FieldTag);
 		std::vector<uint8_t> bytes;
 		rep.to_bytes(*self->circuit, bytes);
 
@@ -308,7 +313,7 @@ public:
 
 	// Get circuit ID
 	static int lua_circuit_id(lua_State* L) {
-		LuaCircuitArtifact* self = sol::stack::get<LuaCircuitArtifact*>(L, 1);
+		LuaCircuitArtifactT* self = sol::stack::get<LuaCircuitArtifactT*>(L, 1);
 
 		if (!self->circuit) {
 			lerror(L,"No circuit artifact");
@@ -322,7 +327,7 @@ public:
 
 	// Set input from OCTET (index and value)
 	static int lua_set_input(lua_State* L) {
-		LuaCircuitArtifact* self = sol::stack::get<LuaCircuitArtifact*>(L, 1);
+		LuaCircuitArtifactT* self = sol::stack::get<LuaCircuitArtifactT*>(L, 1);
 
 		if (!self->circuit) {
 			lerror(L,"No circuit artifact");
@@ -354,7 +359,8 @@ public:
 		}
 
 		// Convert OCTET to field element
-		self->inputs[idx] = self->field.to_montgomery(nat_from_octet<Fp256Nat>(value_oct));
+		self->inputs[idx] = self->field.to_montgomery(
+			nat_from_octet<typename Field::N>(value_oct));
 
 		o_free(L, value_oct);
 		return 0;
@@ -362,7 +368,7 @@ public:
 
 	// Get input as OCTET
 	static int lua_get_input(lua_State* L) {
-		LuaCircuitArtifact* self = sol::stack::get<LuaCircuitArtifact*>(L, 1);
+		LuaCircuitArtifactT* self = sol::stack::get<LuaCircuitArtifactT*>(L, 1);
 
 		if (!self->circuit) {
 			lerror(L,"No circuit artifact");
@@ -397,7 +403,7 @@ public:
 		}
 
 		ReadBuffer buf((const uint8_t*)o_val(oct), o_len(oct));
-		CircuitRep<Field> rep(Fp256Base(), FieldID::P256_ID);
+		CircuitRep<Field> rep(Field(), FieldTag);
 		auto loaded_circuit = rep.from_bytes(buf, false);
 
 		o_free(L, oct);
@@ -409,7 +415,7 @@ public:
 
 		// Create LuaCircuitArtifact using SOL's stack push
 		sol::state_view lua(L);
-		sol::stack::push(L, LuaCircuitArtifact(std::move(loaded_circuit)));
+		sol::stack::push(L, LuaCircuitArtifactT(std::move(loaded_circuit)));
 
 		return 1;
 	}
@@ -418,28 +424,36 @@ public:
 	static const char* __name() { return "zkcc.circuit_artifact"; }
 };
 
+using LuaCircuitArtifact = LuaCircuitArtifactT<Fp256Base, FieldID::P256_ID>;
+using LuaCircuitArtifactBip340 =
+	LuaCircuitArtifactT<Fp256k1Base, FieldID::SECP_ID>;
+
 // Witness bundle: full input vector and public slice
-class LuaWitnessInputs {
+template <class Field_>
+class LuaWitnessInputsT {
 public:
-	using Field = Fp256Base;
+	using Field = Field_;
 	const Field* field;
 	std::unique_ptr<Dense<Field>> all;
 	std::unique_ptr<Dense<Field>> pub;
 
-	LuaWitnessInputs(size_t ninputs, size_t npub)
+	LuaWitnessInputsT(size_t ninputs, size_t npub)
 		: field(nullptr),
 		  all(std::make_unique<Dense<Field>>(1, ninputs)),
 		  pub(std::make_unique<Dense<Field>>(1, npub)) {}
 
-	LuaWitnessInputs(LuaWitnessInputs&&) noexcept = default;
-	LuaWitnessInputs& operator=(LuaWitnessInputs&&) noexcept = default;
+	LuaWitnessInputsT(LuaWitnessInputsT&&) noexcept = default;
+	LuaWitnessInputsT& operator=(LuaWitnessInputsT&&) noexcept = default;
 
-	LuaWitnessInputs(const LuaWitnessInputs&) = delete;
-	LuaWitnessInputs& operator=(const LuaWitnessInputs&) = delete;
+	LuaWitnessInputsT(const LuaWitnessInputsT&) = delete;
+	LuaWitnessInputsT& operator=(const LuaWitnessInputsT&) = delete;
 
 	// Type identification for Lua type() function
 	static const char* __name() { return "zkcc.witness_inputs"; }
 };
+
+using LuaWitnessInputs = LuaWitnessInputsT<Fp256Base>;
+using LuaWitnessInputsBip340 = LuaWitnessInputsT<Fp256k1Base>;
 
 // Build circuit artifact from template
 static int lua_build_circuit_artifact(lua_State* L) {
@@ -474,10 +488,15 @@ static int lua_build_circuit_artifact(lua_State* L) {
 
 // Build Dense witness arrays from inputs
 int lua_build_witness_inputs(lua_State* L);
+int lua_build_witness_inputs_bip340(lua_State* L);
 
 // Prove/verify helpers
 int lua_prove_circuit(lua_State* L);
 int lua_verify_circuit(lua_State* L);
+int lua_prove_circuit_bip340(lua_State* L);
+int lua_verify_circuit_bip340(lua_State* L);
+int lua_bip340_circuit(lua_State* L);
+int lua_bip340_compute_inputs(lua_State* L);
 
 // ============================================================================
 // High-Level Boolean Logic API
@@ -550,40 +569,41 @@ public:
 };
 
 // Wrapper for EltW (field element wire)
-class LuaEltW {
+template <class LogicType_>
+class LuaEltWT {
 public:
-	using Field = Fp256Base;
-	using Backend = CustomCompilerBackend<Field>;
-	using LogicType = Logic<Field, Backend>;
+	using LogicType = LogicType_;
 	using EltW = typename LogicType::EltW;
+	using Field = typename LogicType::Field;
+	using LuaFieldElt = LuaFieldEltT<Field>;
 
 	EltW wire;
 	const LogicType* logic;
 
-	LuaEltW(const EltW& w, const LogicType* l) : wire(w), logic(l) {}
+	LuaEltWT(const EltW& w, const LogicType* l) : wire(w), logic(l) {}
 
 	size_t wire_id() const {
 		return wire;
 	}
 
 	// Arithmetic operations
-	LuaEltW add(const LuaEltW& other) const {
-		return LuaEltW(logic->add(wire, other.wire), logic);
+	LuaEltWT add(const LuaEltWT& other) const {
+		return LuaEltWT(logic->add(wire, other.wire), logic);
 	}
 
-	LuaEltW sub(const LuaEltW& other) const {
-		return LuaEltW(logic->sub(wire, other.wire), logic);
+	LuaEltWT sub(const LuaEltWT& other) const {
+		return LuaEltWT(logic->sub(wire, other.wire), logic);
 	}
 
-	LuaEltW mul(const LuaEltW& other) const {
-		return LuaEltW(logic->mul(wire, other.wire), logic);
+	LuaEltWT mul(const LuaEltWT& other) const {
+		return LuaEltWT(logic->mul(wire, other.wire), logic);
 	}
 
-	LuaEltW mul_scalar(const LuaFp256Elt& k) const {
-		return LuaEltW(logic->mul(k.value, wire), logic);
+	LuaEltWT mul_scalar(const LuaFieldElt& k) const {
+		return LuaEltWT(logic->mul(k.value, wire), logic);
 	}
 
-	bool eq(const LuaEltW& other) const {
+	bool eq(const LuaEltWT& other) const {
 		// Create a wire that checks if the two field elements are equal
 		// We can't evaluate this at binding time, so we'll add a constraint
 		// that the difference is zero and return a placeholder value
@@ -594,11 +614,11 @@ public:
 	}
 
 	// Overloaded operators for Lua
-	LuaEltW operator+(const LuaEltW& other) const { return add(other); }
-	LuaEltW operator-(const LuaEltW& other) const { return sub(other); }
-	LuaEltW operator*(const LuaEltW& other) const { return mul(other); }
-	LuaEltW operator*(const LuaFp256Elt& k) const { return mul_scalar(k); }
-	bool operator==(const LuaEltW& other) const { return eq(other); }
+	LuaEltWT operator+(const LuaEltWT& other) const { return add(other); }
+	LuaEltWT operator-(const LuaEltWT& other) const { return sub(other); }
+	LuaEltWT operator*(const LuaEltWT& other) const { return mul(other); }
+	LuaEltWT operator*(const LuaFieldElt& k) const { return mul_scalar(k); }
+	bool operator==(const LuaEltWT& other) const { return eq(other); }
 
 	// Type identification for Lua type() function
 	static const char* __name() { return "zkcc.eltw"; }
@@ -610,6 +630,12 @@ public:
 		return std::string(buffer);
 	}
 };
+
+using LuaP256LogicType = Logic<Fp256Base, CustomCompilerBackend<Fp256Base>>;
+using LuaBip340LogicType =
+	Logic<Fp256k1Base, CustomCompilerBackend<Fp256k1Base>>;
+using LuaEltW = LuaEltWT<LuaP256LogicType>;
+using LuaEltWBip340 = LuaEltWT<LuaBip340LogicType>;
 
 // Wrapper for bit vectors
 template <size_t N>
@@ -1613,6 +1639,119 @@ public:
 
 	// Type identification for Lua type() function
 	static const char* __name() { return "zkcc.logic"; }
+};
+
+// Minimal secp256k1 logic wrapper used by the zkcc-bip340 plan.
+// This intentionally exposes only the field-oriented surface needed by
+// named_logic(), small arithmetic circuits, and the BIP340 artifact path.
+class LuaLogicBip340 {
+public:
+	using Field = Fp256k1Base;
+	using Backend = CustomCompilerBackend<Field>;
+	using LogicType = Logic<Field, Backend>;
+
+	Field field;
+	std::unique_ptr<QuadCircuit<Field>> circuit;
+	std::unique_ptr<Backend> backend;
+	std::unique_ptr<LogicType> logic;
+
+	LuaLogicBip340() {
+		circuit = std::make_unique<QuadCircuit<Field>>(field);
+		backend = std::make_unique<Backend>(circuit.get());
+		logic = std::make_unique<LogicType>(backend.get(), field);
+	}
+
+	void private_inputs() { circuit->private_input(); }
+	void begin_full_field() { circuit->begin_full_field(); }
+	void PRIV() { private_inputs(); }
+	void FULL() { begin_full_field(); }
+
+	LuaCircuitArtifactBip340 compile(size_t nc = 1) {
+		auto compiled = circuit->mkcircuit(nc);
+		if (!compiled) {
+			lerror(((zenroom_t*)ZEN)->lua, "compile(): failed to build circuit");
+		}
+		return LuaCircuitArtifactBip340(std::move(compiled));
+	}
+
+	LuaFp256k1Elt zero() const { return LuaFp256k1Elt(logic->zero(), &field); }
+	LuaFp256k1Elt one() const { return LuaFp256k1Elt(logic->one(), &field); }
+	LuaFp256k1Elt mone() const { return LuaFp256k1Elt(logic->mone(), &field); }
+	LuaFp256k1Elt elt(uint64_t a) const { return LuaFp256k1Elt(logic->elt(a), &field); }
+
+	LuaEltWBip340 add(const LuaEltWBip340& a, const LuaEltWBip340& b) {
+		return LuaEltWBip340(logic->add(a.wire, b.wire), logic.get());
+	}
+
+	LuaEltWBip340 sub(const LuaEltWBip340& a, const LuaEltWBip340& b) {
+		return LuaEltWBip340(logic->sub(a.wire, b.wire), logic.get());
+	}
+
+	LuaEltWBip340 mul(const LuaEltWBip340& a, const LuaEltWBip340& b) {
+		return LuaEltWBip340(logic->mul(a.wire, b.wire), logic.get());
+	}
+
+	LuaEltWBip340 mul_scalar(const LuaFp256k1Elt& k, const LuaEltWBip340& b) {
+		return LuaEltWBip340(logic->mul(k.value, b.wire), logic.get());
+	}
+
+	LuaEltWBip340 konst(const LuaFp256k1Elt& a) {
+		return LuaEltWBip340(logic->konst(a.value), logic.get());
+	}
+
+	LuaEltWBip340 konst_int(uint64_t a) {
+		return LuaEltWBip340(logic->konst(a), logic.get());
+	}
+
+	LuaEltWBip340 ax(const LuaFp256k1Elt& a, const LuaEltWBip340& x) {
+		return LuaEltWBip340(logic->ax(a.value, x.wire), logic.get());
+	}
+
+	LuaEltWBip340 axy(const LuaFp256k1Elt& a, const LuaEltWBip340& x,
+					  const LuaEltWBip340& y) {
+		return LuaEltWBip340(logic->axy(a.value, x.wire, y.wire), logic.get());
+	}
+
+	LuaEltWBip340 axpy(const LuaEltWBip340& y, const LuaFp256k1Elt& a,
+					   const LuaEltWBip340& x) {
+		return LuaEltWBip340(logic->axpy(y.wire, a.value, x.wire), logic.get());
+	}
+
+	LuaEltWBip340 apy(const LuaEltWBip340& y, const LuaFp256k1Elt& a) {
+		return LuaEltWBip340(logic->apy(y.wire, a.value), logic.get());
+	}
+
+	LuaEltWBip340 expr(sol::protected_function fn, sol::table env) {
+		sol::state_view lua(env.lua_state());
+		sol::table proxy = lua.create_table();
+		for (const auto& kv : env) {
+			proxy[kv.first] = kv.second;
+		}
+		sol::protected_function_result res = fn(proxy);
+		if (!res.valid()) {
+			sol::error err = res;
+			lerror(lua.lua_state(), "expr: %s", err.what());
+		}
+		sol::object obj = res;
+		if (!obj.is<LuaEltWBip340>()) {
+			lerror(lua.lua_state(), "expr: expected EltW result");
+		}
+		return obj.as<LuaEltWBip340>();
+	}
+
+	LuaEltWBip340 assert0_elt(const LuaEltWBip340& a) {
+		return LuaEltWBip340(logic->assert0(a.wire), logic.get());
+	}
+
+	LuaEltWBip340 assert_eq_elt(const LuaEltWBip340& a, const LuaEltWBip340& b) {
+		return LuaEltWBip340(logic->assert_eq(a.wire, b.wire), logic.get());
+	}
+
+	LuaEltWBip340 eltw_input() {
+		return LuaEltWBip340(logic->eltw_input(), logic.get());
+	}
+
+	static const char* __name() { return "zkcc.logic_bip340"; }
 };
 
 // ============================================================================

--- a/lib/zk-circuit-lang/octet_conversions.h
+++ b/lib/zk-circuit-lang/octet_conversions.h
@@ -65,9 +65,8 @@ void nat_to_octet(lua_State* L, const Nat& n) {
         bytes[i] = le_bytes[Nat::kBytes - 1 - i];
     }
     
-    // Push as OCTET
-    extern octet* o_push(lua_State*, const char*, size_t);
-    ::o_push(L, (char*)bytes, Nat::kBytes);
+    // Push as OCTET (copy into GC-owned buffer, not aliased stack memory)
+    ::push_buffer_to_octet(L, (char*)bytes, Nat::kBytes);
 }
 
 // Convert field element to OCTET (from Montgomery form)

--- a/lib/zk-circuit-lang/witness_bindings.cc
+++ b/lib/zk-circuit-lang/witness_bindings.cc
@@ -22,8 +22,10 @@
 #include <cstring>
 
 #include "circuits/sha/flatsha256_witness.h"
+#include "circuits/bip340/bip340_witness.h"
 #include "circuits/ecdsa/verify_witness.h"
 #include "ec/p256.h"
+#include "ec/p256k1.h"
 #include "algebra/fp_p256.h"
 
 extern "C" {
@@ -264,6 +266,105 @@ static int ecdsa_gc(lua_State* L) {
 }
 
 // ============================================================================
+// BIP340 Witness Generation
+// ============================================================================
+
+int bip340_compute_witness(lua_State* L) {
+    const octet* sig_oct = o_arg(L, 1);
+    const octet* pk_oct = o_arg(L, 2);
+    const octet* msg_oct = o_arg(L, 3);
+
+    if (!sig_oct) {
+        lerror(L, "BIP340: signature must be an OCTET");
+        return 0;
+    }
+    if (!pk_oct) {
+        o_free(L, sig_oct);
+        lerror(L, "BIP340: public key must be an OCTET");
+        return 0;
+    }
+    if (!msg_oct) {
+        o_free(L, sig_oct);
+        o_free(L, pk_oct);
+        lerror(L, "BIP340: message must be an OCTET");
+        return 0;
+    }
+    if (o_len(sig_oct) != 64) {
+        o_free(L, sig_oct);
+        o_free(L, pk_oct);
+        o_free(L, msg_oct);
+        lerror(L, "BIP340: signature must be 64 bytes");
+        return 0;
+    }
+    if (o_len(pk_oct) != 32) {
+        o_free(L, sig_oct);
+        o_free(L, pk_oct);
+        o_free(L, msg_oct);
+        lerror(L, "BIP340: public key must be 32 bytes");
+        return 0;
+    }
+
+    Bip340Witness witness(p256k1);
+    bool ok = witness.compute(reinterpret_cast<const uint8_t*>(o_val(sig_oct)),
+                              reinterpret_cast<const uint8_t*>(o_val(pk_oct)),
+                              reinterpret_cast<const uint8_t*>(o_val(msg_oct)),
+                              o_len(msg_oct));
+    if (!ok) {
+        o_free(L, sig_oct);
+        o_free(L, pk_oct);
+        o_free(L, msg_oct);
+        lerror(L, "BIP340: witness computation failed");
+        return 0;
+    }
+
+    auto rx_nat = Bip340Witness::nat_from_be_bytes(
+        reinterpret_cast<const uint8_t*>(o_val(sig_oct)));
+    auto px_nat = Bip340Witness::nat_from_be_bytes(
+        reinterpret_cast<const uint8_t*>(o_val(pk_oct)));
+    auto rx = p256k1_base.to_montgomery(rx_nat);
+    auto px = p256k1_base.to_montgomery(px_nat);
+
+    o_free(L, sig_oct);
+    o_free(L, pk_oct);
+    o_free(L, msg_oct);
+
+    auto push_field_array = [&](const auto& values, size_t n, const char* key) {
+        lua_newtable(L);
+        for (size_t i = 0; i < n; ++i) {
+            field_elt_to_octet(L, values[i], p256k1_base);
+            lua_rawseti(L, -2, i + 1);
+        }
+        lua_setfield(L, -2, key);
+    };
+
+    lua_newtable(L);
+    field_elt_to_octet(L, rx, p256k1_base);
+    lua_setfield(L, -2, "rx");
+    field_elt_to_octet(L, px, p256k1_base);
+    lua_setfield(L, -2, "px");
+    field_elt_to_octet(L, witness.e_, p256k1_base);
+    lua_setfield(L, -2, "e");
+    field_elt_to_octet(L, witness.py_, p256k1_base);
+    lua_setfield(L, -2, "py");
+    field_elt_to_octet(L, witness.ry_, p256k1_base);
+    lua_setfield(L, -2, "ry");
+    field_elt_to_octet(L, witness.rz_inv_, p256k1_base);
+    lua_setfield(L, -2, "rz_inv");
+
+    push_field_array(witness.bits_s_, Bip340Witness::kBits, "bits_s");
+    push_field_array(witness.int_sx_, Bip340Witness::kBits - 1, "int_sx");
+    push_field_array(witness.int_sy_, Bip340Witness::kBits - 1, "int_sy");
+    push_field_array(witness.int_sz_, Bip340Witness::kBits - 1, "int_sz");
+    push_field_array(witness.bits_e_, Bip340Witness::kBits, "bits_e");
+    push_field_array(witness.int_ex_, Bip340Witness::kBits - 1, "int_ex");
+    push_field_array(witness.int_ey_, Bip340Witness::kBits - 1, "int_ey");
+    push_field_array(witness.int_ez_, Bip340Witness::kBits - 1, "int_ez");
+    push_field_array(witness.bits_ry_, Bip340Witness::kBits, "bits_ry");
+
+    return 1;
+}
+
+// ============================================================================
 // Type Conversion Utilities
 // ============================================================================
 
@@ -308,6 +409,7 @@ static const luaL_Reg ecdsa_witness_methods[] = {
 static const luaL_Reg zk_witness_functions[] = {
     {"sha256_compute_message", sha256_compute_message},
     {"ecdsa_create_witness", ecdsa_create_witness},
+    {"bip340_compute", bip340_compute_witness},
     {"nat_from_octet", nat_from_octet_be},
     {NULL, NULL}
 };

--- a/lib/zk-circuit-lang/witness_bindings.h
+++ b/lib/zk-circuit-lang/witness_bindings.h
@@ -36,6 +36,11 @@ int sha256_compute_message(lua_State* L);
 // Returns: boolean success, then witness object if success
 int ecdsa_create_witness(lua_State* L);
 
+// BIP340 witness generation
+// Args: signature (64 bytes), public key (32 bytes), message (OCTET)
+// Returns: table with public values and full witness arrays as OCTETs
+int bip340_compute_witness(lua_State* L);
+
 // ECDSA witness accessors (require witness object on stack)
 int ecdsa_get_rx(lua_State* L);
 int ecdsa_get_ry(lua_State* L);

--- a/src/lua/crypto_zkcc.lua
+++ b/src/lua/crypto_zkcc.lua
@@ -631,51 +631,63 @@ end
 
 M.named_logic = new_named_logic
 
-local function repeat_named_entries(entries, prefix, count, kind, input_type)
-    for i = 1, count do
-        entries[#entries + 1] = {
-            kind = kind,
-            name = string.format("%s_%03d", prefix, i),
-            type = input_type,
-            desc = prefix,
-            index = #entries + 1,
-            decl_order = #entries + 1,
-        }
-    end
-end
-
-local function append_named_entry(entries, name, kind, input_type)
-    entries[#entries + 1] = {
-        kind = kind,
-        name = name,
-        type = input_type,
-        desc = name,
-        index = #entries + 1,
-        decl_order = #entries + 1,
-    }
-end
-
 local function make_bip340_schema(artifact)
+    -- Builds the schema for the native BIP340 verification circuit.
+    -- Entries are ordered and indexed to match Bip340Verify::Witness::input()
+    -- in lfzk_bindings.cc: interleaved bits_s[i], int_sx[i], int_sy[i],
+    -- int_sz[i] (one iteration per i), then e·P trace (also interleaved),
+    -- then py, ry, rz_inv, bits_ry.
+    -- Indices are 1-based absolute positions in the dense witness array.
+
     local public = {}
     local private = {}
     local full = {}
+    local seq = 1 -- 1-based absolute index; v_[0] is the constant-1
 
-    append_named_entry(public, "rx", "public", "field")
-    append_named_entry(public, "px", "public", "field")
-    append_named_entry(public, "e", "public", "field")
+    local function add(list, name, kind, input_type)
+        list[#list + 1] = {
+            kind = kind,
+            name = name,
+            type = input_type,
+            desc = name,
+            index = seq,
+            decl_order = seq,
+        }
+        seq = seq + 1
+    end
 
-    repeat_named_entries(private, "bits_s", 256, "private", "field")
-    repeat_named_entries(private, "int_sx", 255, "private", "field")
-    repeat_named_entries(private, "int_sy", 255, "private", "field")
-    repeat_named_entries(private, "int_sz", 255, "private", "field")
-    repeat_named_entries(private, "bits_e", 256, "private", "field")
-    repeat_named_entries(private, "int_ex", 255, "private", "field")
-    repeat_named_entries(private, "int_ey", 255, "private", "field")
-    repeat_named_entries(private, "int_ez", 255, "private", "field")
-    append_named_entry(private, "py", "private", "field")
-    append_named_entry(private, "ry", "private", "field")
-    append_named_entry(private, "rz_inv", "private", "field")
-    repeat_named_entries(private, "bits_ry", 256, "private", "field")
+    -- Public inputs: v_[1..3]
+    add(public, "rx", "public", "field")
+    add(public, "px", "public", "field")
+    add(public, "e", "public", "field")
+
+    -- Private: s·G trace (interleaved)
+    for i = 1, 256 do
+        add(private, string.format("bits_s_%03d", i), "private", "field")
+        if i < 256 then
+            add(private, string.format("int_sx_%03d", i), "private", "field")
+            add(private, string.format("int_sy_%03d", i), "private", "field")
+            add(private, string.format("int_sz_%03d", i), "private", "field")
+        end
+    end
+
+    -- Private: e·P trace (interleaved)
+    for i = 1, 256 do
+        add(private, string.format("bits_e_%03d", i), "private", "field")
+        if i < 256 then
+            add(private, string.format("int_ex_%03d", i), "private", "field")
+            add(private, string.format("int_ey_%03d", i), "private", "field")
+            add(private, string.format("int_ez_%03d", i), "private", "field")
+        end
+    end
+
+    add(private, "py", "private", "field")
+    add(private, "ry", "private", "field")
+    add(private, "rz_inv", "private", "field")
+
+    for i = 1, 256 do
+        add(private, string.format("bits_ry_%03d", i), "private", "field")
+    end
 
     local schema = {
         public = public,

--- a/src/lua/crypto_zkcc.lua
+++ b/src/lua/crypto_zkcc.lua
@@ -20,6 +20,11 @@
 
 local native = require'zkcore'
 local M = {}
+local TEMPLATE_DEFAULT = "bip340"
+local TEMPLATE_FIELD_ID = {
+    p256 = 1,
+    bip340 = 10,
+}
 
 -- Weak-keyed table to store artifact schemas
 local artifact_schema = setmetatable({}, { __mode = "k" })
@@ -48,6 +53,19 @@ local function has_string_keys(tbl)
         end
     end
     return false
+end
+
+local function normalize_template(template)
+    if template == nil then
+        return TEMPLATE_DEFAULT
+    end
+    if type(template) ~= "string" then
+        error("template must be a string", 3)
+    end
+    if not TEMPLATE_FIELD_ID[template] then
+        error("unknown template: " .. tostring(template), 3)
+    end
+    return template
 end
 
 -- ===========================================================================
@@ -93,6 +111,8 @@ local function snapshot_schema(state, artifact)
         private = copy_entries(state.private),
         full = copy_entries(state.full),
         order = copy_entries(state.order),
+        template = state.template,
+        field_id = state.field_id,
         version = state.version,
         author = state.author,
         source = state.source,
@@ -389,6 +409,8 @@ local function new_state()
     return {
         inputs = 0,
         decl_order = 0,
+        template = TEMPLATE_DEFAULT,
+        field_id = TEMPLATE_FIELD_ID[TEMPLATE_DEFAULT],
         public = {},
         private = {},
         full = {},
@@ -584,10 +606,21 @@ function NamedLogic:info(artifact)
     }
 end
 
-local function new_named_logic()
+local function new_named_logic(template)
+    local normalized = normalize_template(template)
     return setmetatable({
-        _logic = M.logic(),
-        _state = new_state(),
+        _logic = M.logic(normalized),
+        _state = {
+            inputs = 0,
+            decl_order = 0,
+            template = normalized,
+            field_id = TEMPLATE_FIELD_ID[normalized],
+            public = {},
+            private = {},
+            full = {},
+            order = {},
+            by_name = {},
+        },
         _bound = false,
     }, NamedLogic)
 end
@@ -597,6 +630,79 @@ end
 -- ===========================================================================
 
 M.named_logic = new_named_logic
+
+local function repeat_named_entries(entries, prefix, count, kind, input_type)
+    for i = 1, count do
+        entries[#entries + 1] = {
+            kind = kind,
+            name = string.format("%s_%03d", prefix, i),
+            type = input_type,
+            desc = prefix,
+            index = #entries + 1,
+            decl_order = #entries + 1,
+        }
+    end
+end
+
+local function append_named_entry(entries, name, kind, input_type)
+    entries[#entries + 1] = {
+        kind = kind,
+        name = name,
+        type = input_type,
+        desc = name,
+        index = #entries + 1,
+        decl_order = #entries + 1,
+    }
+end
+
+local function make_bip340_schema(artifact)
+    local public = {}
+    local private = {}
+    local full = {}
+
+    append_named_entry(public, "rx", "public", "field")
+    append_named_entry(public, "px", "public", "field")
+    append_named_entry(public, "e", "public", "field")
+
+    repeat_named_entries(private, "bits_s", 256, "private", "field")
+    repeat_named_entries(private, "int_sx", 255, "private", "field")
+    repeat_named_entries(private, "int_sy", 255, "private", "field")
+    repeat_named_entries(private, "int_sz", 255, "private", "field")
+    repeat_named_entries(private, "bits_e", 256, "private", "field")
+    repeat_named_entries(private, "int_ex", 255, "private", "field")
+    repeat_named_entries(private, "int_ey", 255, "private", "field")
+    repeat_named_entries(private, "int_ez", 255, "private", "field")
+    append_named_entry(private, "py", "private", "field")
+    append_named_entry(private, "ry", "private", "field")
+    append_named_entry(private, "rz_inv", "private", "field")
+    repeat_named_entries(private, "bits_ry", 256, "private", "field")
+
+    local schema = {
+        public = public,
+        private = private,
+        full = full,
+        order = {},
+        template = "bip340",
+        field_id = TEMPLATE_FIELD_ID.bip340,
+        counts = {
+            public = #public,
+            private = #private,
+            full = 0,
+        },
+    }
+
+    for _, entry in ipairs(public) do
+        schema.order[#schema.order + 1] = entry
+    end
+    for _, entry in ipairs(private) do
+        schema.order[#schema.order + 1] = entry
+    end
+
+    rebuild_indexes(schema)
+    schema.total = (artifact and artifact.ninput and (artifact.ninput - 1)) or #schema.order
+    schema.npub = (artifact and artifact.npub_input and (artifact.npub_input - 1)) or #public
+    return schema
+end
 
 -- Unwrap named artifacts and resolve named inputs in options tables
 local function unwrap_opts(opts, public_only)
@@ -657,21 +763,36 @@ end
 if M.build_witness_inputs then
     local native_build = M.build_witness_inputs
     M.build_witness_inputs = function(opts)
-        return native_build(unwrap_opts(opts))
+        local resolved = unwrap_opts(opts)
+        local schema = artifact_schema[resolved.circuit] or resolved.circuit.schema
+        if schema and schema.template == "bip340" then
+            return native.build_witness_inputs_bip340(resolved)
+        end
+        return native_build(resolved)
     end
 end
 
 if M.prove_circuit then
     local native_prove = M.prove_circuit
     M.prove_circuit = function(opts)
-        return native_prove(unwrap_opts(opts))
+        local resolved = unwrap_opts(opts)
+        local schema = artifact_schema[resolved.circuit] or resolved.circuit.schema
+        if schema and schema.template == "bip340" then
+            return native.prove_circuit_bip340(resolved)
+        end
+        return native_prove(resolved)
     end
 end
 
 if M.verify_circuit then
     local native_verify = M.verify_circuit
     M.verify_circuit = function(opts)
-        return native_verify(unwrap_opts(opts, true))
+        local resolved = unwrap_opts(opts, true)
+        local schema = artifact_schema[resolved.circuit] or resolved.circuit.schema
+        if schema and schema.template == "bip340" then
+            return native.verify_circuit_bip340(resolved)
+        end
+        return native_verify(resolved)
     end
 end
 
@@ -733,9 +854,19 @@ end
 
 -- Wrap Logic instances to add convenience methods
 if M.create_logic then
-    local native_create = M.create_logic
-    M.create_logic = function()
-        local logic_native = native_create()
+    local native_create_p256 = M.create_logic_p256 or M.create_logic
+    local native_create_bip340 = M.create_logic_bip340
+    M.create_logic = function(template)
+        local normalized = normalize_template(template)
+        local logic_native
+        if normalized == "bip340" then
+            if not native_create_bip340 then
+                error("bip340 logic is not available", 2)
+            end
+            logic_native = native_create_bip340()
+        else
+            logic_native = native_create_p256()
+        end
         
         -- Create a Lua table wrapper that delegates to the native usertype
         local logic_wrapper = {}
@@ -765,6 +896,33 @@ if M.create_logic then
         setmetatable(logic_wrapper, mt)
         
         return logic_wrapper
+    end
+end
+
+M.logic = M.create_logic
+
+function M.bip340_circuit()
+    local artifact = native.bip340_circuit_native()
+    return wrap_artifact(artifact, make_bip340_schema(artifact))
+end
+
+if M.load_circuit_artifact_bip340 then
+    local native_load_bip340 = M.load_circuit_artifact_bip340
+    M.load_circuit_artifact_bip340 = function(octet)
+        local artifact = native_load_bip340(octet)
+        return wrap_artifact(artifact, make_bip340_schema(artifact))
+    end
+end
+
+if M.witness and native.bip340_compute_inputs_native then
+    M.witness.bip340_compute_inputs = function(circuit, sig, pk, msg)
+        local raw_circuit = is_named_artifact(circuit) and circuit:raw() or circuit
+        local inputs, public_inputs =
+            native.bip340_compute_inputs_native(raw_circuit, sig, pk, msg)
+        return {
+            inputs = inputs,
+            public_inputs = public_inputs,
+        }
     end
 end
 

--- a/test/lua/zkcc.bats
+++ b/test/lua/zkcc.bats
@@ -6,4 +6,5 @@ load ../bats_setup
     Z zkcc_sha256.lua
     Z zkcc_arith_progression.lua
     Z zkcc_flatsha256_proof.lua
+    Z zkcc_bip340.lua
 }

--- a/test/lua/zkcc_arith_progression.lua
+++ b/test/lua/zkcc_arith_progression.lua
@@ -11,7 +11,7 @@ local zkcc = require'crypto_zkcc'
 print('=== Arithmetic progression: closed-form sum ===')
 
 -- Declare inputs (named, typed, described)
-local L = zkcc.named_logic()
+local L = zkcc.named_logic("p256")
 local count = L:public_input{ name = 'count', desc = 'number of terms', type = 'field' }
 local step  = L:private_input{ name = 'step', desc = 'common difference', type = 'field' }
 local sum   = L:public_input{ name = 'sum', desc = 'claimed total', type = 'field' }

--- a/test/lua/zkcc_bip340.lua
+++ b/test/lua/zkcc_bip340.lua
@@ -1,0 +1,218 @@
+-- End-to-end BIP340 circuit coverage using the native secp256k1 circuit path.
+--
+-- Accept/reject classification uses SECP.bip340_verify (Option A) instead of
+-- pcall around zk witness functions.  lerror in the zk-circuit-lang bindings
+-- corrupts the Lua state when called inside pcall: the same corruption affects
+-- ALL zk witness functions (sha256_compute_message, bip340_compute_witness,
+-- etc.) even with valid inputs.  In contrast, pcalls around the main secp
+-- module (bip340_lift_x etc.) work correctly, so the SECP-based verifier
+-- provides reliable accept/reject classification without touching the
+-- zk binding error path.
+
+local zkcc = require'crypto_zkcc'
+local S = require("secp")
+
+local VECTOR_CSV = [[
+index,secret key,public key,aux_rand,message,signature,verification result,comment
+0,0000000000000000000000000000000000000000000000000000000000000003,F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9,0000000000000000000000000000000000000000000000000000000000000000,0000000000000000000000000000000000000000000000000000000000000000,E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA821525F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0,TRUE,
+1,B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF,DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659,0000000000000000000000000000000000000000000000000000000000000001,243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89,6896BD60EEAE296DB48A229FF71DFE071BDE413E6D43F917DC8DCF8C78DE33418906D11AC976ABCCB20B091292BFF4EA897EFCB639EA871CFA95F6DE339E4B0A,TRUE,
+2,C90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B14E5C9,DD308AFEC5777E13121FA72B9CC1B7CC0139715309B086C960E18FD969774EB8,C87AA53824B4D7AE2EB035A2B5BBBCCC080E76CDC6D1692C4B0B62D798E6D906,7E2D58D8B3BCDF1ABADEC7829054F90DDA9805AAB56C77333024B9D0A508B75C,5831AAEED7B44BB74E5EAB94BA9D4294C49BCF2A60728D8B4C200F50DD313C1BAB745879A5AD954A72C45A91C3A51D3C7ADEA98D82F8481E0E1E03674A6F3FB7,TRUE,
+3,0B432B2677937381AEF05BB02A66ECD012773062CF3FA2549E44F58ED2401710,25D1DFF95105F5253C4022F628A996AD3A0D95FBF21D468A1B33F8C160D8F517,FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,7EB0509757E246F19449885651611CB965ECC1A187DD51B64FDA1EDC9637D5EC97582B9CB13DB3933705B32BA982AF5AF25FD78881EBB32771FC5922EFC66EA3,TRUE,test fails if msg is reduced modulo p or n
+4,,D69C3509BB99E412E68B0FE8544E72837DFA30746D8BE2AA65975F29D22DC7B9,,4DF3C3F68FCC83B27E9D42C90431A72499F17875C81A599B566C9889B9696703,00000000000000000000003B78CE563F89A0ED9414F5AA28AD0D96D6795F9C6376AFB1548AF603B3EB45C9F8207DEE1060CB71C04E80F593060B07D28308D7F4,TRUE,
+5,,EEFDEA4CDB677750A420FEE807EACF21EB9898AE79B9768766E4FAA04A2D4A34,,243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89,6CFF5C3BA86C69EA4B7376F31A9BCB4F74C1976089B2D9963DA2E5543E17776969E89B4C5564D00349106B8497785DD7D1D713A8AE82B32FA79D5F7FC407D39B,FALSE,public key not on the curve
+6,,DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659,,243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89,FFF97BD5755EEEA420453A14355235D382F6472F8568A18B2F057A14602975563CC27944640AC607CD107AE10923D9EF7A73C643E166BE5EBEAFA34B1AC553E2,FALSE,has_even_y(R) is false
+7,,DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659,,243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89,1FA62E331EDBC21C394792D2AB1100A7B432B013DF3F6FF4F99FCB33E0E1515F28890B3EDB6E7189B630448B515CE4F8622A954CFE545735AAEA5134FCCDB2BD,FALSE,negated message
+8,,DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659,,243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89,6CFF5C3BA86C69EA4B7376F31A9BCB4F74C1976089B2D9963DA2E5543E177769961764B3AA9B2FFCB6EF947B6887A226E8D7C93E00C5ED0C1834FF0D0C2E6DA6,FALSE,negated s value
+9,,DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659,,243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89,0000000000000000000000000000000000000000000000000000000000000000123DDA8328AF9C23A94C1FEECFD123BA4FB73476F0D594DCB65C6425BD186051,FALSE,sG - eP is infinite. Test fails in single verification if has_even_y(inf) is defined as true and x(inf) as 0
+10,,DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659,,243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89,00000000000000000000000000000000000000000000000000000000000000017615FBAF5AE28864013C099742DEADB4DBA87F11AC6754F93780D5A1837CF197,FALSE,sG - eP is infinite. Test fails in single verification if has_even_y(inf) is defined as true and x(inf) as 1
+11,,DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659,,243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89,4A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D69E89B4C5564D00349106B8497785DD7D1D713A8AE82B32FA79D5F7FC407D39B,FALSE,sig[0:32] is not an X coordinate on the curve
+12,,DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659,,243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89,FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F69E89B4C5564D00349106B8497785DD7D1D713A8AE82B32FA79D5F7FC407D39B,FALSE,sig[0:32] is equal to field size
+13,,DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659,,243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89,6CFF5C3BA86C69EA4B7376F31A9BCB4F74C1976089B2D9963DA2E5543E177769FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141,FALSE,sig[32:64] is equal to curve order
+14,,FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30,,243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89,6CFF5C3BA86C69EA4B7376F31A9BCB4F74C1976089B2D9963DA2E5543E17776969E89B4C5564D00349106B8497785DD7D1D713A8AE82B32FA79D5F7FC407D39B,FALSE,public key is not a valid X coordinate because it exceeds the field size
+15,0340034003400340034003400340034003400340034003400340034003400340,778CAA53B4393AC467774D09497A87224BF9FAB6F6E68B23086497324D6FD117,0000000000000000000000000000000000000000000000000000000000000000,,71535DB165ECD9FBBC046E5FFAEA61186BB6AD436732FCCC25291A55895464CF6069CE26BF03466228F19A3A62DB8A649F2D560FAC652827D1AF0574E427AB63,TRUE,message of size 0 (added 2022-12)
+16,0340034003400340034003400340034003400340034003400340034003400340,778CAA53B4393AC467774D09497A87224BF9FAB6F6E68B23086497324D6FD117,0000000000000000000000000000000000000000000000000000000000000000,11,08A20A0AFEF64124649232E0693C583AB1B9934AE63B4C3511F3AE1134C6A303EA3173BFEA6683BD101FA5AA5DBC1996FE7CACFC5A577D33EC14564CEC2BACBF,TRUE,message of size 1 (added 2022-12)
+17,0340034003400340034003400340034003400340034003400340034003400340,778CAA53B4393AC467774D09497A87224BF9FAB6F6E68B23086497324D6FD117,0000000000000000000000000000000000000000000000000000000000000000,0102030405060708090A0B0C0D0E0F1011,5130F39A4059B43BC7CAC09A19ECE52B5D8699D1A71E3C52DA9AFDB6B50AC370C4A482B77BF960F8681540E25B6771ECE1E5A37FD80E5A51897C5566A97EA5A5,TRUE,message of size 17 (added 2022-12)
+18,0340034003400340034003400340034003400340034003400340034003400340,778CAA53B4393AC467774D09497A87224BF9FAB6F6E68B23086497324D6FD117,0000000000000000000000000000000000000000000000000000000000000000,99999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,403B12B0D8555A344175EA7EC746566303321E5DBFA8BE6F091635163ECA79A8585ED3E3170807E7C03B720FC54C7B23897FCBA0E9D0B4A06894CFD249F22367,TRUE,message of size 100 (added 2022-12)
+]]
+
+local function split_csv_line(line)
+    local fields = {}
+    for field in (line .. ","):gmatch("(.-),") do
+        fields[#fields + 1] = field
+    end
+    return fields
+end
+
+local function load_vectors(path)
+    local rows = {}
+    local first = true
+    for line in VECTOR_CSV:gmatch("[^\r\n]+") do
+        if first then
+            first = false
+        elseif #line > 0 then
+            local fields = split_csv_line(line)
+            rows[#rows + 1] = {
+                index = tonumber(fields[1]),
+                secret_key = fields[2],
+                public_key = fields[3],
+                aux_rand = fields[4],
+                message = fields[5],
+                signature = fields[6],
+                expect_valid = fields[7] == "TRUE",
+                comment = fields[8] or "",
+            }
+        end
+    end
+    return rows
+end
+
+local function octet_from_hex(hex)
+    if hex == nil or hex == "" then
+        -- OCTET.new(0) creates an octet containing "0" (len=1), not empty.
+        -- Use OCTET.empty() for truly zero-length octets.
+        return OCTET.empty()
+    end
+    return OCTET.from_hex(hex)
+end
+
+local function octet_flip_last_nibble(octet)
+    local hex = octet:hex()
+    local prefix = hex:sub(1, #hex - 1)
+    local last = tonumber(hex:sub(#hex, #hex), 16)
+    return OCTET.from_hex(prefix .. string.format("%x", (last ~ 1) & 0xf))
+end
+
+-- ===========================================================================
+-- BIP-340 Schnorr verification using the existing SECP module.
+--
+-- This matches the verification logic in src/lua/crypto_schnorr_signature.lua
+-- but is inlined here so the test does not depend on Zencode scenario modules.
+-- ===========================================================================
+
+local G = S.generator()
+
+local function bip340_verify(sig_oct, pk_oct, msg_oct)
+    if #sig_oct ~= 64 or #pk_oct ~= 32 then
+        return false
+    end
+    local r_hex = sig_oct:hex():sub(1, 64)
+    local s_hex = sig_oct:hex():sub(65, 128)
+    local r_oct = OCTET.from_hex(r_hex)
+    local s_oct = OCTET.from_hex(s_hex)
+
+    -- r < p: r must be a valid x-coordinate on the curve
+    local ok_r, Rp = pcall(function() return S.bip340_lift_x(r_oct) end)
+    if not ok_r or not Rp then return false end
+
+    -- s < n (s = 0 is valid, so check is inverted)
+    if not S.bip340_seckey_valid(s_oct) then
+        if s_oct:hex() ~= "0000000000000000000000000000000000000000000000000000000000000000" then
+            return false
+        end
+    end
+
+    -- Lift public key
+    local ok_pk, P = pcall(function() return S.bip340_lift_x(pk_oct) end)
+    if not ok_pk or not P then return false end
+
+    -- e = tagged_hash("BIP0340/challenge", r || pk || msg) mod n
+    local e_hash = S.bip340_tagged_hash("BIP0340/challenge", r_oct .. pk_oct .. msg_oct)
+    local e = S.bip340_challenge_reduce(e_hash)
+
+    -- R = s*G - e*P
+    local sG = G * s_oct
+    local eP = P * e
+    local R = sG - eP
+
+    if R:isinf() then return false end
+    -- R must have even y (compressed prefix 02)
+    if R:compressed():hex():sub(1,2) ~= "02" then return false end
+    -- x(R) must equal r
+    if R:xonly():hex() ~= r_oct:hex() then return false end
+
+    return true
+end
+
+print("=== BIP340 circuit proof flow ===")
+
+local circuit = zkcc.bip340_circuit()
+assert(circuit.schema.template == "bip340", "expected bip340 circuit template")
+assert(circuit.schema.field_id == 10, "expected secp256k1 field id")
+assert(circuit.schema.total == 2304, "unexpected BIP340 input count")
+assert(circuit.schema.npub == 3, "unexpected BIP340 public input count")
+
+local circuit_bytes = circuit:octet()
+local loaded = zkcc.load_circuit_artifact_bip340(circuit_bytes)
+print(string.format("Circuit size: %d bytes, inputs=%d, public=%d",
+    #circuit_bytes, circuit.ninput - 1, circuit.npub_input - 1))
+
+local vectors = load_vectors()
+assert(#vectors > 0, "missing BIP340 test vectors")
+
+local valid_count = 0
+local invalid_count = 0
+local tamper_checked = false
+
+for _, vec in ipairs(vectors) do
+    local sig = octet_from_hex(vec.signature)
+    local pk = octet_from_hex(vec.public_key)
+    local msg = octet_from_hex(vec.message)
+
+    local is_valid = bip340_verify(sig, pk, msg)
+
+    if vec.expect_valid then
+        assert(is_valid, string.format("vector %d should verify: %s", vec.index, vec.comment))
+        valid_count = valid_count + 1
+
+        local built = zkcc.witness.bip340_compute_inputs(loaded, sig, pk, msg)
+        local witness_inputs = built.inputs
+        local verifier_inputs = built.public_inputs
+        local seed = OCTET.from_hex(string.format("%064x", vec.index + 1))
+        local proof = zkcc.prove_circuit{
+            circuit = loaded,
+            inputs = witness_inputs,
+            seed = seed,
+        }
+        assert(proof and #proof > 0, string.format("vector %d proof generation failed", vec.index))
+
+        local verify_ok = zkcc.verify_circuit{
+            circuit = loaded,
+            proof = proof,
+            public_inputs = verifier_inputs,
+            seed = seed,
+        }
+        assert(verify_ok, string.format("vector %d verification failed", vec.index))
+
+        if not tamper_checked then
+            -- Tamper with public input #1 (rx): flip its last nibble.
+            -- Call bip340_compute directly (no pcall) to get the
+            -- field-element OCTETs for rx, px, e that the circuit expects.
+            local witness = zkcc.witness.bip340_compute(sig, pk, msg)
+            local bad_public_inputs = zkcc.build_witness_inputs{
+                circuit = loaded,
+                public_inputs = {
+                    rx = octet_flip_last_nibble(witness.rx),
+                    px = witness.px,
+                    e = witness.e,
+                },
+            }
+            local tampered_ok = zkcc.verify_circuit{
+                circuit = loaded,
+                proof = proof,
+                public_inputs = bad_public_inputs,
+                seed = seed,
+            }
+            assert(not tampered_ok, "tampered public inputs should fail verification")
+            tamper_checked = true
+        end
+    else
+        assert(not is_valid, string.format("vector %d should be rejected: %s", vec.index, vec.comment))
+        invalid_count = invalid_count + 1
+    end
+end
+
+assert(valid_count > 0, "expected valid BIP340 vectors")
+assert(invalid_count > 0, "expected invalid BIP340 vectors")
+assert(tamper_checked, "expected at least one tamper verification check")
+
+print(string.format("✓ BIP340 vectors checked: valid=%d invalid=%d", valid_count, invalid_count))

--- a/test/lua/zkcc_bip340.lua
+++ b/test/lua/zkcc_bip340.lua
@@ -146,6 +146,81 @@ local loaded = zkcc.load_circuit_artifact_bip340(circuit_bytes)
 print(string.format("Circuit size: %d bytes, inputs=%d, public=%d",
     #circuit_bytes, circuit.ninput - 1, circuit.npub_input - 1))
 
+-- ===========================================================================
+-- Regression: prove vector 0 via build_witness_inputs with named keys.
+-- This exercises the interleaved schema mapping path (fix for named-input
+-- ordering: schema must match Bip340Verify::Witness::input() in
+-- lfzk_bindings.cc).
+-- ===========================================================================
+print("=== Named-input regression test (vector 0) ===")
+
+local sig0 = OCTET.from_hex("E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA821525F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0")
+local pk0  = OCTET.from_hex("F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9")
+local msg0 = OCTET.from_hex("0000000000000000000000000000000000000000000000000000000000000000")
+local seed0 = OCTET.from_hex("0000000000000000000000000000000000000000000000000000000000000001")
+
+-- Obtain field-element OCTETs from bip340_compute (direct call, no pcall)
+local w = zkcc.witness.bip340_compute(sig0, pk0, msg0)
+
+-- Build a named-inputs table matching the interleaved schema order
+local named = {
+    rx = w.rx,
+    px = w.px,
+    e  = w.e,
+}
+for i = 1, 256 do
+    named[string.format("bits_s_%03d", i)] = w.bits_s[i]
+    if i < 256 then
+        named[string.format("int_sx_%03d", i)] = w.int_sx[i]
+        named[string.format("int_sy_%03d", i)] = w.int_sy[i]
+        named[string.format("int_sz_%03d", i)] = w.int_sz[i]
+    end
+end
+for i = 1, 256 do
+    named[string.format("bits_e_%03d", i)] = w.bits_e[i]
+    if i < 256 then
+        named[string.format("int_ex_%03d", i)] = w.int_ex[i]
+        named[string.format("int_ey_%03d", i)] = w.int_ey[i]
+        named[string.format("int_ez_%03d", i)] = w.int_ez[i]
+    end
+end
+named.py = w.py
+named.ry = w.ry
+named.rz_inv = w.rz_inv
+for i = 1, 256 do
+    named[string.format("bits_ry_%03d", i)] = w.bits_ry[i]
+end
+
+-- Build witness inputs from named keys
+local named_inputs = zkcc.build_witness_inputs{
+    circuit = loaded,
+    inputs = named,
+}
+local named_public = zkcc.build_witness_inputs{
+    circuit = loaded,
+    public_inputs = { rx = w.rx, px = w.px, e = w.e },
+}
+
+-- Prove and verify through the named path
+local named_proof = zkcc.prove_circuit{
+    circuit = loaded,
+    inputs = named_inputs,
+    seed = seed0,
+}
+assert(named_proof and #named_proof > 0, "named-input proof generation failed")
+
+local named_ok = zkcc.verify_circuit{
+    circuit = loaded,
+    proof = named_proof,
+    public_inputs = named_public,
+    seed = seed0,
+}
+assert(named_ok, "named-input verification failed")
+print("  named-input prove+verify: ok")
+
+-- ===========================================================================
+-- Main BIP340 vector sweep
+-- ===========================================================================
 local vectors = load_vectors()
 assert(#vectors > 0, "missing BIP340 test vectors")
 

--- a/test/lua/zkcc_flatsha256_proof.lua
+++ b/test/lua/zkcc_flatsha256_proof.lua
@@ -3,7 +3,7 @@
 
 local zkcc = require'crypto_zkcc'
 
-local L = zkcc.logic()
+local L = zkcc.logic("p256")
 local BA = L:create_bit_adder32()
 
 local MAX_BLOCKS = 1

--- a/test/lua/zkcc_horner_expr.lua
+++ b/test/lua/zkcc_horner_expr.lua
@@ -22,7 +22,7 @@ local zkcc = require'crypto_zkcc'
 
 print('=== Expr Circuit: Horner cubic ===')
 
-local L = zkcc.named_logic()
+local L = zkcc.named_logic("p256")
 
 -- Inputs: public z, private a,b,c,d,x (all field elements)
 local z = L:public_input{ name = 'z', desc = 'polynomial result', type = 'field' }

--- a/test/lua/zkcc_small.lua
+++ b/test/lua/zkcc_small.lua
@@ -11,7 +11,7 @@ print('=== Full Flow Proof Test (positional inputs) ===')
 -- named_logic + public/private_input for descriptive schemas.
 
 -- Build a simple circuit: public z, private x,y, assert z = x + y
-local L = zkcc.logic()
+local L = zkcc.logic("p256")
 local z = L:eltw_input() -- public input
 L:private_inputs()       -- boundary between public/private
 local x = L:eltw_input() -- private input 0 (index 2)


### PR DESCRIPTION
## Summary

Adds BIP340/secp256k1 support to the zkcc module alongside the existing P-256 field.

### Changes

- **Field/template selection**: `zkcc.logic("bip340")` (new default) and `zkcc.logic("p256")` dispatch to separate native logic types (`LuaLogic` / `LuaLogicBip340`)
- **Template-aware dispatch**: `build_witness_inputs`, `prove_circuit`, and `verify_circuit` automatically select the correct native backend (FFT for P-256, CRT-256 for BIP340) based on artifact metadata
- **Native BIP340 witness**: `zkcc.witness.bip340_compute` returns witness field elements as OCTETs via Longfellow's `Bip340Witness`
- **Native BIP340 circuit**: `zkcc.bip340_circuit()` returns the production BIP340 verify circuit with named schema (`rx`, `px`, `e`)
- **Bitcoin-vector tests**: All 19 BIP340 test vectors covered (9 valid prove+verify, 10 invalid correctly rejected) using SECP-based verification for accept/reject
- **Fix**: `nat_to_octet` used `o_push` with a stack-allocated buffer, causing GC to `free()` a stack pointer at teardown. Switched to `push_buffer_to_octet`.

### Test

```
✓ BIP340 vectors checked: valid=9 invalid=10
```

All existing P-256 zkcc tests pass with explicit `"p256"` opt-in.