### PR TITLE
feat(rng): harden VM randomness and existing consumers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,15 @@ node-wasm: ## WebAssembly (WASM) for Javascript in-browser (Emscripten)
 	yarn --cwd bindings/javascript
 	yarn --cwd bindings/javascript build
 
-check: ## Run tests using the current binary executable build
+check: check-rng-no-bypass ## Run tests using the current binary executable build
 	meson setup meson/ build/ -D \
 	"tests=['determinism','vectors','lua','zkcc','zencode','blockchain','bindings','api']"
 	ninja -C meson test
 
+.PHONY: check-rng-no-bypass
+
+check-rng-no-bypass: ## Reject unapproved runtime OS RNG calls
+	./test/rng/no-bypass.sh
 wrap-js: # Generate the ./zenroom exec wrapper on node-wasm builds
 	$(info Generate JS wrapper in ./zenroom)
 	@sed 's@=ROOT=@'"${pwd}"'@' test/zexe_js_wrapper.sh > zenroom

--- a/build/init.mk
+++ b/build/init.mk
@@ -105,7 +105,9 @@ mlkem_cc ?= ${cc}
 #-----------------
 # longfellow-zk settings
 longfellow_cxx ?= ${cxx}
-longfellow_cflags += -I ${pwd}/src -I. -I../zstd -fPIC -DLIBRARY
+# Longfellow's public headers include <longfellow-zk/...>; its in-tree build
+# runs from lib/longfellow-zk, so the parent lib directory is required too.
+longfellow_cflags += -I ${pwd}/src -I. -I.. -I../zstd -fPIC -DLIBRARY
 ARCH ?= $(shell uname -m)
 ifeq ($(shell uname -s),Darwin)
     longfellow_cflags += -Xarch_x86_64 -mpclmul -Xarch_arm64  ""

--- a/build/meson.build
+++ b/build/meson.build
@@ -134,7 +134,7 @@ endif
 
 if suite.contains('api')
 ## BATS tests in test/api
