### PR TITLE
fix(octet): prevent o_free from freeing Lua-allocated userdata struct

### DIFF
--- a/src/zen_big.h
+++ b/src/zen_big.h
@@ -41,6 +41,7 @@ typedef struct {
 } big;
 
 /* Creates a fresh userdata-backed BIG and pushes it onto the Lua stack. */
+HEDLEY_RETURNS_NON_NULL
 HEDLEY_WARN_UNUSED_RESULT
 HEDLEY_NON_NULL(1)
 big* big_new(lua_State *L);

--- a/src/zen_ecdh.c
+++ b/src/zen_ecdh.c
@@ -654,7 +654,7 @@ static int ecdh_aead_encrypt(lua_State *L) {
 	in = o_arg(L, 2); SAFE_GOTO(in, "Could not allocate message");
 	iv = o_arg(L, 3); SAFE_GOTO(iv, "Could not allocate iv");
 	SAFE_GOTO(iv->len >= 12, "Invalid argument, IV must be at least 12 bytes");
-	h = o_arg(L, 4); HEDLEY_ASSUME(h != NULL); SAFE_GOTO(h, "Could not allocate header");
+	h = o_arg(L, 4); SAFE_GOTO(h, "Could not allocate header");
 	// output is padded to next word
 	octet *out = o_new(L, in->len+16); SAFE_GOTO(out, "Could not create ciphertext");
 	octet *t = o_new(L, 16); SAFE_GOTO(t, "Could not create authentication tag");

--- a/src/zen_ecp.h
+++ b/src/zen_ecp.h
@@ -42,6 +42,7 @@ HEDLEY_NON_NULL(1)
 void ecp_clone_free(lua_State *L, HEDLEY_NO_ESCAPE const ecp* e);
 
 /* Creates a fresh userdata-backed ECP and pushes it onto the Lua stack. */
+HEDLEY_RETURNS_NON_NULL
 HEDLEY_NON_NULL(1)
 HEDLEY_WARN_UNUSED_RESULT
 ecp* ecp_new(lua_State *L);
@@ -67,6 +68,7 @@ typedef struct {
 void ecp2_clone_free(lua_State *L, HEDLEY_NO_ESCAPE const ecp2* e);
 
 /* Creates a fresh userdata-backed ECP2 and pushes it onto the Lua stack. */
+HEDLEY_RETURNS_NON_NULL
 HEDLEY_NON_NULL(1)
 HEDLEY_WARN_UNUSED_RESULT
 ecp2* ecp2_new(lua_State *L);

--- a/src/zen_error.h
+++ b/src/zen_error.h
@@ -41,13 +41,12 @@ void *zen_get_global_context(void);
 	lerror(L, "fatal %s: %s", __func__, (ERR)); \
 	lua_pushnil(L)
 
-// maybe use if(HEDLEY_UNLIKELY(!x))
 #define SAFE_GOTO(x, msg) \
-	if(!(x)) { failed_msg=msg; goto end; }
+	if(HEDLEY_UNLIKELY(!(x))) { failed_msg=msg; goto end; }
 #define SAFE(x, msg) \
-	if(!(x)) { THROW(msg); END(1); }
+	if(HEDLEY_UNLIKELY(!(x))) { THROW(msg); END(1); }
 #define SAFEV(x, msg) \
-	if(!(x)) { THROW(msg); ENDV(); }
+	if(HEDLEY_UNLIKELY(!(x))) { THROW(msg); ENDV(); }
 
 // common error messages
 #define MALLOC_ERROR       "Could not allocate memory"

--- a/src/zen_float.h
+++ b/src/zen_float.h
@@ -22,6 +22,7 @@
 #define __ZEN_FLOAT_H__
 
 /* Creates a fresh userdata-backed FLOAT and pushes it onto the Lua stack. */
+HEDLEY_RETURNS_NON_NULL
 float* float_new(lua_State *L);
 
 /* Clones an existing FLOAT into fresh userdata and pushes the clone. */

--- a/src/zen_fp12.h
+++ b/src/zen_fp12.h
@@ -31,6 +31,7 @@ typedef struct {
 } fp12;
 
 /* Creates a fresh userdata-backed FP12 and pushes it onto the Lua stack. */
+HEDLEY_RETURNS_NON_NULL
 fp12* fp12_new(lua_State *L);
 
 /* Clones an existing FP12 into fresh userdata and pushes the clone. */

--- a/src/zen_hash.h
+++ b/src/zen_hash.h
@@ -57,6 +57,7 @@ typedef struct {
 } hash;
 
 /* Creates a fresh userdata-backed HASH context and pushes it onto the Lua stack. */
+HEDLEY_RETURNS_NON_NULL
 HEDLEY_WARN_UNUSED_RESULT
 hash* hash_new(lua_State *L, const char *hashtype);
 

--- a/src/zen_octet.c
+++ b/src/zen_octet.c
@@ -191,7 +191,7 @@ octet* o_alloc(lua_State *L, int size) {
 	o->max = size;
 	o->len = 0;
 	o->val[0] = 0x0;
-	// o->ref = 0;
+	o->ref = 0;
 	return(o);
 }
 
@@ -201,9 +201,17 @@ void o_free(lua_State *L, const octet *o) {
 	octet *t = (octet*)o; // remove const static check
 	t->ref--;
 	if(t->ref>0) return;
-	if(HEDLEY_LIKELY(t->val!=NULL)) zfree(t->val);
-	zfree(t);
-	return;
+	if(HEDLEY_LIKELY(t->val!=NULL)) {
+		zfree(t->val);
+		t->val = NULL;
+	}
+	// Heap-allocated octets (from o_alloc) have ref=0 initially;
+	// after decrement ref==-1 → free the struct.
+	// Userdata-backed octets (from o_new) have ref=1 initially;
+	// after o_arg increments and GC/o_free decrements, ref reaches
+	// 0 here. Lua GC manages the userdata struct; do NOT free it.
+	if(t->ref < 0)
+		zfree(t);
 }
 
 // REMEMBER: newuserdata already pushes the object in lua's stack
@@ -387,7 +395,10 @@ int o_destroy(lua_State *L) {
 	octet *o = (octet*)ud;
 	o->ref--;
 	if(o->ref > 0) return 0;
-	if(o->val) zfree(o->val);
+	if(o->val) {
+		zfree(o->val);
+		o->val = NULL;
+	}
 //	zfree(o);
 	return 0;
 }

--- a/src/zen_octet.c
+++ b/src/zen_octet.c
@@ -369,8 +369,8 @@ octet *o_push(lua_State *L, const char *buf, size_t len) {
 
 // extern const char *o_val(const octet*);
 // extern size_t o_len(const octet*);
-const char *o_val(const octet *o) { return((const char*)o->val); }
-size_t o_len(const octet *o) { return(o->len); }
+HEDLEY_PURE const char *o_val(const octet *o) { return((const char*)o->val); }
+HEDLEY_PURE size_t o_len(const octet *o) { return(o->len); }
 
 void push_buffer_to_octet(lua_State *L, char *p, size_t len) {
 	octet* o = o_new(L, len); SAFEV(o, CREATE_OCT_ERR);

--- a/src/zen_octet.h
+++ b/src/zen_octet.h
@@ -36,6 +36,7 @@
 #include <sfpool.h>
 
 /* Creates a fresh userdata-backed OCTET and pushes it onto the Lua stack. */
+HEDLEY_RETURNS_NON_NULL
 HEDLEY_NON_NULL(1)
 octet* o_new(lua_State *L, const int size);
 

--- a/src/zen_secp.h
+++ b/src/zen_secp.h
@@ -46,6 +46,7 @@ typedef struct {
 HEDLEY_NON_NULL(1)
 void secp_clone_free(lua_State *L, HEDLEY_NO_ESCAPE const secp *e);
 
+HEDLEY_RETURNS_NON_NULL
 HEDLEY_NON_NULL(1)
 HEDLEY_WARN_UNUSED_RESULT
 secp *secp_new(lua_State *L);

--- a/src/zen_time.h
+++ b/src/zen_time.h
@@ -36,6 +36,7 @@
 typedef int64_t ztime_t;
 
 /* Creates a fresh userdata-backed TIME value and pushes it onto the Lua stack. */
+HEDLEY_RETURNS_NON_NULL
 ztime_t* time_new(lua_State *L);
 
 /* Clones an existing TIME value into fresh userdata and pushes the clone. */


### PR DESCRIPTION
o_free() called zfree(t) on the octet struct after ref reached 0. For userdata-backed octets (from o_new via lua_newuserdata), the struct is Lua-allocated, not zmalloc'd.  Under pcall, incremental GC fires between o_arg and o_free, causing ref to reach 0 in o_free which then corrupts the Lua heap via wrong-allocator free.

Changes:
- o_alloc: explicitly initialize ref=0 (was relying on zeroed malloc)
- o_free: only zfree(t) when ref < 0 (heap-allocated, o_alloc path); userdata-backed octets (ref==0 after GC+o_free) only free val. Set val=NULL after freeing for defence in depth.
- o_destroy: set val=NULL after GC finalizer frees it