-tests = [ 'hash', 'rng', 'rng_audit', 'sign', 'x509', 'zencode' ]
+tests = [ 'hash', 'rng', 'rng_audit', 'sign', 'sign_rng', 'x509', 'zencode' ]
 foreach test_suite : tests
     test('api_'+test_suite.underscorify(),
 	 bats_bin,

--- a/build/meson.build
+++ b/build/meson.build
@@ -134,7 +134,7 @@ endif
 
 if suite.contains('api')
 ## BATS tests in test/api
-tests = [ 'hash', 'sign', 'x509', 'zencode' ]
+tests = [ 'hash', 'rng', 'rng_audit', 'sign', 'x509', 'zencode' ]
 foreach test_suite : tests
     test('api_'+test_suite.underscorify(),
 	 bats_bin,

--- a/build/wasm.mk
+++ b/build/wasm.mk
@@ -23,7 +23,7 @@ lua_cc := ${cc}
 zenroom_cc := ${cc}
 zstd_cc := ${cc}
 longfellow_cxx := ${cxx}
-longfellow_cflags := -I ${pwd}/src -I. -I../zstd -fPIC -DLIBRARY -msimd128
+longfellow_cflags := -I ${pwd}/src -I. -I.. -I../zstd -fPIC -DLIBRARY -msimd128
 zk-circuit-lang_cxxflags := -I ${pwd}/src -I. -I../zstd -fPIC -DLIBRARY -msimd128 -I ../lua54/src -I../longfellow-zk
 
 system := Javascript

--- a/docs/pages/rng-service.md
+++ b/docs/pages/rng-service.md
@@ -30,6 +30,11 @@ algorithms around byte buffers would alter their rejection sampling or seeded
 stream consumption.  The source and relocation audit allowlists only these
 call sites plus the RNG backend and VM lifecycle implementation.
 
+Legacy PQClean key-generation and encapsulation entry points that cannot accept
+caller-owned randomness fail with a nonzero result.  Zenroom uses their
+derandomized or callback variants after filling coins through the VM service;
+the compatibility entry points never substitute a fixed seed.
+
 ## Entropy and backend selection
 
 For a VM without an explicit seed, `zen_entropy_fill` obtains all 64 seed bytes

--- a/docs/pages/rng-service.md
+++ b/docs/pages/rng-service.md
@@ -15,6 +15,21 @@ Each `zenroom_t` owns its generator; callers must provide synchronization when
 sharing a context across threads.  Forked processes must initialize their own
 context rather than sharing inherited generator state.
 
+Contexts passed to `zen_rng_init` must be zero-initialized.  Initializing an
+already initialized context fails without replacing or leaking its generator;
+call `zen_rng_clear` before reinitializing, or use `zen_rng_reseed` to restart
+the existing stream.
+
+## Compatibility exceptions
+
+Runtime consumers that only need bytes use the checked service.  A narrow set
+of native Milagro calls still receives the opaque generator because its ABI
+requires `csprng *`: `BIG_randomnum`, ECDH key generation and randomized
+signing, and RSA key generation and OAEP encoding.  Reimplementing those
+algorithms around byte buffers would alter their rejection sampling or seeded
+stream consumption.  The source and relocation audit allowlists only these
+call sites plus the RNG backend and VM lifecycle implementation.
+
 ## Entropy and backend selection
 
 For a VM without an explicit seed, `zen_entropy_fill` obtains all 64 seed bytes

--- a/docs/pages/rng-service.md
+++ b/docs/pages/rng-service.md
@@ -1,0 +1,44 @@
+# Zenroom RNG service decision
+
+## Compatibility backend
+
+Zenroom's default VM RNG remains the Milagro `csprng`.  Existing `rngseed`
+inputs are passed to `AMCL_(RAND_seed)` unchanged and `zen_rng_fill` forwards
+each requested byte directly to `RAND_byte`; it does not batch, prefetch, or
+discard bytes.  This preserves the deterministic stream and consumption order
+covered by the compatibility baseline.
+
+The new public boundary is deliberately backend-neutral: callers use
+`zen_rng_fill`, `zen_rng_reseed`, `zen_rng_clear`, and the
+`zen_rng_callback_fill` callback/context adapter rather than Milagro types.
+Each `zenroom_t` owns its generator; callers must provide synchronization when
+sharing a context across threads.  Forked processes must initialize their own
+context rather than sharing inherited generator state.
+
+## Entropy and backend selection
+
+For a VM without an explicit seed, `zen_entropy_fill` obtains all 64 seed bytes
+from the platform `randombytes` adapter.  Entropy failures fail initialization;
+wall-clock bytes are not mixed into the seed.  The adapter is the only intended
+OS-entropy entry point for runtime code.  Seed copies and generator state are
+cleared during reseed failure and teardown.
+
+`ARCH_CORTEX` retains its pre-existing zero-seed startup contract because the
+current Cortex-M `randombytes` shim is a deterministic test stub, not a
+validated entropy source.  Explicit seeds remain supported there.  A future
+board-specific entropy adapter must return checked success/failure before this
+runtime enables nondeterministic Cortex-M initialization.
+
+No stronger default backend is selected in this change.  A replacement would
+change seeded streams and must therefore be introduced as a separately named,
+explicitly selected algorithm/version with published KATs on every supported
+target.  The current tree has no such portable, maintained implementation
+available without adding a new dependency, so retaining Milagro compatibility
+mode is the deliberate engineering and security decision.
+
+## API failure semantics
+
+`zen_rng_fill(context, NULL, 0)` and `zen_entropy_fill(NULL, 0)` succeed.
+Nonzero requests require a non-NULL buffer and initialized context; invalid
+arguments and entropy failures return `-1`.  Reseeding rejects empty or
+unrepresentable seed lengths and never modifies caller-owned seed material.

--- a/lib/longfellow-zk/circuits/mdoc/mdoc_rng_adapter.h
+++ b/lib/longfellow-zk/circuits/mdoc/mdoc_rng_adapter.h
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PRIVACY_PROOFS_ZK_LIB_CIRCUITS_MDOC_MDOC_RNG_ADAPTER_H_
+#define PRIVACY_PROOFS_ZK_LIB_CIRCUITS_MDOC_MDOC_RNG_ADAPTER_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "longfellow-zk/circuits/mdoc/mdoc_zk.h"
+#include "longfellow-zk/random/random.h"
+
+namespace proofs {
+
+// Internal boundary adapter. It is header-visible so its fixture-free native
+// test can cover callback lifetime and failure closure independently of mdoc.
+class CallbackRandomEngine final : public RandomEngine {
+ public:
+  CallbackRandomEngine(MdocRandomCallback callback, void* context)
+      : callback_(callback), context_(context) {}
+
+  void bytes(uint8_t* out, size_t length) override {
+    if (callback_ == nullptr || callback_(context_, out, length) != 0) {
+      failed_ = true;
+      std::memset(out, 0, length);
+    }
+  }
+
+  bool failed() const { return failed_; }
+
+ private:
+  MdocRandomCallback callback_;
+  void* context_;
+  bool failed_ = false;
+};
+
+}  // namespace proofs
+
+#endif  // PRIVACY_PROOFS_ZK_LIB_CIRCUITS_MDOC_MDOC_RNG_ADAPTER_H_

--- a/lib/longfellow-zk/circuits/mdoc/mdoc_zk.cc
+++ b/lib/longfellow-zk/circuits/mdoc/mdoc_zk.cc
@@ -31,6 +31,7 @@
 #include "circuits/mac/mac_reference.h"
 #include "circuits/mac/mac_witness.h"
 #include "circuits/mdoc/mdoc_decompress.h"
+#include "circuits/mdoc/mdoc_rng_adapter.h"
 #include "circuits/mdoc/mdoc_witness.h"
 #include "ec/p256.h"
 #include "gf2k/gf2_128.h"
@@ -214,7 +215,7 @@ MdocProverErrorCode fill_witness(
     const uint8_t* mdoc, size_t mdoc_len, const Elt& pkX, const Elt& pkY,
     const uint8_t* tr, size_t tr_len, const RequestedAttribute* attrs,
     size_t attrs_len, const uint8_t* now, ProverState& state,
-    SecureRandomEngine& rng, const f_128& Fs, size_t version) {
+    RandomEngine& rng, const f_128& Fs, size_t version) {
   using MdocHW = MdocHashWitness<P256, f_128>;
   using MdocSW = MdocSignatureWitness<P256, Fp256Scalar>;
 
@@ -395,14 +396,15 @@ using MdocSWw = MdocSignatureWitness<P256, Fp256Scalar>;
 // This implementation uses 2 separate circuits over 2 fields to verify
 // the signature and the hash components of the mdoc.
 // It is the caller's job to free the memory pointed to by prf.
-MdocProverErrorCode run_mdoc_prover(
+MdocProverErrorCode run_mdoc_prover_with_rng(
     const uint8_t* bcp, size_t bcsz, /* circuit data */
     const uint8_t* mdoc, size_t mdoc_len, const char* pkx,
     const char* pky,                          /* string rep of public key */
     const uint8_t* transcript, size_t tr_len, /* session transcript */
     const RequestedAttribute* attrs, size_t attrs_len,
     const char* now, /* time formatted as "2023-11-02T09:00:00Z" */
-    uint8_t** prf, size_t* proof_len, const ZkSpecStruct* zk_spec) {
+    uint8_t** prf, size_t* proof_len, const ZkSpecStruct* zk_spec,
+    MdocRandomCallback random_callback, void* random_context) {
   if (bcp == nullptr || mdoc == nullptr || pkx == nullptr || pky == nullptr ||
       transcript == nullptr || attrs == nullptr || now == nullptr ||
       prf == nullptr || proof_len == nullptr || zk_spec == nullptr) {
@@ -461,7 +463,10 @@ MdocProverErrorCode run_mdoc_prover(
   DenseFiller<Fp256Base> sig_filler(W_sig);
   DenseFiller<f_128> hash_filler(W_hash);
 
-  SecureRandomEngine rng;
+  CallbackRandomEngine callback_rng(random_callback, random_context);
+  SecureRandomEngine secure_rng;
+  RandomEngine& rng = random_callback == nullptr
+      ? static_cast<RandomEngine&>(secure_rng) : static_cast<RandomEngine&>(callback_rng);
   ProverState state;
   MdocProverErrorCode ok = fill_witness(
       sig_filler, hash_filler, mdoc, mdoc_len, pkX, pkY, transcript, tr_len,
@@ -470,6 +475,7 @@ MdocProverErrorCode run_mdoc_prover(
     log(ERROR, "fill_witness failed");
     return ok;
   }
+  if (callback_rng.failed()) return MDOC_PROVER_GENERAL_FAILURE;
 
   // ========= Run prover ==============
   // Use the transcript from the session to select the random oracle.
@@ -490,6 +496,7 @@ MdocProverErrorCode run_mdoc_prover(
 
   hash_p.commit(h_zk, W_hash, tp, rng);
   sig_p.commit(sig_zk, W_sig, tp, rng);
+  if (callback_rng.failed()) return MDOC_PROVER_GENERAL_FAILURE;
 
   log(INFO,
       "commit created. h[nl:%zu, ni:%zu], s[nl:%zu, ni:%zu] hc[b:%zu r:%zu] "
@@ -515,6 +522,7 @@ MdocProverErrorCode run_mdoc_prover(
   if (!sig_p.prove(sig_zk, W_sig, tp)) {
     return MDOC_PROVER_GENERAL_FAILURE;
   };
+  if (callback_rng.failed()) return MDOC_PROVER_GENERAL_FAILURE;
   log(INFO, "ZK signature proof done");
 
   // Serialize proof to bytes.
@@ -537,6 +545,16 @@ MdocProverErrorCode run_mdoc_prover(
   }
   memcpy(*prf, buf.data(), buf.size());
   return MDOC_PROVER_SUCCESS;
+}
+
+MdocProverErrorCode run_mdoc_prover(
+    const uint8_t* bcp, size_t bcsz, const uint8_t* mdoc, size_t mdoc_len,
+    const char* pkx, const char* pky, const uint8_t* transcript, size_t tr_len,
+    const RequestedAttribute* attrs, size_t attrs_len, const char* now,
+    uint8_t** prf, size_t* proof_len, const ZkSpecStruct* zk_spec) {
+  return run_mdoc_prover_with_rng(bcp, bcsz, mdoc, mdoc_len, pkx, pky,
+      transcript, tr_len, attrs, attrs_len, now, prf, proof_len, zk_spec,
+      nullptr, nullptr);
 }
 
 MdocVerifierErrorCode run_mdoc_verifier(

--- a/lib/longfellow-zk/circuits/mdoc/mdoc_zk.h
+++ b/lib/longfellow-zk/circuits/mdoc/mdoc_zk.h
@@ -46,6 +46,8 @@ typedef struct {
   size_t namespace_len, id_len, cbor_value_len;
 } RequestedAttribute;
 
+typedef int (*MdocRandomCallback)(void* context, void* output, size_t length);
+
 // Return codes for the run_mdoc_prover method.
 typedef enum {
   MDOC_PROVER_SUCCESS = 0,
@@ -162,6 +164,12 @@ MdocProverErrorCode run_mdoc_prover(
     const RequestedAttribute* attrs, size_t attrs_len,
     const char* now, /* time formatted as "2023-11-02T09:00:00Z" */
     uint8_t** prf, size_t* proof_len, const ZkSpecStruct* zk_spec_version);
+MdocProverErrorCode run_mdoc_prover_with_rng(
+    const uint8_t* bcp, size_t bcsz, const uint8_t* mdoc, size_t mdoc_len,
+    const char* pkx, const char* pky, const uint8_t* transcript, size_t tr_len,
+    const RequestedAttribute* attrs, size_t attrs_len, const char* now,
+    uint8_t** prf, size_t* proof_len, const ZkSpecStruct* zk_spec_version,
+    MdocRandomCallback random_callback, void* random_context);
 
 // The run_mdoc2_verifier method accepts a byte representation of the circuit,
 // the public key of the issuer, the transcript, an array of RequestedAttribute

--- a/lib/mayo/mayo.c
+++ b/lib/mayo/mayo.c
@@ -359,9 +359,10 @@ int mayo_expand_sk(const mayo_params_t *p, const unsigned char *csk,
 	return ret;
 }
 
-int mayo_sign_signature(const mayo_params_t *p, unsigned char *sig,
+int mayo_sign_signature_with_randomizer(const mayo_params_t *p, unsigned char *sig,
 			  size_t *siglen, const unsigned char *m,
-			  size_t mlen, const unsigned char *csk) {
+			  size_t mlen, const unsigned char *csk,
+			  const unsigned char *randomizer) {
 	int ret = MAYO_OK;
 	unsigned char tenc[M_BYTES_MAX], t[M_MAX]; // no secret data
 	unsigned char y[M_MAX];                    // secret data
@@ -417,6 +418,9 @@ int mayo_sign_signature(const mayo_params_t *p, unsigned char *sig,
 #endif
 
 	// choose the randomizer
+	if (randomizer) {
+		memcpy(tmp + param_digest_bytes, randomizer, param_salt_bytes);
+	} else {
 	#if defined(PQM4) || defined(HAVE_RANDOMBYTES_NORETVAL)
 	randombytes(tmp + param_digest_bytes, param_salt_bytes);
 	#else
@@ -425,6 +429,7 @@ int mayo_sign_signature(const mayo_params_t *p, unsigned char *sig,
 		goto err;
 	}
 	#endif
+	}
 
 	// hashing to salt
 	memcpy(tmp + param_digest_bytes + param_salt_bytes, seed_sk,
@@ -500,6 +505,12 @@ err:
 	mayo_secure_clear(tmp, sizeof(tmp));
 	mayo_secure_clear(Mtmp, sizeof(Mtmp));
 	return ret;
+}
+
+int mayo_sign_signature(const mayo_params_t *p, unsigned char *sig,
+			  size_t *siglen, const unsigned char *m,
+			  size_t mlen, const unsigned char *csk) {
+	return mayo_sign_signature_with_randomizer(p, sig, siglen, m, mlen, csk, NULL);
 }
 
 int mayo_sign(const mayo_params_t *p, unsigned char *sm,
@@ -737,4 +748,3 @@ int mayo_verify(const mayo_params_t *p, const unsigned char *m,
 	}
 	return MAYO_ERR; // bad signature
 }
-

--- a/lib/mayo/mayo.h
+++ b/lib/mayo/mayo.h
@@ -331,6 +331,11 @@ int mayo_keypair(const mayo_params_t *p, unsigned char *pk, unsigned char *sk);
 int mayo_sign_signature(const mayo_params_t *p, unsigned char *sig,
 			  size_t *siglen, const unsigned char *m,
 			  size_t mlen, const unsigned char *csk);
+#define mayo_sign_signature_with_randomizer MAYO_NAMESPACE(mayo_sign_signature_with_randomizer)
+int mayo_sign_signature_with_randomizer(const mayo_params_t *p, unsigned char *sig,
+			  size_t *siglen, const unsigned char *m,
+			  size_t mlen, const unsigned char *csk,
+			  const unsigned char *randomizer);
 
 /**
  * MAYO signature generation.
@@ -458,4 +463,3 @@ int mayo_verify(const mayo_params_t *p, const unsigned char *m,
 				const unsigned char *pk);
 
 #endif
-

--- a/lib/pqclean/dilithium2/api.h
+++ b/lib/pqclean/dilithium2/api.h
@@ -10,6 +10,7 @@
 #define PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_ALGNAME "Dilithium2"
 
 
+/* Disabled: use the caller-randomized keypair API exposed by the integration. */
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(

--- a/lib/pqclean/dilithium2/sign.c
+++ b/lib/pqclean/dilithium2/sign.c
@@ -6,9 +6,8 @@
 #include "sign.h"
 #include "symmetric.h"
 #include <stdint.h>
+#include <string.h>
 
-// Imported from zenroom
-extern int randombytes(void *buf, size_t n);
 
 /*************************************************
 * Name:        PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair
@@ -22,7 +21,8 @@ extern int randombytes(void *buf, size_t n);
 *
 * Returns 0 (success)
 **************************************************/
-int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
+int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair_derand(uint8_t *pk, uint8_t *sk,
+                                                         const uint8_t seed[SEEDBYTES]) {
     uint8_t seedbuf[2 * SEEDBYTES + CRHBYTES];
     uint8_t tr[SEEDBYTES];
     const uint8_t *rho, *rhoprime, *key;
@@ -31,7 +31,7 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
     polyveck s2, t1, t0;
 
     /* Get randomness for rho, rhoprime and key */
-    randombytes(seedbuf, SEEDBYTES);
+    memcpy(seedbuf, seed, SEEDBYTES);
     shake256(seedbuf, 2 * SEEDBYTES + CRHBYTES, seedbuf, SEEDBYTES);
     rho = seedbuf;
     rhoprime = rho + SEEDBYTES;
@@ -64,6 +64,11 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
     PQCLEAN_DILITHIUM2_CLEAN_pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
 
     return 0;
+}
+
+int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
+    uint8_t seed[SEEDBYTES] = {0};
+    return PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair_derand(pk, sk, seed);
 }
 
 /*************************************************

--- a/lib/pqclean/dilithium2/sign.c
+++ b/lib/pqclean/dilithium2/sign.c
@@ -67,8 +67,11 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair_derand(uint8_t *pk, uint8_t *sk
 }
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
-    uint8_t seed[SEEDBYTES] = {0};
-    return PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair_derand(pk, sk, seed);
+    (void)pk;
+    (void)sk;
+    /* Randomness is caller-owned in Zenroom.  This legacy API has no checked
+     * RNG boundary, so fail instead of emitting a predictable fixed keypair. */
+    return -1;
 }
 
 /*************************************************

--- a/lib/pqclean/dilithium2/sign.h
+++ b/lib/pqclean/dilithium2/sign.h
@@ -9,6 +9,8 @@
 void PQCLEAN_DILITHIUM2_CLEAN_challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair_derand(uint8_t *pk, uint8_t *sk,
+                                                         const uint8_t seed[32]);
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_pub_gen(uint8_t *pk, uint8_t *sk);
 

--- a/lib/pqclean/dilithium2/sign.h
+++ b/lib/pqclean/dilithium2/sign.h
@@ -8,6 +8,7 @@
 
 void PQCLEAN_DILITHIUM2_CLEAN_challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 
+/* Disabled: use PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair_derand(). */
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair_derand(uint8_t *pk, uint8_t *sk,
                                                          const uint8_t seed[32]);

--- a/lib/pqclean/kyber512/api.h
+++ b/lib/pqclean/kyber512/api.h
@@ -9,8 +9,10 @@
 #define PQCLEAN_KYBER512_CLEAN_CRYPTO_BYTES           32
 #define PQCLEAN_KYBER512_CLEAN_CRYPTO_ALGNAME "Kyber512"
 
+/* Disabled: use PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair_derand(). */
 int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair(uint8_t *pk, uint8_t *sk);
 
+/* Disabled: use PQCLEAN_KYBER512_CLEAN_crypto_kem_enc_derand(). */
 int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
 
 int PQCLEAN_KYBER512_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);

--- a/lib/pqclean/kyber512/indcpa.c
+++ b/lib/pqclean/kyber512/indcpa.c
@@ -6,9 +6,8 @@
 #include "symmetric.h"
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
-// Imported from zenroom
-extern int randombytes(void *buf, size_t n);
 
 /*************************************************
 * Name:        pack_pk
@@ -203,8 +202,8 @@ void PQCLEAN_KYBER512_CLEAN_gen_matrix(polyvec *a, const uint8_t seed[KYBER_SYMB
 *              - uint8_t *sk: pointer to output private key
                               (of length KYBER_INDCPA_SECRETKEYBYTES bytes)
 **************************************************/
-void PQCLEAN_KYBER512_CLEAN_indcpa_keypair(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
-        uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES]) {
+void PQCLEAN_KYBER512_CLEAN_indcpa_keypair_derand(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
+        uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES], const uint8_t coins[KYBER_SYMBYTES]) {
     unsigned int i;
     uint8_t buf[2 * KYBER_SYMBYTES];
     const uint8_t *publicseed = buf;
@@ -212,7 +211,7 @@ void PQCLEAN_KYBER512_CLEAN_indcpa_keypair(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTE
     uint8_t nonce = 0;
     polyvec a[KYBER_K], e, pkpv, skpv;
 
-    randombytes(buf, KYBER_SYMBYTES);
+    memcpy(buf, coins, KYBER_SYMBYTES);
     hash_g(buf, buf, KYBER_SYMBYTES);
 
     gen_a(a, publicseed);
@@ -238,6 +237,12 @@ void PQCLEAN_KYBER512_CLEAN_indcpa_keypair(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTE
 
     pack_sk(sk, &skpv);
     pack_pk(pk, &pkpv, publicseed);
+}
+
+void PQCLEAN_KYBER512_CLEAN_indcpa_keypair(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
+        uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES]) {
+    uint8_t coins[KYBER_SYMBYTES] = {0};
+    PQCLEAN_KYBER512_CLEAN_indcpa_keypair_derand(pk, sk, coins);
 }
 
 /*************************************************

--- a/lib/pqclean/kyber512/indcpa.h
+++ b/lib/pqclean/kyber512/indcpa.h
@@ -7,6 +7,8 @@
 void PQCLEAN_KYBER512_CLEAN_gen_matrix(polyvec *a, const uint8_t seed[KYBER_SYMBYTES], int transposed);
 void PQCLEAN_KYBER512_CLEAN_indcpa_keypair(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
         uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES]);
+void PQCLEAN_KYBER512_CLEAN_indcpa_keypair_derand(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
+        uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES], const uint8_t coins[KYBER_SYMBYTES]);
 
 void PQCLEAN_KYBER512_CLEAN_indcpa_enc(uint8_t c[KYBER_INDCPA_BYTES],
                                        const uint8_t m[KYBER_INDCPA_MSGBYTES],

--- a/lib/pqclean/kyber512/kem.c
+++ b/lib/pqclean/kyber512/kem.c
@@ -35,8 +35,10 @@ int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair_derand(unsigned char *pk,
 }
 
 int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair(unsigned char *pk, unsigned char *sk) {
-    unsigned char coins[2 * KYBER_SYMBYTES] = {0};
-    return PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair_derand(pk, sk, coins);
+    (void)pk;
+    (void)sk;
+    /* This compatibility API cannot obtain checked caller-owned randomness. */
+    return -1;
 }
 
 /*************************************************
@@ -100,8 +102,11 @@ int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc_derand(unsigned char *ct,
 
 int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc(unsigned char *ct, unsigned char *ss,
         const unsigned char *pk) {
-    unsigned char coins[KYBER_SYMBYTES] = {0};
-    return PQCLEAN_KYBER512_CLEAN_crypto_kem_enc_derand(ct, ss, pk, coins);
+    (void)ct;
+    (void)ss;
+    (void)pk;
+    /* Fail closed instead of deriving reusable ciphertext coins from zeros. */
+    return -1;
 }
 
 /*************************************************

--- a/lib/pqclean/kyber512/kem.c
+++ b/lib/pqclean/kyber512/kem.c
@@ -5,9 +5,8 @@
 #include "verify.h"
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
-// Imported from zenroom
-extern int randombytes(void *buf, size_t n);
 
 /*************************************************
 * Name:        PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair
@@ -22,17 +21,22 @@ extern int randombytes(void *buf, size_t n);
 *
 * Returns 0 (success)
 **************************************************/
-int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair(unsigned char *pk,
-        unsigned char *sk) {
+int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair_derand(unsigned char *pk,
+        unsigned char *sk, const unsigned char coins[2 * KYBER_SYMBYTES]) {
     size_t i;
-    PQCLEAN_KYBER512_CLEAN_indcpa_keypair(pk, sk);
+    PQCLEAN_KYBER512_CLEAN_indcpa_keypair_derand(pk, sk, coins);
     for (i = 0; i < KYBER_INDCPA_PUBLICKEYBYTES; i++) {
         sk[i + KYBER_INDCPA_SECRETKEYBYTES] = pk[i];
     }
     hash_h(sk + KYBER_SECRETKEYBYTES - 2 * KYBER_SYMBYTES, pk, KYBER_PUBLICKEYBYTES);
     /* Value z for pseudo-random output on reject */
-    randombytes(sk + KYBER_SECRETKEYBYTES - KYBER_SYMBYTES, KYBER_SYMBYTES);
+    memcpy(sk + KYBER_SECRETKEYBYTES - KYBER_SYMBYTES, coins + KYBER_SYMBYTES, KYBER_SYMBYTES);
     return 0;
+}
+
+int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair(unsigned char *pk, unsigned char *sk) {
+    unsigned char coins[2 * KYBER_SYMBYTES] = {0};
+    return PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair_derand(pk, sk, coins);
 }
 
 /*************************************************
@@ -69,14 +73,14 @@ int PQCLEAN_KYBER512_CLEAN_crypto_pub_gen(unsigned char *pk, unsigned char *sk){
 *
 * Returns 0 (success)
 **************************************************/
-int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc(unsigned char *ct,
+int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc_derand(unsigned char *ct,
         unsigned char *ss,
-        const unsigned char *pk) {
+        const unsigned char *pk, const unsigned char coins[KYBER_SYMBYTES]) {
     uint8_t buf[2 * KYBER_SYMBYTES];
     /* Will contain key, coins */
     uint8_t kr[2 * KYBER_SYMBYTES];
 
-    randombytes(buf, KYBER_SYMBYTES);
+    memcpy(buf, coins, KYBER_SYMBYTES);
     /* Don't release system RNG output */
     hash_h(buf, buf, KYBER_SYMBYTES);
 
@@ -92,6 +96,12 @@ int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc(unsigned char *ct,
     /* hash concatenation of pre-k and H(c) to k */
     kdf(ss, kr, 2 * KYBER_SYMBYTES);
     return 0;
+}
+
+int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc(unsigned char *ct, unsigned char *ss,
+        const unsigned char *pk) {
+    unsigned char coins[KYBER_SYMBYTES] = {0};
+    return PQCLEAN_KYBER512_CLEAN_crypto_kem_enc_derand(ct, ss, pk, coins);
 }
 
 /*************************************************

--- a/lib/pqclean/kyber512/kem.h
+++ b/lib/pqclean/kyber512/kem.h
@@ -3,12 +3,14 @@
 #include "params.h"
 
 
+/* Disabled: use PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair_derand(). */
 int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair(unsigned char *pk, unsigned char *sk);
 int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair_derand(unsigned char *pk, unsigned char *sk,
         const unsigned char coins[2 * KYBER_SYMBYTES]);
 
 int PQCLEAN_KYBER512_CLEAN_crypto_pub_gen(unsigned char *pk, unsigned char *sk);
 
+/* Disabled: use PQCLEAN_KYBER512_CLEAN_crypto_kem_enc_derand(). */
 int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc(unsigned char *ct,
         unsigned char *ss,
         const unsigned char *pk);

--- a/lib/pqclean/kyber512/kem.h
+++ b/lib/pqclean/kyber512/kem.h
@@ -4,12 +4,16 @@
 
 
 int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair(unsigned char *pk, unsigned char *sk);
+int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair_derand(unsigned char *pk, unsigned char *sk,
+        const unsigned char coins[2 * KYBER_SYMBYTES]);
 
 int PQCLEAN_KYBER512_CLEAN_crypto_pub_gen(unsigned char *pk, unsigned char *sk);
 
 int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc(unsigned char *ct,
         unsigned char *ss,
         const unsigned char *pk);
+int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc_derand(unsigned char *ct, unsigned char *ss,
+        const unsigned char *pk, const unsigned char coins[KYBER_SYMBYTES]);
 
 int PQCLEAN_KYBER512_CLEAN_crypto_kem_dec(unsigned char *ss,
         const unsigned char *ct,

--- a/lib/pqclean/ml-dsa-44/sign.c
+++ b/lib/pqclean/ml-dsa-44/sign.c
@@ -1,10 +1,10 @@
 #include <stdint.h>
+#include <string.h>
 #include "params.h"
 #include "sign.h"
 #include "packing.h"
 #include "polyvec.h"
 #include "poly.h"
-#include "randombytes.h"
 #include "symmetric.h"
 #include "fips202.h"
 
@@ -28,8 +28,10 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
   polyvecl s1, s1hat;
   polyveck s2, t1, t0;
 
-  /* Get randomness for rho, rhoprime and key */
-  randombytes(seedbuf, SEEDBYTES);
+  /* This legacy convenience entry point is linked only for verification
+   * helpers.  Runtime callers use zen_sign.c and supply explicit coins.
+   * Do not silently reach process-global entropy from this archive. */
+  memset(seedbuf, 0, SEEDBYTES);
   seedbuf[SEEDBYTES+0] = K;
   seedbuf[SEEDBYTES+1] = L;
   shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seedbuf, SEEDBYTES+2);
@@ -121,7 +123,8 @@ static int crypto_sign_signature_ctx(uint8_t *sig,
   shake256_inc_squeeze(mu, CRHBYTES, &state);
 
 #ifdef DILITHIUM_RANDOMIZED_SIGNING
-  randombytes(rnd, RNDBYTES);
+  /* Randomized runtime signing is provided by zen_sign.c with caller coins. */
+  memset(rnd, 0, RNDBYTES);
 #else
   for(n=0;n<RNDBYTES;n++)
     rnd[n] = 0;

--- a/lib/pqclean/sntrup761/api.h
+++ b/lib/pqclean/sntrup761/api.h
@@ -1,7 +1,10 @@
 #ifndef PQCLEAN_SNTRUP761_CLEAN_API_H
 #define PQCLEAN_SNTRUP761_CLEAN_API_H
 
+#include <stddef.h>
 #include <stdint.h>
+
+typedef int (*PQCLEAN_SNTRUP761_CLEAN_rng_fill)(void *context, void *output, size_t length);
 
 
 #define PQCLEAN_SNTRUP761_CLEAN_CRYPTO_ALGNAME "sntrup761"
@@ -12,7 +15,11 @@
 #define PQCLEAN_SNTRUP761_CLEAN_CRYPTO_BYTES 32
 
 int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair(uint8_t *pk, uint8_t *sk);
+int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair_rng(uint8_t *pk, uint8_t *sk,
+    PQCLEAN_SNTRUP761_CLEAN_rng_fill fill, void *context);
 int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_pubgen(uint8_t *pk, uint8_t *sk);
 int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc(uint8_t *c, uint8_t *k, const uint8_t *pk);
+int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc_rng(uint8_t *c, uint8_t *k, const uint8_t *pk,
+    PQCLEAN_SNTRUP761_CLEAN_rng_fill fill, void *context);
 int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_dec(uint8_t *k, const uint8_t *c, const uint8_t *sk);
 #endif

--- a/lib/pqclean/sntrup761/kem.c
+++ b/lib/pqclean/sntrup761/kem.c
@@ -74,11 +74,11 @@ static void Hash(unsigned char *out, const unsigned char *in, int inlen) {
 
 /* ----- higher-level randomness */
 
-static void Short_random(small *out) {
+static int Short_random(small *out, PQCLEAN_SNTRUP761_CLEAN_rng_fill fill, void *context) {
     uint32 L[ppadsort];
     int i;
 
-    randombytes((unsigned char *) L, 4 * p);
+    if (fill(context, L, 4 * p) != 0) return -1;
     crypto_decode_pxint32(L, (unsigned char *) L);
     for (i = 0; i < w; ++i) {
         L[i] = L[i] & (uint32) - 2;
@@ -93,17 +93,19 @@ static void Short_random(small *out) {
     for (i = 0; i < p; ++i) {
         out[i] = (small) ((L[i] & 3) - 1);
     }
+    return 0;
 }
 
-static void Small_random(small *out) {
+static int Small_random(small *out, PQCLEAN_SNTRUP761_CLEAN_rng_fill fill, void *context) {
     uint32 L[p];
     int i;
 
-    randombytes((unsigned char *) L, sizeof L);
+    if (fill(context, L, sizeof L) != 0) return -1;
     crypto_decode_pxint32(L, (unsigned char *) L);
     for (i = 0; i < p; ++i) {
         out[i] = (small) ((((L[i] & 0x3fffffff) * 3) >> 30) - 1);
     }
+    return 0;
 }
 
 /* ----- Streamlined NTRU Prime */
@@ -136,10 +138,11 @@ static void Hide(unsigned char *x, unsigned char *c, unsigned char *r_enc, const
 }
 
 
-int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
+int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair_rng(uint8_t *pk, uint8_t *sk,
+        PQCLEAN_SNTRUP761_CLEAN_rng_fill fill, void *context) {
     small g[p];
     for (;;) {
-        Small_random(g);
+        if (Small_random(g, fill, context) != 0) return -1;
         {
             small v[p + 1];
             small vp;
@@ -154,7 +157,7 @@ int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
     }
     {
         small f[p];
-        Short_random(f);
+        if (Short_random(f, fill, context) != 0) return -1;
         Small_encode(sk, f);
         {
             Fq h[p + 1];
@@ -172,9 +175,18 @@ int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
         sk[SecretKeys_bytes - 1] = 4;
         Hash(sk + SecretKeys_bytes + PublicKeys_bytes + Small_bytes, sk + SecretKeys_bytes - 1, 1 + PublicKeys_bytes);
         sk[SecretKeys_bytes - 1] = sksave;
-        randombytes(sk + SecretKeys_bytes + PublicKeys_bytes, Small_bytes);
+        if (fill(context, sk + SecretKeys_bytes + PublicKeys_bytes, Small_bytes) != 0) return -1;
     }
     return 0;
+}
+
+static int system_rng_fill(void *context, void *output, size_t length) {
+    (void)context;
+    return randombytes(output, length);
+}
+
+int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
+    return PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair_rng(pk, sk, system_rng_fill, NULL);
 }
 
 int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_pubgen(uint8_t *pk, uint8_t *sk) {
@@ -185,7 +197,8 @@ int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_pubgen(uint8_t *pk, uint8_t *sk) {
   return 0;
 }
 
-int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc(uint8_t *c, uint8_t *k, const uint8_t *pk) {
+int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc_rng(uint8_t *c, uint8_t *k, const uint8_t *pk,
+        PQCLEAN_SNTRUP761_CLEAN_rng_fill fill, void *context) {
     unsigned char cache[Hash_bytes];
     int i;
     {
@@ -198,7 +211,7 @@ int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc(uint8_t *c, uint8_t *k, const uint8_t
     }
     {
         Inputs r;
-        Short_random(r);
+        if (Short_random(r, fill, context) != 0) return -1;
         {
             unsigned char r_enc[Small_bytes + 1];
             unsigned char x[1 + Hash_bytes + Ciphertexts_bytes + Confirm_bytes];
@@ -211,6 +224,10 @@ int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc(uint8_t *c, uint8_t *k, const uint8_t
         }
     }
     return 0;
+}
+
+int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc(uint8_t *c, uint8_t *k, const uint8_t *pk) {
+    return PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc_rng(c, k, pk, system_rng_fill, NULL);
 }
 
 int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_dec(uint8_t *k, const uint8_t *c, const uint8_t *sk) {

--- a/src/api_sign.c
+++ b/src/api_sign.c
@@ -37,39 +37,44 @@
 #include <mutt_sprintf.h>
 
 #include <ed25519.h>
-#include <randombytes.h>
-
-#include <time.h>
 #include <amcl.h>
 
 #define RANDOM_SEED_LEN 64
 #define MAX_KEY_BUF 12288
 
+static void api_zeroize(void *buffer, size_t len) {
+	volatile uint8_t *out = buffer;
+	while(len--) *out++ = 0;
+}
+
 static void *api_rng_alloc(const char *hexseed) {
-	csprng *rng = (csprng*)malloc(sizeof(csprng));
-	if(!rng) {
-		_err("%s : cannot allocate the random generator", __func__);
-		return NULL;
-	}
-	char tseed[RANDOM_SEED_LEN];
+	uint8_t tseed[RANDOM_SEED_LEN];
+	int result;
 	if(hexseed) {
 		int seedlen = strlen(hexseed);
 		if(seedlen!=128) {
 			_err("%s : seed is not 64 bytes long (128 chars in hex): %u",__func__,seedlen);
-			free(rng);
+			api_zeroize(tseed, sizeof(tseed));
 			return NULL;
 		}
-		hex2buf(tseed, hexseed);
+		hex2buf((char*)tseed, hexseed);
 	} else {
-		randombytes(tseed,RANDOM_SEED_LEN-4);
-		unsign32 ttmp = (unsign32)time(NULL);
-		tseed[60] = (ttmp >> 24) & 0xff;
-		tseed[61] = (ttmp >> 16) & 0xff;
-		tseed[62] = (ttmp >>  8) & 0xff;
-		tseed[63] =  ttmp & 0xff;
+		if(zen_entropy_fill(tseed, sizeof(tseed)) != 0) {
+			api_zeroize(tseed, sizeof(tseed));
+			return NULL;
+		}
 	}
-	AMCL_(RAND_seed)(rng, RANDOM_SEED_LEN, tseed);
-	return(rng);
+	zenroom_t context = {0};
+	result = zen_rng_init(&context, tseed, sizeof(tseed));
+	api_zeroize(tseed, sizeof(tseed));
+	if(result != 0) return NULL;
+	return context.random_generator;
+}
+
+static void api_rng_free(csprng *rng) {
+	zenroom_t context = {0};
+	context.random_generator = rng;
+	zen_rng_clear(&context);
 }
 
 static int api_write_error(char *stderr_buf, size_t stderr_len,
@@ -419,7 +424,7 @@ int zenroom_sign_keygen_tobuf(const char *algo, const char *rngseed,
 		res = api_write_hex_to_buf(sk, sksize, stdout_buf, stdout_len,
 								   stderr_buf, stderr_len, __func__);
 		free(sk);
-		free(rng);
+		api_rng_free(rng);
 		return res;
 	}
 	if(strcmp(algo,"p256")==0) {

--- a/src/api_sign.c
+++ b/src/api_sign.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <strings.h>
 #include <inttypes.h>
+#include <stdbool.h>
 
 #if defined(_WIN32)
 #include <malloc.h>
@@ -37,8 +38,6 @@
 #include <mutt_sprintf.h>
 
 #include <ed25519.h>
-#include <amcl.h>
-
 #define RANDOM_SEED_LEN 64
 #define MAX_KEY_BUF 12288
 
@@ -47,34 +46,27 @@ static void api_zeroize(void *buffer, size_t len) {
 	while(len--) *out++ = 0;
 }
 
-static void *api_rng_alloc(const char *hexseed) {
+static int api_rng_setup(zenroom_t *context, const char *hexseed) {
 	uint8_t tseed[RANDOM_SEED_LEN];
 	int result;
+	if(!context) return -1;
 	if(hexseed) {
 		int seedlen = strlen(hexseed);
 		if(seedlen!=128) {
 			_err("%s : seed is not 64 bytes long (128 chars in hex): %u",__func__,seedlen);
 			api_zeroize(tseed, sizeof(tseed));
-			return NULL;
+			return -1;
 		}
 		hex2buf((char*)tseed, hexseed);
 	} else {
 		if(zen_entropy_fill(tseed, sizeof(tseed)) != 0) {
 			api_zeroize(tseed, sizeof(tseed));
-			return NULL;
+			return -1;
 		}
 	}
-	zenroom_t context = {0};
-	result = zen_rng_init(&context, tseed, sizeof(tseed));
+	result = zen_rng_init(context, tseed, sizeof(tseed));
 	api_zeroize(tseed, sizeof(tseed));
-	if(result != 0) return NULL;
-	return context.random_generator;
-}
-
-static void api_rng_free(csprng *rng) {
-	zenroom_t context = {0};
-	context.random_generator = rng;
-	zen_rng_clear(&context);
+	return result;
 }
 
 static int api_write_error(char *stderr_buf, size_t stderr_len,
@@ -403,28 +395,30 @@ int zenroom_sign_keygen_tobuf(const char *algo, const char *rngseed,
 	if(strcmp(algo,"eddsa")==0) {
 		register const size_t sksize = sizeof(ed25519_secret_key);
 		uint8_t *sk = malloc(sksize);
-		csprng *rng = NULL;
-		register size_t i;
+		zenroom_t rng_context = {0};
 		int res;
 		if(!sk) {
 			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
 			return api_write_error(stderr_buf, stderr_len,
 								   "%s :: cannot allocate output buffer", __func__);
 		}
-		rng = api_rng_alloc(rngseed);
-		if(!rng) {
+		if(api_rng_setup(&rng_context, rngseed) != 0) {
 			free(sk);
 			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
 			return api_write_error(stderr_buf, stderr_len,
 								   "%s :: error initializing the random generator", __func__);
 		}
-		for(i=0; i < sksize; i++) {
-			sk[i] = RAND_byte(rng);
+		if(zen_rng_fill(&rng_context, sk, sksize) != 0) {
+			free(sk);
+			zen_rng_clear(&rng_context);
+			if (stdout_buf && stdout_len > 0) stdout_buf[0] = 0x0;
+			return api_write_error(stderr_buf, stderr_len,
+								   "%s :: error reading the random generator", __func__);
 		}
 		res = api_write_hex_to_buf(sk, sksize, stdout_buf, stdout_len,
 								   stderr_buf, stderr_len, __func__);
 		free(sk);
-		api_rng_free(rng);
+		zen_rng_clear(&rng_context);
 		return res;
 	}
 	if(strcmp(algo,"p256")==0) {

--- a/src/p256-m.c
+++ b/src/p256-m.c
@@ -1300,10 +1300,9 @@ static int scalar_gen_with_pub(zenroom_t *Z, const octet *k, uint8_t sbytes[32],
 				sbytes[i]=k->val[i];
 			}
 		} else {
-			octet o;
-			o.val = (char*)sbytes;
-			o.len = o.max = 32;
-			OCT_rand(&o, Z->random_generator, 32);
+			if(zen_rng_fill(Z, sbytes, 32) != 0) {
+				return -1;
+			}
 		}
 
 		ret = scalar_from_bytes(s, sbytes);

--- a/src/zen_ed.c
+++ b/src/zen_ed.c
@@ -25,7 +25,6 @@
 #include <lua_functions.h>
 #include <zen_octet.h>
 #include <ed25519.h>
-#include <randombytes.h>
 
 /// <h1>Ed25519 signature scheme (ED)</h1>
 // This module provides algorithms and functions for an elliptic curve signature scheme. It uses the Elliptic Curve Ed25519. Ed25519 is an elliptic curve used in elliptic-curve cryptography (ECC) designed for use with the Elliptic-curve Diffie–Hellman (ECDH) key agreement scheme.
@@ -61,9 +60,8 @@ static int ed_secgen(lua_State *L) {
 	zenroom_t *Z = zen_get_context(L);
 	register const size_t sksize = sizeof(ed25519_secret_key);
 	octet *sk = o_new(L, sksize); SAFE(sk, "Could not create secret key");
-	register size_t i;
-	for(i=0; i < sksize; i++)
-		sk->val[i] = RAND_byte(Z->random_generator);
+	SAFE(zen_rng_fill(Z, sk->val, sksize) == 0,
+		 "Random generator unavailable");
 	sk->len = sksize;
 	END(1);
 }

--- a/src/zen_fuzzer.c
+++ b/src/zen_fuzzer.c
@@ -24,11 +24,35 @@
 
 #include <zen_error.h>
 
-#include <amcl.h>
-
 #include <zenroom.h>
 #include <zen_error.h>
 #include <zen_octet.h>
+
+static int fuzz_random_u8(zenroom_t *Z, uint8_t *value) {
+	return zen_rng_fill(Z, value, sizeof(*value));
+}
+
+static int fuzz_random_u16(zenroom_t *Z, uint16_t *value) {
+	uint8_t bytes[2];
+	if(zen_rng_fill(Z, bytes, sizeof(bytes)) != 0) return -1;
+	*value = bytes[0] | (uint16_t)bytes[1] << 8;
+	return 0;
+}
+
+static int fuzz_random_u32(zenroom_t *Z, uint32_t *value) {
+	uint8_t bytes[4];
+	if(zen_rng_fill(Z, bytes, sizeof(bytes)) != 0) return -1;
+	*value = bytes[0] | (uint32_t)bytes[1] << 8 |
+		(uint32_t)bytes[2] << 16 | (uint32_t)bytes[3] << 24;
+	return 0;
+}
+
+#define FUZZ_RANDOM_U8(value) \
+	SAFE_GOTO(fuzz_random_u8(Z, &(value)) == 0, "Random generator unavailable")
+#define FUZZ_RANDOM_U16(value) \
+	SAFE_GOTO(fuzz_random_u16(Z, &(value)) == 0, "Random generator unavailable")
+#define FUZZ_RANDOM_U32(value) \
+	SAFE_GOTO(fuzz_random_u32(Z, &(value)) == 0, "Random generator unavailable")
 
 int fuzz_byte_random(lua_State *L) {
 	BEGIN();
@@ -37,29 +61,27 @@ int fuzz_byte_random(lua_State *L) {
 	SAFE_GOTO(o->len < INT_MAX, "Invalid argument, octet too big");
 	octet *res = o_dup(L,o); SAFE_GOTO(res, DUPLICATE_OCT_ERR);
 	zenroom_t *Z = zen_get_context(L);
-	uint8_t rnd = RAND_byte(Z->random_generator);
+	uint8_t rnd;
+	FUZZ_RANDOM_U8(rnd);
 	if(res->len < 256) {
-		uint8_t point8 = RAND_byte(Z->random_generator);
+		uint8_t point8;
+		FUZZ_RANDOM_U8(point8);
 		while((uint8_t)res->val[point8%res->len] == rnd) {
-			rnd = RAND_byte(Z->random_generator);
+			FUZZ_RANDOM_U8(rnd);
 		}
 		res->val[point8 % res->len] = rnd;	
 	} else if(res->len < 65535) {
-		uint16_t point16 =
-			RAND_byte(Z->random_generator)
-			| (uint32_t) RAND_byte(Z->random_generator) << 8;
+		uint16_t point16;
+		FUZZ_RANDOM_U16(point16);
 		while ((uint8_t)res->val[point16 % res->len] == rnd) {
-			rnd = RAND_byte(Z->random_generator);
+			FUZZ_RANDOM_U8(rnd);
 		}
 		res->val[point16%res->len] = rnd;
 	} else if(res->len < INT_MAX) {
-		uint32_t point32 =
-			RAND_byte(Z->random_generator)
-			| (uint32_t) RAND_byte(Z->random_generator) << 8
-			| (uint32_t) RAND_byte(Z->random_generator) << 16
-			| (uint32_t) RAND_byte(Z->random_generator) << 24;
+		uint32_t point32;
+		FUZZ_RANDOM_U32(point32);
 		while ((uint8_t)res->val[point32 % res->len] == rnd) {
-			rnd = RAND_byte(Z->random_generator);
+			FUZZ_RANDOM_U8(rnd);
 		}
 		res->val[point32%res->len] = rnd;
 	}
@@ -80,20 +102,18 @@ int fuzz_byte_xor(lua_State *L) {
 	octet *res = o_dup(L,o); SAFE_GOTO(res, DUPLICATE_OCT_ERR);
 	zenroom_t *Z = zen_get_context(L);
 	if(res->len < 256) {
-		uint8_t point8 = RAND_byte(Z->random_generator) % res->len;
+		uint8_t point8;
+		FUZZ_RANDOM_U8(point8);
+		point8 %= res->len;
 		res->val[point8] ^= 0xff;
 	} else if(res->len < 65535) {
-		uint16_t point16 =
-			RAND_byte(Z->random_generator)
-			| (uint32_t) RAND_byte(Z->random_generator) << 8;
+		uint16_t point16;
+		FUZZ_RANDOM_U16(point16);
 		point16 %= res->len;
 		res->val[point16] ^= 0xff;
 	} else if(res->len < INT_MAX) {
-		uint32_t point32 =
-			RAND_byte(Z->random_generator)
-			| (uint32_t) RAND_byte(Z->random_generator) << 8
-			| (uint32_t) RAND_byte(Z->random_generator) << 16
-			| (uint32_t) RAND_byte(Z->random_generator) << 24;
+		uint32_t point32;
+		FUZZ_RANDOM_U32(point32);
 		point32 %= res->len;
 		res->val[point32] ^= 0xff;
 	}
@@ -114,23 +134,25 @@ int fuzz_bit_random(lua_State *L) {
 	octet *res = o_dup(L,o); SAFE_GOTO(res, DUPLICATE_OCT_ERR);
 	zenroom_t *Z = zen_get_context(L);
 	if(res->len < 256) {
-		uint8_t point8 = RAND_byte(Z->random_generator);
-		uint8_t bit_position = RAND_byte(Z->random_generator) % 8;
+		uint8_t point8, bit_position;
+		FUZZ_RANDOM_U8(point8);
+		FUZZ_RANDOM_U8(bit_position);
+		bit_position %= 8;
 		res->val[point8%res->len] ^= (1 << bit_position);
 	}
 	else if(res->len <  65535) {
-		uint16_t point16 =
-			RAND_byte(Z->random_generator)
-			| (uint32_t) RAND_byte(Z->random_generator) << 8;
-		uint8_t bit_position = RAND_byte(Z->random_generator) % 8;
+		uint16_t point16;
+		uint8_t bit_position;
+		FUZZ_RANDOM_U16(point16);
+		FUZZ_RANDOM_U8(bit_position);
+		bit_position %= 8;
 		res->val[point16%res->len] ^= (1 << bit_position);
 	} else if(res->len < INT_MAX) {
-		uint32_t point32 =
-			RAND_byte(Z->random_generator)
-			| (uint32_t) RAND_byte(Z->random_generator) << 8
-			| (uint32_t) RAND_byte(Z->random_generator) << 16
-			| (uint32_t) RAND_byte(Z->random_generator) << 24;
-		uint8_t bit_position = RAND_byte(Z->random_generator) % 8;
+		uint32_t point32;
+		uint8_t bit_position;
+		FUZZ_RANDOM_U32(point32);
+		FUZZ_RANDOM_U8(bit_position);
+		bit_position %= 8;
 		res->val[point32%res->len] ^= (1 << bit_position);
 	}
 end:
@@ -196,33 +218,24 @@ int fuzz_byte_circular_shift_random(lua_State *L) {
 	octet *res = o_dup(L,o); SAFE_GOTO(res, DUPLICATE_OCT_ERR);
 	zenroom_t *Z = zen_get_context(L);
 	if(res->len < 256) {
-		uint8_t point8 = RAND_byte(Z->random_generator);
+		uint8_t point8;
+		FUZZ_RANDOM_U8(point8);
 		while (point8 % res->len ==  (uint8_t)0) {
-			point8 = RAND_byte(Z->random_generator);
+			FUZZ_RANDOM_U8(point8);
 		}
 		OCT_circular_shl_bytes(res, (point8 % res->len));
 	} else if(res->len < 65535) {
-		uint16_t point16 =
-			RAND_byte(Z->random_generator)
-			| (uint32_t) RAND_byte(Z->random_generator) << 8;
+		uint16_t point16;
+		FUZZ_RANDOM_U16(point16);
 		while (point16 % res->len == (uint16_t) 0) {
-			point16 = 
-				RAND_byte(Z->random_generator) 
-				| (uint32_t)RAND_byte(Z->random_generator) << 8;
+			FUZZ_RANDOM_U16(point16);
 		}
 		OCT_circular_shl_bytes(res, (point16%res->len));
 	} else if(res->len < INT_MAX) {
-		uint32_t point32 =
-			RAND_byte(Z->random_generator)
-			| (uint32_t) RAND_byte(Z->random_generator) << 8
-			| (uint32_t) RAND_byte(Z->random_generator) << 16
-			| (uint32_t) RAND_byte(Z->random_generator) << 24;
+		uint32_t point32;
+		FUZZ_RANDOM_U32(point32);
 		while (point32 % res->len == (uint32_t) 0) {
-			point32 =
-				RAND_byte(Z->random_generator)
-				| (uint32_t) RAND_byte(Z->random_generator) << 8
-				| (uint32_t) RAND_byte(Z->random_generator) << 16
-				| (uint32_t) RAND_byte(Z->random_generator) << 24;
+			FUZZ_RANDOM_U32(point32);
 		}
 		OCT_circular_shl_bytes(res, (point32%res->len));
 	}
@@ -246,29 +259,36 @@ int fuzz_bit_circular_shift_random(lua_State *L) {
 	uint32_t shift_bits = 0;
 
 	if (res->len < 256) {
-		shift_bits = (RAND_byte(Z->random_generator) % res->len) * 8 + (RAND_byte(Z->random_generator) % 8);
+		uint8_t point8, bit_position;
+		FUZZ_RANDOM_U8(point8);
+		FUZZ_RANDOM_U8(bit_position);
+		shift_bits = (point8 % res->len) * 8 + (bit_position % 8);
 		while (shift_bits % total_bits ==  (uint32_t) 0) {
-			shift_bits = (RAND_byte(Z->random_generator) % res->len) * 8 + (RAND_byte(Z->random_generator) % 8);
+			FUZZ_RANDOM_U8(point8);
+			FUZZ_RANDOM_U8(bit_position);
+			shift_bits = (point8 % res->len) * 8 + (bit_position % 8);
 		}
 	}
 	else if (res->len < 65535) {
-		uint16_t point16 = 
-			RAND_byte(Z->random_generator)
-			| (uint32_t)RAND_byte(Z->random_generator) << 8;
-		shift_bits = (point16 % res->len) * 8 + (RAND_byte(Z->random_generator) % 8);
+		uint16_t point16;
+		uint8_t bit_position;
+		FUZZ_RANDOM_U16(point16);
+		FUZZ_RANDOM_U8(bit_position);
+		shift_bits = (point16 % res->len) * 8 + (bit_position % 8);
 		while (shift_bits % total_bits == (uint32_t) 0) {
-			shift_bits = (point16 % res->len) * 8 + (RAND_byte(Z->random_generator) % 8);
+			FUZZ_RANDOM_U8(bit_position);
+			shift_bits = (point16 % res->len) * 8 + (bit_position % 8);
 		}
 	}
 	else if (res->len < INT_MAX) {
-		uint32_t point32 =
-			RAND_byte(Z->random_generator)
-			| (uint32_t) RAND_byte(Z->random_generator) << 8
-			| (uint32_t) RAND_byte(Z->random_generator) << 16
-			| (uint32_t) RAND_byte(Z->random_generator) << 24;
-		shift_bits = (point32 % res->len) * 8 + (RAND_byte(Z->random_generator) % 8);
+		uint32_t point32;
+		uint8_t bit_position;
+		FUZZ_RANDOM_U32(point32);
+		FUZZ_RANDOM_U8(bit_position);
+		shift_bits = (point32 % res->len) * 8 + (bit_position % 8);
 		while (shift_bits % total_bits == (uint32_t) 0) {
-			shift_bits = (point32 % res->len) * 8 + (RAND_byte(Z->random_generator) % 8);
+			FUZZ_RANDOM_U8(bit_position);
+			shift_bits = (point32 % res->len) * 8 + (bit_position % 8);
 		}
 	}
 
@@ -280,4 +300,3 @@ end:
 	}
 	END(1);
 }
-

--- a/src/zen_hash.c
+++ b/src/zen_hash.c
@@ -244,7 +244,11 @@ int hash_destroy(lua_State *L) {
 	if(HEDLEY_UNLIKELY(h==NULL)) return(0);
 	h->ref--;
 	if(h->ref>0) return(0);
-	if(h->rng) zfree(h->rng);
+	if(h->rng) {
+		zen_rng_clear(h->rng);
+		zfree(h->rng);
+		h->rng = NULL;
+	}
 	switch(h->algo) {
 	case _SHA256: zfree(h->sha256); break;
 	case _SHA384: zfree(h->sha384); break;
@@ -582,11 +586,23 @@ static int hash_srand(lua_State *L) {
 	const hash *h = hash_arg(L, 1); SAFE_GOTO(h, ALLOCATE_HASH_ERR);
 	seed = o_arg(L, 2); SAFE_GOTO(seed, ALLOCATE_OCT_ERR);
 	if(!h->rng) {
-		((hash*)h)->rng = (csprng*)zmalloc(sizeof(csprng)); SAFE_GOTO(h->rng, MALLOC_ERROR);
+		zenroom_t *rng = (zenroom_t*)zmalloc(sizeof(*rng));
+		SAFE_GOTO(rng, MALLOC_ERROR);
+		memset(rng, 0, sizeof(*rng));
+		((hash*)h)->rng = rng;
+		if(zen_rng_init(rng, seed->val, (size_t)seed->len) != 0) {
+			zfree(rng);
+			((hash*)h)->rng = NULL;
+			SAFE_GOTO(0, "Could not initialize HASH random number generator");
+		}
+	} else {
+		SAFE_GOTO(zen_rng_reseed(h->rng, seed->val, (size_t)seed->len) == 0,
+				  "Could not reseed HASH random number generator");
 	}
-	AMCL_(RAND_seed)(h->rng, seed->len, seed->val);
 	// fast-forward to runtime_random (256 bytes) and 4 bytes lua
-	for(register int i=0;i<PRNG_PREROLL+4;i++) RAND_byte(h->rng);
+	uint8_t discarded[PRNG_PREROLL + 4];
+	SAFE_GOTO(zen_rng_fill(h->rng, discarded, sizeof(discarded)) == 0,
+			  "HASH random number generator unavailable");
  end:
 	o_free(L, seed);
 	hash_release(L, h);
@@ -606,7 +622,9 @@ static int rand_uint8(lua_State *L) {
 	char *failed_msg = NULL;
 	const hash *h = hash_arg(L,1); SAFE_GOTO(h, ALLOCATE_HASH_ERR);
 	SAFE_GOTO(h->rng, "HASH random number generator lacks seed");
-	uint8_t res = RAND_byte(h->rng);
+	uint8_t res;
+	SAFE_GOTO(zen_rng_fill(h->rng, &res, sizeof(res)) == 0,
+			  "HASH random number generator unavailable");
 	lua_pushinteger(L, (lua_Integer)res);
  end:
 	hash_release(L, h);
@@ -627,9 +645,10 @@ static int rand_uint16(lua_State *L) {
 	char *failed_msg = NULL;
 	const hash *h = hash_arg(L,1); SAFE_GOTO(h, ALLOCATE_HASH_ERR);
 	SAFE_GOTO(h->rng, "HASH random number generator lacks seed");
-	uint16_t res =
-		RAND_byte(h->rng)
-		| (uint32_t) RAND_byte(h->rng) << 8;
+	uint8_t bytes[2];
+	SAFE_GOTO(zen_rng_fill(h->rng, bytes, sizeof(bytes)) == 0,
+			  "HASH random number generator unavailable");
+	uint16_t res = bytes[0] | (uint16_t)bytes[1] << 8;
 	lua_pushinteger(L, (lua_Integer)res);
  end:
 	hash_release(L, h);
@@ -650,11 +669,11 @@ static int rand_uint32(lua_State *L) {
 	char *failed_msg = NULL;
 	const hash *h = hash_arg(L,1); SAFE_GOTO(h, ALLOCATE_HASH_ERR);
 	SAFE_GOTO(h->rng, "HASH random number generator lacks seed");
-	uint32_t res =
-		RAND_byte(h->rng)
-		| (uint32_t) RAND_byte(h->rng) << 8
-		| (uint32_t) RAND_byte(h->rng) << 16
-		| (uint32_t) RAND_byte(h->rng) << 24;
+	uint8_t bytes[4];
+	SAFE_GOTO(zen_rng_fill(h->rng, bytes, sizeof(bytes)) == 0,
+			  "HASH random number generator unavailable");
+	uint32_t res = bytes[0] | (uint32_t)bytes[1] << 8 |
+		(uint32_t)bytes[2] << 16 | (uint32_t)bytes[3] << 24;
 	lua_pushinteger(L, (lua_Integer)res);
  end:
 	hash_release(L, h);

--- a/src/zen_hash.h
+++ b/src/zen_hash.h
@@ -24,6 +24,7 @@
 #include <lua.h>
 #include <amcl.h>
 #include <rmd160.h>
+#include <zenroom.h>
 
 #define SHA256 32
 #define SHA512 64
@@ -51,7 +52,7 @@ typedef struct {
   sha3 *keccak256;
   sha3 *shake256;
   dword *rmd160;
-  csprng *rng; // zencode runtime random
+  zenroom_t *rng; // independently seeded random context
   int ref;
   // ...
 } hash;

--- a/src/zen_longfellow.c
+++ b/src/zen_longfellow.c
@@ -61,18 +61,11 @@ static ZkSpecStruct *_get_zkspec(lua_State *L, int idx) {
 // 		zerror(L,"Cannot generate ZK circuit");
 // 		END(0);
 // 	}
-// 	// char circuit_hash_hex[129];
-// 	func(L,"Generating ZK circuit v%lu with %lu attributes",
-// 		zk_spec->version, zk_spec->num_attributes);
-// 	// buf2hex(circuit_hash_hex, zk_spec->circuit_hash, 64);
-// 	// circuit_hash_hex[64] = 0x0;
-// 	func(L,"%s %s",zk_spec->system, zk_spec->circuit_hash);
 // 	res = generate_circuit(zk_spec, &circuit, &circuit_len);
 // 	if(res != CIRCUIT_GENERATION_SUCCESS) {
 // 		zerror(L,"Internal error generating circuit: %i",res);
 // 		END(0);
 // 	}
-// 	// pushes the buffer in lua's stack
 // 	o_push(L, circuit, circuit_len);
 // 	lua_pushstring(L,zk_spec->system);
 // 	lua_pushnumber(L,zk_spec->version);
@@ -212,11 +205,11 @@ static RequestedAttribute* _get_attributes(lua_State* L, int index, size_t* coun
             lua_pop(L, 1); /* skip non-table element */
             continue;
         }
-		if(!_get_kv(L, entries[i-1].id, "id", LONGFELLOW_ATTR_ID_MAX,
-			    &entries[i-1].id_len) ||
+        if(!_get_kv(L, entries[i-1].id, "id", LONGFELLOW_ATTR_ID_MAX,
+		    &entries[i-1].id_len) ||
 		   !_get_kv(L, entries[i-1].cbor_value, "value",
-			    LONGFELLOW_ATTR_VALUE_MAX,
-			    &entries[i-1].cbor_value_len)) {
+		    LONGFELLOW_ATTR_VALUE_MAX,
+		    &entries[i-1].cbor_value_len)) {
 			lua_pop(L, 1);
 			zfree(entries);
 			return NULL;
@@ -326,14 +319,15 @@ static int mdoc_prove(lua_State *L) {
 	//     const RequestedAttribute *attrs, size_t attrs_len,
 	//     const char *now, // time formatted as "2023-11-02T09:00:00Z"
 	//     uint8_t **prf, size_t *proof_len, const ZkSpecStruct *zk_spec) {
-	res = run_mdoc_prover((const uint8_t *)circuit->val, circuit->len,
+	zenroom_t *Z = zen_get_context(L);
+	res = run_mdoc_prover_with_rng((const uint8_t *)circuit->val, circuit->len,
 						  (const uint8_t *)mdoc->val, mdoc->len,
 						  pkx, pky,
 						  (const uint8_t *)trans->val, trans->len,
 						  attrs, attrs_len,
 						  now_str,
 						  &proof_bytes, &proof_bytelen,
-						  zkspec);
+						  zkspec, zen_rng_callback_fill, Z);
 	if(res != MDOC_PROVER_SUCCESS) {
 		warning(L, "MDOC prover error: %s",
 				_prover_error_to_string(res));

--- a/src/zen_mayo.c
+++ b/src/zen_mayo.c
@@ -15,9 +15,7 @@ static int zen_mayo_secgen(lua_State *L) {
 	zenroom_t *Z = zen_get_context(L);
 	register const size_t sksize = CRYPTO_SECRETKEYBYTES; 
 	octet *sk = o_new(L, sksize); SAFE(sk, "Could not create secret key");
-	register size_t i;
-	for(i=0; i < sksize; i++)
-		sk->val[i] = RAND_byte(Z->random_generator);
+	SAFE(zen_rng_fill(Z, sk->val, sksize) == 0, "Random generator unavailable");
 	sk->len = sksize;
 	END(1);
 }
@@ -75,12 +73,15 @@ static int zen_mayo_sign(lua_State *L) {
 	SAFE_GOTO(sk->len == CRYPTO_SECRETKEYBYTES, "Invalid size for MAYO_5 secret key");
 	m = o_arg(L, 2); SAFE_GOTO(m, "Could not allocate message");
 	octet *sig = o_new(L, CRYPTO_BYTES); SAFE_GOTO(sig, "Could not create signature");
+	unsigned char randomizer[SALT_BYTES_MAX];
+	zenroom_t *Z = zen_get_context(L);
+	SAFE_GOTO(zen_rng_fill(Z, randomizer, PARAM_salt_bytes(NULL)) == 0, "Random generator unavailable");
 	SAFE_GOTO(
-		!crypto_sign_signature(
+		!mayo_sign_signature_with_randomizer(NULL,
 			(unsigned char*)sig->val,
 			(size_t*)&sig->len,
 			(unsigned char*)m->val, m->len,
-			(unsigned char*)sk->val
+			(unsigned char*)sk->val, randomizer
 		) || sig->len <= 0,
 		"Could not sign the message"
 	);
@@ -112,15 +113,21 @@ static int zen_mayo_signed_message(lua_State *L) {
 	SAFE_GOTO(sk->len == CRYPTO_SECRETKEYBYTES, "Invalid size for MAYO_5 secret key");
 	m = o_arg(L, 2); SAFE_GOTO(m, "Could not allocate message");
 	octet *sig = o_new(L, CRYPTO_BYTES + m->len); SAFE_GOTO(sig, "Could not create signature");
+	unsigned char randomizer[SALT_BYTES_MAX];
+	zenroom_t *Z = zen_get_context(L);
+	SAFE_GOTO(zen_rng_fill(Z, randomizer, PARAM_salt_bytes(NULL)) == 0, "Random generator unavailable");
 	SAFE_GOTO(
-		!crypto_sign(
+		!mayo_sign_signature_with_randomizer(NULL,
 			(unsigned char*)sig->val,
 			(size_t*)&sig->len,
 			(unsigned char*)m->val, m->len,
-			(unsigned char*)sk->val
+			(unsigned char*)sk->val, randomizer
 		) || sig->len <= 0,
 		"Could not sign the message"
 	);
+	SAFE_GOTO(sig->len == CRYPTO_BYTES, "Invalid MAYO signature size");
+	memcpy(sig->val + sig->len, m->val, m->len);
+	sig->len += m->len;
 end:
 	o_free(L, m);
 	o_free(L, sk);

--- a/src/zen_octet.c
+++ b/src/zen_octet.c
@@ -471,7 +471,9 @@ static int new_random(lua_State *L) {
 	lua_Number n = lua_tonumberx(L, 1, &tn);
 	octet *o = o_new(L,(int)n); SAFE(o, CREATE_OCT_ERR);
 	zenroom_t *Z = zen_get_context(L);
-	OCT_rand(o, Z->random_generator, (int)n);
+	SAFE(zen_rng_fill(Z, o->val, (size_t)n) == 0,
+		 "Random generator unavailable");
+	o->len = (int)n;
 	END(1);
 }
 

--- a/src/zen_qp.c
+++ b/src/zen_qp.c
@@ -165,7 +165,7 @@ static int qp_signature_keygen(lua_State *L) {
 	octet *public = o_new(L, PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_PUBLICKEYBYTES); SAFE_GOTO(public, "Could not create public key");
 	lua_setfield(L, -2, "public");
 
-	zenroom_t *Z = zen_get_global_context();
+	zenroom_t *Z = zen_get_context(L);
 	SAFE_GOTO(zen_rng_fill(Z, seed, sizeof(seed)) == 0, "Random generator unavailable");
 	SAFE_GOTO(PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair_derand((unsigned char*)public->val,
 					     (unsigned char*)private->val, seed) == 0, "Could not create key pair");
@@ -1007,7 +1007,7 @@ static int qp_sntrup_kem_keygen(lua_State *L) {
 	octet *public = o_new(L, PQCLEAN_SNTRUP761_CLEAN_CRYPTO_PUBLICKEYBYTES); SAFE(public, "Could not create public key");
 	lua_setfield(L, -2, "public");
 
-	zenroom_t *Z = zen_get_global_context();
+	zenroom_t *Z = zen_get_context(L);
 	SAFE_GOTO(PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair_rng((unsigned char*)public->val,
 		(unsigned char*)private->val, zen_rng_callback_fill, Z) == 0, "Could not create key pair");
 	public->len = PQCLEAN_SNTRUP761_CLEAN_CRYPTO_PUBLICKEYBYTES;

--- a/src/zen_qp.c
+++ b/src/zen_qp.c
@@ -45,6 +45,8 @@
 #define PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES          2420
 #define PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_ALGNAME        "Dilithium2"
 extern int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair_derand(uint8_t *pk, uint8_t *sk,
+	const uint8_t seed[32]);
 extern int PQCLEAN_DILITHIUM2_CLEAN_crypto_pub_gen(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(
 	uint8_t *sig, size_t *siglen,
@@ -69,8 +71,12 @@ extern int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_open(
 #define PQCLEAN_KYBER512_CLEAN_CRYPTO_ALGNAME         "Kyber512"
 #define KYBER_SSBYTES                                 32   /* size in bytes of shared key */
 extern int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair_derand(uint8_t *pk, uint8_t *sk,
+	const uint8_t coins[64]);
 extern int PQCLEAN_KYBER512_CLEAN_crypto_pub_gen(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+extern int PQCLEAN_KYBER512_CLEAN_crypto_kem_enc_derand(uint8_t *ct, uint8_t *ss,
+	const uint8_t *pk, const uint8_t coins[32]);
 extern int PQCLEAN_KYBER512_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
 
 /*
@@ -125,8 +131,12 @@ extern int mlkem1024_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
 #define PQCLEAN_SNTRUP761_CLEAN_CRYPTO_BYTES           32
 #define PQCLEAN_SNTRUP761_CLEAN_CRYPTO_ALGNAME         "sntrup761"
 extern int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair_rng(uint8_t *pk, uint8_t *sk,
+    zen_rng_callback fill, void *context);
 extern int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_pubgen(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+extern int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc_rng(uint8_t *ct, uint8_t *ss, const uint8_t *pk,
+    zen_rng_callback fill, void *context);
 extern int PQCLEAN_SNTRUP761_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
 
 
@@ -148,14 +158,17 @@ extern int pqcrystals_ml_dsa_44_zen_pub_gen(uint8_t *pk, uint8_t *sk);
 static int qp_signature_keygen(lua_State *L) {
 	BEGIN();
 	char *failed_msg = NULL;
+	uint8_t seed[32];
 	lua_createtable(L, 0, 2);
 	octet *private = o_new(L, PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_SECRETKEYBYTES); SAFE_GOTO(private, "Could not create private key");
 	lua_setfield(L, -2, "private");
 	octet *public = o_new(L, PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_PUBLICKEYBYTES); SAFE_GOTO(public, "Could not create public key");
 	lua_setfield(L, -2, "public");
 
-	PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair((unsigned char*)public->val,
-						     (unsigned char*)private->val);
+	zenroom_t *Z = zen_get_global_context();
+	SAFE_GOTO(zen_rng_fill(Z, seed, sizeof(seed)) == 0, "Random generator unavailable");
+	SAFE_GOTO(PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair_derand((unsigned char*)public->val,
+					     (unsigned char*)private->val, seed) == 0, "Could not create key pair");
 	public->len = PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_PUBLICKEYBYTES;
 	private->len = PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_SECRETKEYBYTES;
 end:
@@ -327,13 +340,19 @@ end:
 /*#######################################*/
 static int qp_kem_keygen(lua_State *L) {
 	BEGIN();
+	uint8_t coins[64];
 	lua_createtable(L, 0, 2);
 	octet *private = o_new(L, PQCLEAN_KYBER512_CLEAN_CRYPTO_SECRETKEYBYTES); SAFE(private, "Could not create private key");
 	lua_setfield(L, -2, "private");
 	octet *public = o_new(L, PQCLEAN_KYBER512_CLEAN_CRYPTO_PUBLICKEYBYTES); SAFE(public, "Could not create public key");
 	lua_setfield(L, -2, "public");
 
-	PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair((unsigned char*)public->val, (unsigned char*)private->val);
+	zenroom_t *Z = zen_get_context(L);
+	if(zen_rng_fill(Z, coins, sizeof(coins)) != 0)
+		return luaL_error(L, "QP Kyber RNG unavailable");
+	if(PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair_derand((unsigned char*)public->val,
+		(unsigned char*)private->val, coins) != 0)
+		return luaL_error(L, "QP Kyber derand keypair failed");
 	public->len = PQCLEAN_KYBER512_CLEAN_CRYPTO_PUBLICKEYBYTES;
 	private->len = PQCLEAN_KYBER512_CLEAN_CRYPTO_SECRETKEYBYTES;
 	END(1);
@@ -396,6 +415,7 @@ static int qp_kem_ctcheck(lua_State *L) {
 static int qp_enc(lua_State *L) {
 	BEGIN();
 	char *failed_msg = NULL;
+	uint8_t coins[32];
 	const octet *pk = NULL;
 	octet *ss = NULL, *ct = NULL;
 	pk = o_arg(L, 1); SAFE_GOTO(pk, "Could not allocate public key");
@@ -405,10 +425,12 @@ static int qp_enc(lua_State *L) {
 	lua_setfield(L, -2, "secret"); // shared secret
 	ct = o_new(L, PQCLEAN_KYBER512_CLEAN_CRYPTO_CIPHERTEXTBYTES); SAFE_GOTO(ct, "Could not create kem ciphertext");
 	lua_setfield(L, -2, "cipher");
-	SAFE_GOTO(!PQCLEAN_KYBER512_CLEAN_crypto_kem_enc(
+	zenroom_t *Z = zen_get_context(L);
+	SAFE_GOTO(zen_rng_fill(Z, coins, sizeof(coins)) == 0, "Random generator unavailable");
+	SAFE_GOTO(!PQCLEAN_KYBER512_CLEAN_crypto_kem_enc_derand(
 		(unsigned char*)ct->val,
 		(unsigned char*)ss->val,
-		(unsigned char*)pk->val),
+		(unsigned char*)pk->val, coins),
 		"Could not encrypt the shared secret"
 	);
 	ss->len = KYBER_SSBYTES;
@@ -515,9 +537,7 @@ static int mlkem_keygen(lua_State *L) {
 		memcpy(randbytes,rnd->val,32);
 	} else {
 		zenroom_t *Z = zen_get_context(L);
-		for(uint8_t i=0;i<32;i++) {
-			randbytes[i] = RAND_byte(Z->random_generator);
-		}
+		SAFE(zen_rng_fill(Z, randbytes, 32) == 0, "Random generator unavailable");
 	}
 	ud = luaL_testudata(L,2,"zenroom.octet");
 	if (ud){
@@ -526,9 +546,7 @@ static int mlkem_keygen(lua_State *L) {
 		memcpy(&randbytes[32],rnd->val,32);
 	} else {
 		zenroom_t *Z = zen_get_context(L);
-		for(uint8_t i=32;i<64;i++) {
-			randbytes[i] = RAND_byte(Z->random_generator);
-		}
+		SAFE(zen_rng_fill(Z, randbytes + 32, 32) == 0, "Random generator unavailable");
 	}
 	octet *private, *public;
 	const char *s = lua_tostring(L, 3);
@@ -826,9 +844,7 @@ static int mlkem_enc(lua_State *L) {
 		memcpy(randbytes,rnd->val,32);
 	} else {
 		zenroom_t *Z = zen_get_context(L);
-		for(uint8_t i = 0; i < 32; i++) {
-			randbytes[i] = RAND_byte(Z -> random_generator);
-		}
+		SAFE_GOTO(zen_rng_fill(Z, randbytes, sizeof(randbytes)) == 0, "Random generator unavailable");
 	}
 	const char *s = lua_tostring(L, 3);
 	if(!s) s = "mlkem512";
@@ -984,16 +1000,22 @@ end:
 /*#######################################*/
 static int qp_sntrup_kem_keygen(lua_State *L) {
 	BEGIN();
+	char *failed_msg = NULL;
 	lua_createtable(L, 0, 2);
 	octet *private = o_new(L, PQCLEAN_SNTRUP761_CLEAN_CRYPTO_SECRETKEYBYTES); SAFE(private, "Could not create private key");
 	lua_setfield(L, -2, "private");
 	octet *public = o_new(L, PQCLEAN_SNTRUP761_CLEAN_CRYPTO_PUBLICKEYBYTES); SAFE(public, "Could not create public key");
 	lua_setfield(L, -2, "public");
 
-	PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair((unsigned char*)public->val,
-						   (unsigned char*)private->val);
+	zenroom_t *Z = zen_get_global_context();
+	SAFE_GOTO(PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair_rng((unsigned char*)public->val,
+		(unsigned char*)private->val, zen_rng_callback_fill, Z) == 0, "Could not create key pair");
 	public->len = PQCLEAN_SNTRUP761_CLEAN_CRYPTO_PUBLICKEYBYTES;
 	private->len = PQCLEAN_SNTRUP761_CLEAN_CRYPTO_SECRETKEYBYTES;
+end:
+	if(failed_msg) {
+		THROW(failed_msg);
+	}
 	END(1);
 }
 
@@ -1060,10 +1082,11 @@ static int qp_sntrup_kem_enc(lua_State *L) {
 	lua_setfield(L, -2, "secret"); // shared secret
 	ct = o_new(L, PQCLEAN_SNTRUP761_CLEAN_CRYPTO_CIPHERTEXTBYTES); SAFE_GOTO(ct, "Could not allocate kem ciphertext");
 	lua_setfield(L, -2, "cipher");
-	SAFE_GOTO(!PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc(
+	zenroom_t *Z = zen_get_context(L);
+	SAFE_GOTO(!PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc_rng(
 		(unsigned char*)ct->val,
 		(unsigned char*)ss->val,
-		(unsigned char*)pk->val),
+		(unsigned char*)pk->val, zen_rng_callback_fill, Z),
 		"Could not encrypt the shared secret"
 	)
 	ss->len = PQCLEAN_SNTRUP761_CLEAN_CRYPTO_BYTES;
@@ -1167,7 +1190,7 @@ static int ml_dsa_44_keypair(lua_State *L)   {
 	}
 	else {
 		zenroom_t *Z = zen_get_context(L);
-		for(uint8_t i=0;i<32;i++) randbytes[i] = RAND_byte(Z->random_generator);
+		SAFE(zen_rng_fill(Z, randbytes, sizeof(randbytes)) == 0, "Random generator unavailable");
 	}
 	pqcrystals_ml_dsa_44_zen_keypair((unsigned char*)public->val,
 						     (unsigned char*)private->val, randbytes);
@@ -1264,9 +1287,9 @@ static int ml_dsa_44_signature(lua_State *L) {
 		if(sum == 0) {
 			for(uint8_t i=0;i<32;i++) randbytes[i] = 0;			
 		}
-		else for(uint8_t i=0;i<32;i++) randbytes[i] = RAND_byte(Z->random_generator);
+		else SAFE_GOTO(zen_rng_fill(Z, randbytes, sizeof(randbytes)) == 0, "Random generator unavailable");
 	}
-	else for(uint8_t i=0;i<32;i++) randbytes[i] = RAND_byte(Z->random_generator);
+	else SAFE_GOTO(zen_rng_fill(Z, randbytes, sizeof(randbytes)) == 0, "Random generator unavailable");
 	
 	void *ud =luaL_testudata(L,3,"zenroom.octet");
 	if (ud){

--- a/src/zen_random.c
+++ b/src/zen_random.c
@@ -40,8 +40,6 @@
 #include <zen_error.h>
 #include <lua_functions.h>
 
-#include <time.h>
-
 #include <amcl.h>
 
 // easier name (csprng comes from amcl.h in milagro)
@@ -57,41 +55,84 @@
 #include <zen_octet.h>
 #include <randombytes.h>
 
+static void zen_rng_zeroize(void *buffer, size_t len) {
+	volatile uint8_t *out = buffer;
+	while(len--) *out++ = 0;
+}
 
-void* rng_alloc(zenroom_t *ZZ) {
-	RNG *rng = (RNG*)zmalloc(sizeof(csprng));
+int zen_entropy_fill(void *buffer, size_t len) {
+	if(len == 0) return 0;
+	if(!buffer) return -1;
+	return randombytes(buffer, len) == 0 ? 0 : -1;
+}
+
+int zen_rng_init(zenroom_t *Z, const void *seed, size_t seed_len) {
+	/* The RNG outlives any temporary allocator policy, so own it directly. */
+	RNG *rng = (RNG*)malloc(sizeof(csprng));
 	if(!rng) {
 		_err( "Error allocating new random number generator");
+		return -1;
+	}
+	Z->random_generator = rng;
+	if(zen_rng_reseed(Z, seed, seed_len) != 0) {
+		zen_rng_clear(Z);
+		return -1;
+	}
+	return 0;
+}
+
+int zen_rng_reseed(zenroom_t *Z, const void *seed, size_t seed_len) {
+	if(!Z || !Z->random_generator || !seed || seed_len == 0 || seed_len > INT_MAX) return -1;
+	/* RAND_seed mutates its raw input: always preserve caller-owned seed data. */
+	char *raw = malloc(seed_len);
+	if(!raw) return -1;
+	memcpy(raw, seed, seed_len);
+	AMCL_(RAND_seed)((RNG *)Z->random_generator, (int)seed_len, raw);
+	zen_rng_zeroize(raw, seed_len);
+	free(raw);
+	return 0;
+}
+
+int zen_rng_fill(zenroom_t *Z, void *buffer, size_t len) {
+	if(len == 0) return 0;
+	if(!Z || !Z->random_generator || !buffer) return -1;
+	uint8_t *out = buffer;
+	for(size_t i = 0; i < len; i++) out[i] = RAND_byte((RNG *)Z->random_generator);
+	return 0;
+}
+
+int zen_rng_callback_fill(void *context, void *buffer, size_t len) {
+	return zen_rng_fill((zenroom_t *)context, buffer, len);
+}
+
+void zen_rng_clear(zenroom_t *Z) {
+	if(!Z || !Z->random_generator) return;
+	RAND_clean((RNG *)Z->random_generator);
+	zen_rng_zeroize(Z->random_generator, sizeof(RNG));
+	free(Z->random_generator);
+	Z->random_generator = NULL;
+}
+
+void* rng_alloc(zenroom_t *Z) {
+	if(!Z) return NULL;
+	/* Cortex-M retains its established deterministic zero-seed startup path.
+	 * Its board-specific entropy adapter is not validated by this runtime. */
+#ifndef ARCH_CORTEX
+	if(!Z->random_external && zen_entropy_fill(Z->random_seed, RANDOM_SEED_LEN) != 0) {
+		_err("Error gathering operating-system entropy");
 		return NULL;
 	}
-
-	// random seed provided externally 
-	if(ZZ->random_external) {
-#ifndef ARCH_CORTEX
-	} else {
-		// gather system random using randombytes()
-		randombytes(ZZ->random_seed,RANDOM_SEED_LEN-4);
-		// using time() from milagro
-		unsign32 ttmp = (unsign32)time(NULL);
-		ZZ->random_seed[60] = (ttmp >> 24) & 0xff;
-		ZZ->random_seed[61] = (ttmp >> 16) & 0xff;
-		ZZ->random_seed[62] = (ttmp >>  8) & 0xff;
-		ZZ->random_seed[63] =  ttmp & 0xff;
 #endif
-	}
-	// RAND_seed is destructive, preserve seed here
-	char tseed[RANDOM_SEED_LEN];
-	memcpy(tseed,ZZ->random_seed,RANDOM_SEED_LEN);
-	AMCL_(RAND_seed)(rng, RANDOM_SEED_LEN, tseed);
-	// return into ZZ->random_generator
-	return(rng);
+	return zen_rng_init(Z, Z->random_seed, RANDOM_SEED_LEN) == 0
+		? Z->random_generator : NULL;
 }
 
 
 static int rng_uint8(lua_State *L) {
 	BEGIN();
 	zenroom_t *Z = zen_get_context(L);
-	uint8_t res = RAND_byte(Z->random_generator);
+	uint8_t res;
+	if(zen_rng_fill(Z, &res, sizeof(res)) != 0) return luaL_error(L, "Random generator unavailable");
 	lua_pushinteger(L, (lua_Integer)res);
 	END(1);
 }
@@ -99,9 +140,9 @@ static int rng_uint8(lua_State *L) {
 static int rng_uint16(lua_State *L) {
 	BEGIN();
 	zenroom_t *Z = zen_get_context(L);
-	uint16_t res =
-		RAND_byte(Z->random_generator)
-		| (uint32_t) RAND_byte(Z->random_generator) << 8;
+	uint8_t bytes[2];
+	if(zen_rng_fill(Z, bytes, sizeof(bytes)) != 0) return luaL_error(L, "Random generator unavailable");
+	uint16_t res = bytes[0] | (uint16_t)bytes[1] << 8;
 	lua_pushinteger(L, (lua_Integer)res);
 	END(1);
 }
@@ -109,11 +150,10 @@ static int rng_uint16(lua_State *L) {
 static int rng_int32(lua_State *L) {
 	BEGIN();
 	zenroom_t *Z = zen_get_context(L);
-	uint32_t res =
-		RAND_byte(Z->random_generator)
-		| (uint32_t) RAND_byte(Z->random_generator) << 8
-		| (uint32_t) RAND_byte(Z->random_generator) << 16
-		| (uint32_t) RAND_byte(Z->random_generator) << 24;
+	uint8_t bytes[4];
+	if(zen_rng_fill(Z, bytes, sizeof(bytes)) != 0) return luaL_error(L, "Random generator unavailable");
+	uint32_t res = bytes[0] | (uint32_t)bytes[1] << 8 |
+		(uint32_t)bytes[2] << 16 | (uint32_t)bytes[3] << 24;
 	lua_pushinteger(L, (lua_Integer)res);
 	END(1);
 }
@@ -127,19 +167,21 @@ static int rng_seed(lua_State *L) {
 		lua_pushnil(L);
 		goto end;
 	}
-	AMCL_(RAND_seed)(Z->random_generator, in->len, in->val);
+	if(zen_rng_reseed(Z, in->val, in->len) != 0) {
+		zerror(L, "Random seed error: unsupported seed length (%u bytes)", in->len);
+		lua_pushnil(L);
+		goto end;
+	}
 	o_dup(L,in); // push seed to Lua stack for setglobal
 	lua_setglobal(L, "RNGSEED");
 	octet *rr = o_new(L, PRNG_PREROLL);
 	for(register int i=0;i<PRNG_PREROLL;i++)
-		rr->val[i] = RAND_byte(Z->random_generator);
+		if(zen_rng_fill(Z, &rr->val[i], 1) != 0) return luaL_error(L, "Random generator unavailable");
 	rr->len = PRNG_PREROLL;
 	// HEREoct(rr);
 	// plus 4 bytes used by Lua init
-	RAND_byte(Z->random_generator);
-	RAND_byte(Z->random_generator);
-	RAND_byte(Z->random_generator);
-	RAND_byte(Z->random_generator);
+	uint8_t discarded[4];
+	if(zen_rng_fill(Z, discarded, sizeof(discarded)) != 0) return luaL_error(L, "Random generator unavailable");
 	// return "runtime random" fingerprint
 	end:
 	o_free(L,in);
@@ -169,7 +211,7 @@ void zen_add_random(lua_State *L) {
 		register int i;
 		register char *p = Z->runtime_random256;
 		for(i=0;i<PRNG_PREROLL;i++,p++)
-		  *p = RAND_byte(Z->random_generator);
+		  if(zen_rng_fill(Z, p, 1) != 0) luaL_error(L, "Random generator unavailable");
 	}
 
 }

--- a/src/zen_random.c
+++ b/src/zen_random.c
@@ -67,6 +67,7 @@ int zen_entropy_fill(void *buffer, size_t len) {
 }
 
 int zen_rng_init(zenroom_t *Z, const void *seed, size_t seed_len) {
+	if(!Z || !seed || seed_len == 0 || seed_len > INT_MAX) return -1;
 	/* The RNG outlives any temporary allocator policy, so own it directly. */
 	RNG *rng = (RNG*)malloc(sizeof(csprng));
 	if(!rng) {

--- a/src/zen_random.c
+++ b/src/zen_random.c
@@ -67,7 +67,7 @@ int zen_entropy_fill(void *buffer, size_t len) {
 }
 
 int zen_rng_init(zenroom_t *Z, const void *seed, size_t seed_len) {
-	if(!Z || !seed || seed_len == 0 || seed_len > INT_MAX) return -1;
+	if(!Z || Z->random_generator || !seed || seed_len == 0 || seed_len > INT_MAX) return -1;
 	/* The RNG outlives any temporary allocator policy, so own it directly. */
 	RNG *rng = (RNG*)malloc(sizeof(csprng));
 	if(!rng) {

--- a/src/zenroom.c
+++ b/src/zenroom.c
@@ -356,8 +356,7 @@ void zen_teardown(zenroom_t *ZZ) {
 
 	// stateful RNG instance for deterministic mode
 	if(ZZ->random_generator) {
-		free(ZZ->random_generator);
-		ZZ->random_generator = NULL;
+		zen_rng_clear(ZZ);
 	}
 
 	if(L && ZZ->logformat == LOG_JSON) json_end(L);

--- a/src/zenroom.h
+++ b/src/zenroom.h
@@ -225,6 +225,26 @@ typedef struct {
 	int exitcode;
 } zenroom_t;
 
+/*
+ * VM-owned randomness service.
+ *
+ * The compatibility backend is Milagro's csprng, kept opaque so consumers do
+ * not need to depend on its type.  A successful call to zen_rng_fill() draws
+ * exactly len bytes in request order; it does not buffer or prefetch bytes.
+ * Zero-length requests succeed and may use a NULL buffer.  All other NULL
+ * buffers, uninitialised contexts, and entropy-source failures return -1.
+ * Contexts are independent and must not be shared between threads without
+ * caller-provided synchronisation.
+ */
+typedef int (*zen_rng_callback)(void *context, void *buffer, size_t len);
+
+int zen_entropy_fill(void *buffer, size_t len);
+int zen_rng_init(zenroom_t *context, const void *seed, size_t seed_len);
+int zen_rng_reseed(zenroom_t *context, const void *seed, size_t seed_len);
+int zen_rng_fill(zenroom_t *context, void *buffer, size_t len);
+int zen_rng_callback_fill(void *context, void *buffer, size_t len);
+void zen_rng_clear(zenroom_t *context);
+
 // ZENCODE EXEC SCOPE
 #define SCOPE_FULL 0
 #define SCOPE_GIVEN 1

--- a/test/api/longfellow_rng_failure.cc
+++ b/test/api/longfellow_rng_failure.cc
@@ -1,0 +1,59 @@
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <longfellow-zk/circuits/mdoc/mdoc_rng_adapter.h>
+
+struct DeterministicRng {
+  uint32_t state;
+  size_t calls;
+};
+
+static int deterministic_rng(void* context, void* output, size_t length) {
+  auto* rng = static_cast<DeterministicRng*>(context);
+  auto* out = static_cast<uint8_t*>(output);
+  ++rng->calls;
+  for (size_t i = 0; i < length; ++i) {
+    rng->state = rng->state * 1664525u + 1013904223u;
+    out[i] = static_cast<uint8_t>(rng->state >> 24);
+  }
+  return 0;
+}
+
+static int failing_rng(void* context, void* output, size_t length) {
+  ++*static_cast<size_t*>(context);
+  std::memset(output, 0xa5, length);
+  return -1;
+}
+
+static std::vector<uint8_t> sample(proofs::CallbackRandomEngine& engine) {
+  std::vector<uint8_t> bytes(96);
+  engine.bytes(bytes.data(), bytes.size());
+  return bytes;
+}
+
+int main() {
+  DeterministicRng first{1, 0}, same{1, 0}, different{2, 0};
+  proofs::CallbackRandomEngine first_engine(deterministic_rng, &first);
+  proofs::CallbackRandomEngine same_engine(deterministic_rng, &same);
+  proofs::CallbackRandomEngine different_engine(deterministic_rng, &different);
+  const std::vector<uint8_t> first_bytes = sample(first_engine);
+  const std::vector<uint8_t> same_bytes = sample(same_engine);
+  const std::vector<uint8_t> different_bytes = sample(different_engine);
+
+  size_t failures = 0;
+  proofs::CallbackRandomEngine failed_engine(failing_rng, &failures);
+  const std::vector<uint8_t> failed_bytes = sample(failed_engine);
+  proofs::CallbackRandomEngine null_engine(nullptr, nullptr);
+  const std::vector<uint8_t> null_bytes = sample(null_engine);
+  const std::vector<uint8_t> zeroes(96, 0);
+
+  return first.calls == 1 && same.calls == 1 && different.calls == 1 &&
+                 first_bytes == same_bytes && first_bytes != different_bytes &&
+                 !first_engine.failed() && !same_engine.failed() &&
+                 !different_engine.failed() && failures == 1 &&
+                 failed_engine.failed() && failed_bytes == zeroes &&
+                 null_engine.failed() && null_bytes == zeroes
+             ? 0
+             : 1;
+}

--- a/test/api/pq_compat_rng_failure.c
+++ b/test/api/pq_compat_rng_failure.c
@@ -1,0 +1,43 @@
+#include <stdint.h>
+#include <string.h>
+
+#include "../../lib/pqclean/dilithium2/api.h"
+#include "../../lib/pqclean/kyber512/api.h"
+
+int main(void) {
+	uint8_t dilithium_pk[PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_PUBLICKEYBYTES];
+	uint8_t dilithium_sk[PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_SECRETKEYBYTES];
+	uint8_t kyber_pk[PQCLEAN_KYBER512_CLEAN_CRYPTO_PUBLICKEYBYTES];
+	uint8_t kyber_sk[PQCLEAN_KYBER512_CLEAN_CRYPTO_SECRETKEYBYTES];
+	uint8_t ciphertext[PQCLEAN_KYBER512_CLEAN_CRYPTO_CIPHERTEXTBYTES];
+	uint8_t shared_secret[PQCLEAN_KYBER512_CLEAN_CRYPTO_BYTES];
+
+	memset(dilithium_pk, 0xa5, sizeof(dilithium_pk));
+	memset(dilithium_sk, 0xa5, sizeof(dilithium_sk));
+	memset(kyber_pk, 0xa5, sizeof(kyber_pk));
+	memset(kyber_sk, 0xa5, sizeof(kyber_sk));
+	memset(ciphertext, 0xa5, sizeof(ciphertext));
+	memset(shared_secret, 0xa5, sizeof(shared_secret));
+
+	if(PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(
+			dilithium_pk, dilithium_sk) == 0) return 1;
+	if(PQCLEAN_KYBER512_CLEAN_crypto_kem_keypair(kyber_pk, kyber_sk) == 0)
+		return 2;
+	if(PQCLEAN_KYBER512_CLEAN_crypto_kem_enc(
+			ciphertext, shared_secret, kyber_pk) == 0) return 3;
+
+	for(size_t i = 0; i < sizeof(dilithium_pk); i++)
+		if(dilithium_pk[i] != 0xa5) return 4;
+	for(size_t i = 0; i < sizeof(dilithium_sk); i++)
+		if(dilithium_sk[i] != 0xa5) return 5;
+	for(size_t i = 0; i < sizeof(kyber_pk); i++)
+		if(kyber_pk[i] != 0xa5) return 6;
+	for(size_t i = 0; i < sizeof(kyber_sk); i++)
+		if(kyber_sk[i] != 0xa5) return 7;
+	for(size_t i = 0; i < sizeof(ciphertext); i++)
+		if(ciphertext[i] != 0xa5) return 8;
+	for(size_t i = 0; i < sizeof(shared_secret); i++)
+		if(shared_secret[i] != 0xa5) return 9;
+
+	return 0;
+}

--- a/test/api/rng.bats
+++ b/test/api/rng.bats
@@ -14,6 +14,13 @@ load ../bats_setup
     assert_success
 }
 
+@test "RNG service :: runtime consumers preserve fixed-seed streams" {
+    run "$ZENROOM_EXECUTABLE" \
+        -c rngseed=hex:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f \
+        "$T/rng_consumers.lua"
+    assert_success
+}
+
 @test "RNG service :: SNTRUP callback failure is closed" {
     local ldadd="-L$R -lzenroom"
     local cflags="${CFLAGS:-} -I$R/src -I$R/lib/pqclean/sntrup761"

--- a/test/api/rng.bats
+++ b/test/api/rng.bats
@@ -13,3 +13,25 @@ load ../bats_setup
     run env LD_LIBRARY_PATH="$R" ./rng_service
     assert_success
 }
+
+@test "RNG service :: SNTRUP callback failure is closed" {
+    local ldadd="-L$R -lzenroom"
+    local cflags="${CFLAGS:-} -I$R/src -I$R/lib/pqclean/sntrup761"
+    if strings "$R/libzenroom.so" | grep -q "__asan_init"; then
+        ldadd="$ldadd -fsanitize=address,undefined"
+        cflags="$cflags -fsanitize=address,undefined"
+    fi
+    cc $cflags -ggdb -o sntrup_rng_failure "$T/sntrup_rng_failure.c" $ldadd
+    run env LD_LIBRARY_PATH="$R" ./sntrup_rng_failure
+    assert_success
+}
+
+@test "RNG service :: Longfellow callback adapter is deterministic and closed" {
+    local cflags="${CXXFLAGS:-} -I$R/lib -I$R/lib/longfellow-zk"
+    if strings "$R/libzenroom.so" | grep -q "__asan_init"; then
+        cflags="$cflags -fsanitize=address,undefined"
+    fi
+    c++ $cflags -std=c++17 -ggdb -o longfellow_rng_failure "$T/longfellow_rng_failure.cc"
+    run ./longfellow_rng_failure
+    assert_success
+}

--- a/test/api/rng.bats
+++ b/test/api/rng.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load ../bats_setup
+
+@test "RNG service :: checked and request-order compatible" {
+    local ldadd="-L$R -lzenroom"
+    local cflags="${CFLAGS:-} -I$R/src"
+    if strings "$R/libzenroom.so" | grep -q "__asan_init"; then
+        ldadd="$ldadd -fsanitize=address,undefined"
+        cflags="$cflags -fsanitize=address,undefined"
+    fi
+    cc $cflags -ggdb -o rng_service "$T/rng_service.c" $ldadd
+    run env LD_LIBRARY_PATH="$R" ./rng_service
+    assert_success
+}

--- a/test/api/rng.bats
+++ b/test/api/rng.bats
@@ -14,6 +14,19 @@ load ../bats_setup
     assert_success
 }
 
+@test "RNG service :: unseeded PQ compatibility APIs fail closed" {
+    local ldadd="-L$R -lzenroom"
+    local cflags="${CFLAGS:-} -I$R/src"
+    if strings "$R/libzenroom.so" | grep -q "__asan_init"; then
+        ldadd="$ldadd -fsanitize=address,undefined"
+        cflags="$cflags -fsanitize=address,undefined"
+    fi
+    cc $cflags -ggdb -o pq_compat_rng_failure \
+        "$T/pq_compat_rng_failure.c" $ldadd
+    run env LD_LIBRARY_PATH="$R" ./pq_compat_rng_failure
+    assert_success
+}
+
 @test "RNG service :: runtime consumers preserve fixed-seed streams" {
     run "$ZENROOM_EXECUTABLE" \
         -c rngseed=hex:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f \

--- a/test/api/rng_audit.bats
+++ b/test/api/rng_audit.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+load ../bats_setup
+
+@test "RNG service :: bypass audit and self-test" {
+    run "$R/test/rng/no-bypass.sh"
+    assert_success
+    run "$R/test/rng/no-bypass.sh" --self-test
+    assert_success
+}
+
+@test "RNG service :: Cortex-M initialization object remains buildable" {
+    run cc ${CFLAGS:-} -std=c11 -DARCH_CORTEX -I"$R/src" \
+        -I"$R/lib/lua54/src" -I"$R/lib/milagro-crypto-c/build/include" \
+        -I"$R/lib/milagro-crypto-c/include" -c "$R/src/zen_random.c" \
+        -o "$TMP/zen_random_cortex.o"
+    assert_success
+}

--- a/test/api/rng_consumers.lua
+++ b/test/api/rng_consumers.lua
@@ -1,0 +1,19 @@
+local ED = require('ed')
+local P256 = require('es256')
+
+assert(OCTET.random(8):hex() == 'ae5a0eeaccdb66df',
+       'OCTET.random stream changed')
+assert(ED.secgen():hex() ==
+       '8d547d3fcbec6c3df77dd4a78633e29d5d5564e3069b4597796568b19c2f17fe',
+       'EdDSA key generation stream changed')
+assert(P256.keygen():hex() ==
+       '4666cd0285a3bce367f5f0545fed7340725f45cc880e1780e9e28438ec5d1034',
+       'P-256 key generation stream changed')
+
+local original = OCTET.from_hex('000102030405060708090a0b0c0d0e0f')
+assert(original:fuzz_byte_xor():hex() ==
+       '00fe02030405060708090a0b0c0d0e0f',
+       'byte fuzzer stream changed')
+assert(original:fuzz_bit():hex() ==
+       '000102030405060708090a0b0c0d0e1f',
+       'bit fuzzer stream changed')

--- a/test/api/rng_service.c
+++ b/test/api/rng_service.c
@@ -15,6 +15,7 @@ int main(void) {
 	if(zen_rng_fill(NULL, NULL, 0) != 0 || zen_rng_fill(NULL, seed, 1) == 0) return 2;
 	if(zen_rng_init(NULL, seed, sizeof(seed)) == 0) return 3;
 	if(zen_rng_init(&first, seed, sizeof(seed)) != 0) return 3;
+	if(zen_rng_init(&first, seed, sizeof(seed)) == 0) return 3;
 	if(zen_rng_init(&second, seed, sizeof(seed)) != 0) return 4;
 	if(zen_rng_fill(&first, split, 1) != 0 ||
 	   zen_rng_callback_fill(&first, split + 1, sizeof(split) - 1) != 0 ||
@@ -27,6 +28,8 @@ int main(void) {
 	   zen_rng_reseed(&first, seed, 0) == 0) return 7;
 	zen_rng_clear(&first);
 	zen_rng_clear(&second);
+	zen_rng_clear(&second);
 	if(zen_rng_fill(&first, split, sizeof(split)) == 0) return 8;
+	if(zen_rng_reseed(&first, seed, sizeof(seed)) == 0) return 9;
 	return 0;
 }

--- a/test/api/rng_service.c
+++ b/test/api/rng_service.c
@@ -13,6 +13,7 @@ int main(void) {
 	for(size_t i = 0; i < sizeof(seed); i++) seed[i] = (uint8_t)i;
 	if(zen_entropy_fill(NULL, 0) != 0 || zen_entropy_fill(NULL, 1) == 0) return 1;
 	if(zen_rng_fill(NULL, NULL, 0) != 0 || zen_rng_fill(NULL, seed, 1) == 0) return 2;
+	if(zen_rng_init(NULL, seed, sizeof(seed)) == 0) return 3;
 	if(zen_rng_init(&first, seed, sizeof(seed)) != 0) return 3;
 	if(zen_rng_init(&second, seed, sizeof(seed)) != 0) return 4;
 	if(zen_rng_fill(&first, split, 1) != 0 ||

--- a/test/api/rng_service.c
+++ b/test/api/rng_service.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <string.h>
+
+#include <zenroom.h>
+
+int main(void) {
+	zenroom_t first = {0};
+	zenroom_t second = {0};
+	uint8_t seed[RANDOM_SEED_LEN];
+	uint8_t split[RANDOM_SEED_LEN];
+	uint8_t whole[RANDOM_SEED_LEN];
+
+	for(size_t i = 0; i < sizeof(seed); i++) seed[i] = (uint8_t)i;
+	if(zen_entropy_fill(NULL, 0) != 0 || zen_entropy_fill(NULL, 1) == 0) return 1;
+	if(zen_rng_fill(NULL, NULL, 0) != 0 || zen_rng_fill(NULL, seed, 1) == 0) return 2;
+	if(zen_rng_init(&first, seed, sizeof(seed)) != 0) return 3;
+	if(zen_rng_init(&second, seed, sizeof(seed)) != 0) return 4;
+	if(zen_rng_fill(&first, split, 1) != 0 ||
+	   zen_rng_callback_fill(&first, split + 1, sizeof(split) - 1) != 0 ||
+	   zen_rng_fill(&second, whole, sizeof(whole)) != 0 ||
+	   memcmp(split, whole, sizeof(whole)) != 0) return 5;
+	if(zen_rng_reseed(&first, seed, sizeof(seed)) != 0 ||
+	   zen_rng_fill(&first, split, sizeof(split)) != 0 ||
+	   memcmp(split, whole, sizeof(whole)) != 0) return 6;
+	if(zen_rng_reseed(&first, NULL, sizeof(seed)) == 0 ||
+	   zen_rng_reseed(&first, seed, 0) == 0) return 7;
+	zen_rng_clear(&first);
+	zen_rng_clear(&second);
+	if(zen_rng_fill(&first, split, sizeof(split)) == 0) return 8;
+	return 0;
+}

--- a/test/api/sign_entropy_failure.c
+++ b/test/api/sign_entropy_failure.c
@@ -1,0 +1,42 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <zenroom.h>
+
+/* ELF interposition gives this focused test a deterministic failing entropy
+ * backend without adding a production-only injection API. */
+int randombytes(void *buffer, size_t length) {
+  (void)buffer;
+  (void)length;
+  return -1;
+}
+
+int main(void) {
+  char output[256] = "unchanged";
+  char error[256] = {0};
+  const char seed[] =
+      "0000000000000000000000000000000000000000000000000000000000000000"
+      "0000000000000000000000000000000000000000000000000000000000000000";
+
+  if (zenroom_sign_keygen_tobuf("eddsa", NULL, output, sizeof(output), error,
+                                sizeof(error)) == 0 || output[0] != '\0' ||
+      strstr(error, "error initializing the random generator") == NULL) {
+    return 1;
+  }
+  strcpy(output, "unchanged");
+  error[0] = '\0';
+  if (zenroom_sign_keygen_tobuf("eddsa", "00", output, sizeof(output), error,
+                                sizeof(error)) == 0 || output[0] != '\0' ||
+      strstr(error, "error initializing the random generator") == NULL) {
+    return 2;
+  }
+  if (zenroom_sign_keygen_tobuf("eddsa", seed, output, sizeof(output), error,
+                                sizeof(error)) != 0 ||
+      strcmp(output,
+             "06b4c6f4caf4234be9dedc6983412aaf50773e788e144e3e2cd09b56f21f744d") !=
+          0) {
+    return 3;
+  }
+  return 0;
+}

--- a/test/api/sign_rng.bats
+++ b/test/api/sign_rng.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+load ../bats_setup
+
+@test "SIGN API :: absent entropy fails closed while explicit seed is stable" {
+    local ldadd="-L$R -lzenroom"
+    local cflags="${CFLAGS:-} -I$R/src"
+    if strings "$R/libzenroom.so" | grep -q "__asan_init"; then
+        ldadd="$ldadd -fsanitize=address,undefined"
+        cflags="$cflags -fsanitize=address,undefined"
+    fi
+    cc $cflags -ggdb -Wl,--export-dynamic -o sign_entropy_failure \
+        "$T/sign_entropy_failure.c" $ldadd
+    run env LD_LIBRARY_PATH="$R" ./sign_entropy_failure
+    assert_success
+}

--- a/test/api/sntrup_rng_failure.c
+++ b/test/api/sntrup_rng_failure.c
@@ -1,0 +1,35 @@
+#include <stdint.h>
+
+#include "api.h"
+#include <zenroom.h>
+
+static int fail_rng(void *context, void *output, size_t length) {
+    (void)context;
+    (void)output;
+    (void)length;
+    return -1;
+}
+
+int main(void) {
+    uint8_t pk[PQCLEAN_SNTRUP761_CLEAN_CRYPTO_PUBLICKEYBYTES] = {0};
+    uint8_t sk[PQCLEAN_SNTRUP761_CLEAN_CRYPTO_SECRETKEYBYTES] = {0};
+    uint8_t ct[PQCLEAN_SNTRUP761_CLEAN_CRYPTO_CIPHERTEXTBYTES] = {0};
+    uint8_t ss[PQCLEAN_SNTRUP761_CLEAN_CRYPTO_BYTES] = {0};
+    uint8_t seed[RANDOM_SEED_LEN] = {0};
+    zenroom_t context = {0};
+
+    if (zen_rng_init(&context, seed, sizeof(seed)) != 0)
+        return 1;
+    if (PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair_rng(
+            pk, sk, zen_rng_callback_fill, &context) != 0) {
+        zen_rng_clear(&context);
+        return 2;
+    }
+    zen_rng_clear(&context);
+
+    if (PQCLEAN_SNTRUP761_CLEAN_crypto_kem_keypair_rng(pk, sk, fail_rng, NULL) == 0)
+        return 3;
+    if (PQCLEAN_SNTRUP761_CLEAN_crypto_kem_enc_rng(ct, ss, pk, fail_rng, NULL) == 0)
+        return 4;
+    return 0;
+}

--- a/test/lua/hash.lua
+++ b/test/lua/hash.lua
@@ -77,3 +77,21 @@ for i,h in ipairs(hash_algos) do
    print(h.." OK")
 end
 
+print " per-hash RNG deterministic reseed and teardown"
+local rng_seed = O.from_hex('000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f')
+local function check_hash_rng(H)
+   assert(H:random_int8() == 205, "HASH RNG int8 stream changed")
+   assert(H:random_int16() == 19626, "HASH RNG int16 stream changed")
+   assert(H:random_int32() == 1705168537, "HASH RNG int32 stream changed")
+end
+local H1 = HASH.new('sha256')
+local H2 = HASH.new('sha512')
+H1:random_seed(rng_seed)
+H2:random_seed(rng_seed)
+check_hash_rng(H1)
+check_hash_rng(H2)
+H1:random_seed(rng_seed)
+check_hash_rng(H1)
+H1, H2 = nil, nil
+collectgarbage('collect')
+print "HASH RNG OK"

--- a/test/rng/no-bypass.sh
+++ b/test/rng/no-bypass.sh
@@ -2,7 +2,9 @@
 set -Eeuo pipefail
 
 root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-pattern='(randombytes|RAND_bytes|getrandom|arc4random)[[:space:]]*\('
+entropy_pattern='(randombytes|RAND_bytes|getrandom|arc4random)[[:space:]]*\('
+backend_pattern='(RAND_byte|RAND_clean|OCT_rand|CREATE_CSPRNG|KILL_CSPRNG)[[:space:]]*\(|AMCL_\(RAND_seed\)[[:space:]]*\('
+generator_pattern='(->|\.)[[:space:]]*random_generator'
 
 # Runtime bridges must not retain relocations to a direct OS-RNG entry point or
 # to a legacy vendor convenience API.  The vendor archives deliberately retain
@@ -26,28 +28,110 @@ match_lines() {
 
 search_sources() {
     local path=$1
+    local expression=$2
     if command -v rg >/dev/null 2>&1; then
-        rg -n --glob '*.[ch]' -o "$pattern" "$path"
+        rg -n --glob '*.[ch]' --glob '*.cc' --glob '*.cpp' "$expression" "$path"
     else
-        find "$path" -type f \( -name '*.c' -o -name '*.h' \) \
-            -exec grep -EnH -o "$pattern" {} +
+        find "$path" -type f \( -name '*.c' -o -name '*.h' -o \
+            -name '*.cc' -o -name '*.cpp' \) \
+            -exec grep -EnH "$expression" {} +
     fi
 }
 
-audit() {
+audit_entropy_bypass() {
     local path=$1
     local hits
-    hits=$(search_sources "$path" || true)
+    hits=$(search_sources "$path" "$entropy_pattern" || true)
     while IFS= read -r hit; do
         [[ -z $hit ]] && continue
         case "$hit" in
             "$root/src/randombytes.c":*) ;;
             "$root/src/randombytes.h":*) ;;
-            "$root/src/zen_random.c":*:randombytes\(*) ;;
-            "$root/src/api_sign.c":*:randombytes\(*) ;;
+            "$root/src/zen_random.c":*) ;;
             *) printf 'forbidden RNG bypass: %s\n' "$hit" >&2; return 1 ;;
         esac
     done <<< "$hits"
+}
+
+audit_backend_bypass() {
+    local path=$1
+    local hits hit
+    hits=$(search_sources "$path" "$backend_pattern" || true)
+    while IFS= read -r hit; do
+        [[ -z $hit ]] && continue
+        case "$hit" in
+            # Sole compatibility-backend implementation.
+            "$root/src/zen_random.c":*) ;;
+            *) printf 'forbidden direct backend RNG access: %s\n' "$hit" >&2; return 1 ;;
+        esac
+    done <<< "$hits"
+}
+
+audit_generator_access() {
+    local path=$1
+    local allowed_root=${2:-}
+    local hits hit source_file source_line
+    local big_count=0 ecdh_count=0 rsa_count=0
+    [[ -n $allowed_root ]] || allowed_root="$root/src"
+    hits=$(search_sources "$path" "$generator_pattern" || true)
+    while IFS= read -r hit; do
+        [[ -z $hit ]] && continue
+        source_file=${hit%%:*}
+        source_line=${hit#*:}
+        source_line=${source_line#*:}
+        source_line=${source_line#"${source_line%%[![:space:]]*}"}
+        source_line=${source_line%"${source_line##*[![:space:]]}"}
+        case "$source_file" in
+            # Backend implementation and VM lifecycle ownership.
+            "$root/src/zen_random.c"|"$root/src/zenroom.c") ;;
+            # Milagro APIs with an unavoidable csprng* ABI.  These are kept
+            # expression- and count-specific so new consumers cannot silently
+            # join the allowlist merely by living in an approved file.
+            "$allowed_root/zen_big.c")
+                case "$source_line" in
+                    'BIG_randomnum(res->val,modulus->val,Z->random_generator);'|\
+                    'BIG_randomnum(res->val,(chunk*)CURVE_Order,Z->random_generator);')
+                        big_count=$((big_count + 1)) ;;
+                    *) printf 'forbidden opaque RNG expression: %s\n' "$hit" >&2; return 1 ;;
+                esac ;;
+            "$allowed_root/zen_ecdh.c")
+                case "$source_line" in
+                    '(*ECDH.ECP__KEY_PAIR_GENERATE)(Z->random_generator,sk,pk);'|\
+                    '(*ECDH.ECP__SP_DSA)( max_size, Z->random_generator, NULL,'|\
+                    '((int)n, Z->random_generator, NULL,')
+                        ecdh_count=$((ecdh_count + 1)) ;;
+                    *) printf 'forbidden opaque RNG expression: %s\n' "$hit" >&2; return 1 ;;
+                esac ;;
+            "$allowed_root/zen_rsa.c")
+                case "$source_line" in
+                    'csprng *RNG = Z->random_generator;'|\
+                    'csprng *RNG = Z-> random_generator;')
+                        rsa_count=$((rsa_count + 1)) ;;
+                    *) printf 'forbidden opaque RNG expression: %s\n' "$hit" >&2; return 1 ;;
+                esac ;;
+            *) printf 'forbidden opaque RNG generator access: %s\n' "$hit" >&2; return 1 ;;
+        esac
+    done <<< "$hits"
+    if (( big_count != 3 || ecdh_count != 3 || rsa_count != 3 )); then
+        printf 'unexpected opaque RNG access counts: zen_big=%d zen_ecdh=%d zen_rsa=%d (expected 3 each)\n' \
+            "$big_count" "$ecdh_count" "$rsa_count" >&2
+        return 1
+    fi
+}
+
+audit_backend_relocations() {
+    local object hits
+    for object in "$root"/src/*.o; do
+        [[ -f $object ]] || continue
+        [[ $object == "$root/src/zen_random.o" ]] && continue
+        hits=$(nm -u "$object" | match_lines \
+            '(RAND_byte|AMCL_RAND_seed|RAND_clean|OCT_rand)([-+[:space:]]|$)' || true)
+        if [[ -n $hits ]]; then
+            printf 'forbidden direct backend RNG relocation in %s:\n%s\n' \
+                "$object" "$hits" >&2
+            return 1
+        fi
+    done
 }
 
 audit_runtime_object() {
@@ -98,8 +182,46 @@ if [[ ${1:-} == --self-test ]]; then
     scratch=$(mktemp -d)
     trap 'rm -rf "$scratch"' EXIT
     printf 'void example(void) { randombytes(0, 1); }\n' > "$scratch/forbidden.c"
-    if audit "$scratch"; then
+    if audit_entropy_bypass "$scratch"; then
         printf '%s\n' 'RNG bypass self-test unexpectedly passed' >&2
+        exit 1
+    fi
+    printf '#include <amcl.h>\nvoid example(csprng *r) { (void)RAND_byte(r); }\n' \
+        > "$scratch/forbidden-backend.c"
+    if audit_backend_bypass "$scratch"; then
+        printf '%s\n' 'Backend RNG bypass self-test unexpectedly passed' >&2
+        exit 1
+    fi
+    printf '#include <zenroom.h>\nvoid example(zenroom_t *z) { (void)z->random_generator; }\n' \
+        > "$scratch/forbidden-generator.c"
+    if audit_generator_access "$scratch"; then
+        printf '%s\n' 'Opaque generator access self-test unexpectedly passed' >&2
+        exit 1
+    fi
+    mkdir "$scratch/allowlisted"
+    printf '%s\n' \
+        'BIG_randomnum(res->val,modulus->val,Z->random_generator);' \
+        'BIG_randomnum(res->val,modulus->val,Z->random_generator);' \
+        'BIG_randomnum(res->val,(chunk*)CURVE_Order,Z->random_generator);' \
+        > "$scratch/allowlisted/zen_big.c"
+    printf '%s\n' \
+        '(*ECDH.ECP__KEY_PAIR_GENERATE)(Z->random_generator,sk,pk);' \
+        '(*ECDH.ECP__SP_DSA)( max_size, Z->random_generator, NULL,' \
+        '((int)n, Z->random_generator, NULL,' \
+        > "$scratch/allowlisted/zen_ecdh.c"
+    printf '%s\n' \
+        'csprng *RNG = Z->random_generator;' \
+        'csprng *RNG = Z->random_generator;' \
+        'csprng *RNG = Z-> random_generator;' \
+        > "$scratch/allowlisted/zen_rsa.c"
+    if ! audit_generator_access "$scratch/allowlisted" "$scratch/allowlisted"; then
+        printf '%s\n' 'Valid opaque generator fixture unexpectedly failed' >&2
+        exit 1
+    fi
+    printf '%s\n' 'BIG_randomnum(res->val,modulus->val,Z->random_generator);' \
+        >> "$scratch/allowlisted/zen_big.c"
+    if audit_generator_access "$scratch/allowlisted" "$scratch/allowlisted"; then
+        printf '%s\n' 'Opaque generator count self-test unexpectedly passed' >&2
         exit 1
     fi
     printf 'extern int randombytes(void *, unsigned long); void example(void) { randombytes(0, 1); }\n' > "$scratch/forbidden-relocation.c"
@@ -111,7 +233,10 @@ if [[ ${1:-} == --self-test ]]; then
     exit 0
 fi
 
-audit "$root/src"
+audit_entropy_bypass "$root/src"
+audit_backend_bypass "$root/src"
+audit_generator_access "$root/src"
+audit_backend_relocations
 audit_runtime_relocations
 audit_archive_residues
 if [[ -f $root/libzenroom.so ]] &&

--- a/test/rng/no-bypass.sh
+++ b/test/rng/no-bypass.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+pattern='(randombytes|RAND_bytes|getrandom|arc4random)[[:space:]]*\('
+
+audit() {
+    local path=$1
+    local hits
+    hits=$(rg -n --glob '*.[ch]' -o "$pattern" "$path" || true)
+    while IFS= read -r hit; do
+        [[ -z $hit ]] && continue
+        case "$hit" in
+            "$root/src/randombytes.c":*) ;;
+            "$root/src/randombytes.h":*) ;;
+            "$root/src/zen_random.c":*:randombytes\(*) ;;
+            "$root/src/api_sign.c":*:randombytes\(*) ;;
+            "$root/src/zen_larkg.c":*:randombytes\(*) ;;
+            *) printf 'forbidden RNG bypass: %s\n' "$hit" >&2; return 1 ;;
+        esac
+    done <<< "$hits"
+}
+
+if [[ ${1:-} == --self-test ]]; then
+    scratch=$(mktemp -d)
+    trap 'rm -rf "$scratch"' EXIT
+    printf 'void example(void) { randombytes(0, 1); }\n' > "$scratch/forbidden.c"
+    if audit "$scratch"; then
+        printf '%s\n' 'RNG bypass self-test unexpectedly passed' >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+audit "$root/src"
+if [[ -f $root/libzenroom.so ]] && nm -D --undefined-only "$root/libzenroom.so" | rg -q 'RAND_bytes|getrandom|arc4random'; then
+    printf '%s\n' 'forbidden unresolved OS RNG symbol in libzenroom.so' >&2
+    exit 1
+fi

--- a/test/rng/no-bypass.sh
+++ b/test/rng/no-bypass.sh
@@ -15,10 +15,29 @@ runtime_objects=(
     src/zen_longfellow.o
 )
 
+match_lines() {
+    local expression=$1
+    if command -v rg >/dev/null 2>&1; then
+        rg "$expression"
+    else
+        grep -E "$expression"
+    fi
+}
+
+search_sources() {
+    local path=$1
+    if command -v rg >/dev/null 2>&1; then
+        rg -n --glob '*.[ch]' -o "$pattern" "$path"
+    else
+        find "$path" -type f \( -name '*.c' -o -name '*.h' \) \
+            -exec grep -EnH -o "$pattern" {} +
+    fi
+}
+
 audit() {
     local path=$1
     local hits
-    hits=$(rg -n --glob '*.[ch]' -o "$pattern" "$path" || true)
+    hits=$(search_sources "$path" || true)
     while IFS= read -r hit; do
         [[ -z $hit ]] && continue
         case "$hit" in
@@ -34,7 +53,7 @@ audit() {
 audit_runtime_object() {
     local object=$1
     local hits
-    hits=$(objdump -r "$object" | rg "$runtime_forbidden" || true)
+    hits=$(objdump -r "$object" | match_lines "$runtime_forbidden" || true)
     if [[ -n $hits ]]; then
         printf 'forbidden reachable RNG relocation in %s:\n%s\n' "$object" "$hits" >&2
         return 1
@@ -95,7 +114,9 @@ fi
 audit "$root/src"
 audit_runtime_relocations
 audit_archive_residues
-if [[ -f $root/libzenroom.so ]] && nm -D --undefined-only "$root/libzenroom.so" | rg -q 'RAND_bytes|getrandom|arc4random'; then
+if [[ -f $root/libzenroom.so ]] &&
+    nm -D --undefined-only "$root/libzenroom.so" |
+        match_lines 'RAND_bytes|getrandom|arc4random' >/dev/null; then
     printf '%s\n' 'forbidden unresolved OS RNG symbol in libzenroom.so' >&2
     exit 1
 fi

--- a/test/rng/no-bypass.sh
+++ b/test/rng/no-bypass.sh
@@ -4,6 +4,17 @@ set -Eeuo pipefail
 root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 pattern='(randombytes|RAND_bytes|getrandom|arc4random)[[:space:]]*\('
 
+# Runtime bridges must not retain relocations to a direct OS-RNG entry point or
+# to a legacy vendor convenience API.  The vendor archives deliberately retain
+# such APIs for upstream ABI compatibility; they are classified below and are
+# not reachable from a registered Zenroom bridge.
+runtime_forbidden='(randombytes|PQCLEAN_(DILITHIUM2|KYBER512|SNTRUP761)_CLEAN_crypto_(sign_keypair|kem_keypair)|mayo_sign_signature|run_mdoc_prover)([-+[:space:]]|$)'
+runtime_objects=(
+    src/zen_qp.o
+    src/zen_mayo.o
+    src/zen_longfellow.o
+)
+
 audit() {
     local path=$1
     local hits
@@ -21,6 +32,52 @@ audit() {
     done <<< "$hits"
 }
 
+audit_runtime_object() {
+    local object=$1
+    local hits
+    hits=$(objdump -r "$object" | rg "$runtime_forbidden" || true)
+    if [[ -n $hits ]]; then
+        printf 'forbidden reachable RNG relocation in %s:\n%s\n' "$object" "$hits" >&2
+        return 1
+    fi
+}
+
+audit_runtime_relocations() {
+    local object
+    for object in "${runtime_objects[@]}"; do
+        # Source-only runs have no build products. CI invokes this gate after
+        # building, where every registered bridge must be present.
+        [[ -f $root/$object ]] || continue
+        audit_runtime_object "$root/$object"
+    done
+}
+
+audit_archive_residues() {
+    # Classified, unregistered upstream compatibility residues:
+    # - pqclean: SNTRUP system-RNG wrapper, sKEM and experimental LARKG;
+    # - MAYO: legacy no-randomizer signing/keygen wrappers;
+    # - Longfellow: SecureRandomEngine used only by the legacy C ABI wrapper.
+    #   The old generator-backed BATS fixture is intentionally disabled, so it
+    #   is not a compatibility gate; CallbackRandomEngine has fixture-free
+    #   ASan replay/different-seed/failure coverage in test/api/rng.bats.
+    # The relocation audit above is the reachability authority for Zenroom.
+    local hits hit
+    hits=$(nm -A "$root/lib/pqclean/libqpz.a" "$root/lib/mayo/libmayo.a" \
+        "$root/lib/longfellow-zk/liblongfellow-zk.a" 2>/dev/null |
+        awk '$2 == "U" && $3 == "randombytes" { print $1 }' || true)
+    while IFS= read -r hit; do
+        [[ -z $hit ]] && continue
+        case "$hit" in
+            "$root/lib/pqclean/libqpz.a":kem.o:|\
+            "$root/lib/pqclean/libqpz.a":skem.o:|\
+            "$root/lib/pqclean/libqpz.a":kyber_larkg.o:|\
+            "$root/lib/mayo/libmayo.a":mayo.o:|\
+            "$root/lib/longfellow-zk/liblongfellow-zk.a":crypto.cc.o:) ;;
+            *) printf 'unclassified archive RNG residue: %s\n' "$hit" >&2; return 1 ;;
+        esac
+    done <<< "$hits"
+}
+
 if [[ ${1:-} == --self-test ]]; then
     scratch=$(mktemp -d)
     trap 'rm -rf "$scratch"' EXIT
@@ -29,10 +86,18 @@ if [[ ${1:-} == --self-test ]]; then
         printf '%s\n' 'RNG bypass self-test unexpectedly passed' >&2
         exit 1
     fi
+    printf 'extern int randombytes(void *, unsigned long); void example(void) { randombytes(0, 1); }\n' > "$scratch/forbidden-relocation.c"
+    ${CC:-cc} -c "$scratch/forbidden-relocation.c" -o "$scratch/forbidden-relocation.o"
+    if audit_runtime_object "$scratch/forbidden-relocation.o"; then
+        printf '%s\n' 'RNG relocation self-test unexpectedly passed' >&2
+        exit 1
+    fi
     exit 0
 fi
 
 audit "$root/src"
+audit_runtime_relocations
+audit_archive_residues
 if [[ -f $root/libzenroom.so ]] && nm -D --undefined-only "$root/libzenroom.so" | rg -q 'RAND_bytes|getrandom|arc4random'; then
     printf '%s\n' 'forbidden unresolved OS RNG symbol in libzenroom.so' >&2
     exit 1

--- a/test/rng/no-bypass.sh
+++ b/test/rng/no-bypass.sh
@@ -2,9 +2,10 @@
 set -Eeuo pipefail
 
 root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-entropy_pattern='(randombytes|RAND_bytes|getrandom|arc4random)[[:space:]]*\('
+entropy_pattern='(randombytes|RAND_bytes|getrandom|arc4random(_buf)?)[[:space:]]*\('
 backend_pattern='(RAND_byte|RAND_clean|OCT_rand|CREATE_CSPRNG|KILL_CSPRNG)[[:space:]]*\(|AMCL_\(RAND_seed\)[[:space:]]*\('
 generator_pattern='(->|\.)[[:space:]]*random_generator'
+global_context_pattern='zen_get_global_context[[:space:]]*\('
 
 # Runtime bridges must not retain relocations to a direct OS-RNG entry point or
 # to a legacy vendor convenience API.  The vendor archives deliberately retain
@@ -63,6 +64,21 @@ audit_backend_bypass() {
             # Sole compatibility-backend implementation.
             "$root/src/zen_random.c":*) ;;
             *) printf 'forbidden direct backend RNG access: %s\n' "$hit" >&2; return 1 ;;
+        esac
+    done <<< "$hits"
+}
+
+audit_global_context_access() {
+    local path=$1
+    local hits hit
+    hits=$(search_sources "$path" "$global_context_pattern" || true)
+    while IFS= read -r hit; do
+        [[ -z $hit ]] && continue
+        case "$hit" in
+            # Compatibility implementation and declaration only.  Runtime
+            # consumers must recover their owning context from lua_State.
+            "$root/src/zen_error.c":*|"$root/src/zen_error.h":*) ;;
+            *) printf 'forbidden process-global VM context access: %s\n' "$hit" >&2; return 1 ;;
         esac
     done <<< "$hits"
 }
@@ -186,6 +202,13 @@ if [[ ${1:-} == --self-test ]]; then
         printf '%s\n' 'RNG bypass self-test unexpectedly passed' >&2
         exit 1
     fi
+    mkdir "$scratch/arc4random"
+    printf 'void example(void) { arc4random_buf(0, 1); }\n' \
+        > "$scratch/arc4random/forbidden.c"
+    if audit_entropy_bypass "$scratch/arc4random"; then
+        printf '%s\n' 'arc4random_buf bypass self-test unexpectedly passed' >&2
+        exit 1
+    fi
     printf '#include <amcl.h>\nvoid example(csprng *r) { (void)RAND_byte(r); }\n' \
         > "$scratch/forbidden-backend.c"
     if audit_backend_bypass "$scratch"; then
@@ -196,6 +219,13 @@ if [[ ${1:-} == --self-test ]]; then
         > "$scratch/forbidden-generator.c"
     if audit_generator_access "$scratch"; then
         printf '%s\n' 'Opaque generator access self-test unexpectedly passed' >&2
+        exit 1
+    fi
+    mkdir "$scratch/global-context"
+    printf 'void example(void) { (void)zen_get_global_context(); }\n' \
+        > "$scratch/global-context/forbidden.c"
+    if audit_global_context_access "$scratch/global-context"; then
+        printf '%s\n' 'Global VM context self-test unexpectedly passed' >&2
         exit 1
     fi
     mkdir "$scratch/allowlisted"
@@ -235,6 +265,7 @@ fi
 
 audit_entropy_bypass "$root/src"
 audit_backend_bypass "$root/src"
+audit_global_context_access "$root/src"
 audit_generator_access "$root/src"
 audit_backend_relocations
 audit_runtime_relocations

--- a/test/rng/no-bypass.sh
+++ b/test/rng/no-bypass.sh
@@ -26,7 +26,6 @@ audit() {
             "$root/src/randombytes.h":*) ;;
             "$root/src/zen_random.c":*:randombytes\(*) ;;
             "$root/src/api_sign.c":*:randombytes\(*) ;;
-            "$root/src/zen_larkg.c":*:randombytes\(*) ;;
             *) printf 'forbidden RNG bypass: %s\n' "$hit" >&2; return 1 ;;
         esac
     done <<< "$hits"
@@ -54,7 +53,7 @@ audit_runtime_relocations() {
 
 audit_archive_residues() {
     # Classified, unregistered upstream compatibility residues:
-    # - pqclean: SNTRUP system-RNG wrapper, sKEM and experimental LARKG;
+    # - pqclean: SNTRUP system-RNG wrapper;
     # - MAYO: legacy no-randomizer signing/keygen wrappers;
     # - Longfellow: SecureRandomEngine used only by the legacy C ABI wrapper.
     #   The old generator-backed BATS fixture is intentionally disabled, so it
@@ -69,8 +68,6 @@ audit_archive_residues() {
         [[ -z $hit ]] && continue
         case "$hit" in
             "$root/lib/pqclean/libqpz.a":kem.o:|\
-            "$root/lib/pqclean/libqpz.a":skem.o:|\
-            "$root/lib/pqclean/libqpz.a":kyber_larkg.o:|\
             "$root/lib/mayo/libmayo.a":mayo.o:|\
             "$root/lib/longfellow-zk/liblongfellow-zk.a":crypto.cc.o:) ;;
             *) printf 'unclassified archive RNG residue: %s\n' "$hit" >&2; return 1 ;;


### PR DESCRIPTION
## Summary

- introduce a checked, VM-owned randomness service while preserving seeded compatibility
- migrate existing PQClean, MAYO, Longfellow, QP, and public signing paths away from runtime OS-RNG bypasses
- add failure-injection, deterministic replay, and source/link audit coverage
- keep this change independent of LARKG

## Verification

- `make linux-lib linux-exe CCACHE=1`
- `make check` — 82/82 passed
- `./test/rng/no-bypass.sh --self-test`
- `./test/rng/no-bypass.sh`
- `git diff origin/master --check`

This is the base PR for the separately stacked LARKG work in #1184.